### PR TITLE
rename: EA Turbo → Turbo EA everywhere

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
-# EA Turbo Configuration
+# Turbo EA Configuration
 # Copy this file to .env and update values
 
 # PostgreSQL — point to your existing PostgreSQL container
 # On Unraid: use the container name or IP of your PostgreSQL instance
 POSTGRES_HOST=PostgreSQL
 POSTGRES_PORT=5432
-POSTGRES_DB=eaturbo
-POSTGRES_USER=eaturbo
+POSTGRES_DB=turboea
+POSTGRES_USER=turboea
 POSTGRES_PASSWORD=changeme_use_a_strong_password
 
 # Backend

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
-# EA Turbo - Enterprise Architecture Management Platform
+# Turbo EA - Enterprise Architecture Management Platform
 
 ## Overview
 
-EA Turbo is a self-hosted Enterprise Architecture Management (EAM) platform inspired by SAP LeanIX, designed for deployment on Unraid. It provides application portfolio management, business capability mapping, technology risk management, and integration architecture visualization through an event-driven API architecture.
+Turbo EA is a self-hosted Enterprise Architecture Management (EAM) platform inspired by SAP LeanIX, designed for deployment on Unraid. It provides application portfolio management, business capability mapping, technology risk management, and integration architecture visualization through an event-driven API architecture.
 
 ---
 
@@ -331,7 +331,7 @@ All relations carry:
 - Unraid 6.12+ with Docker support enabled
 - Community Applications plugin installed
 - At least 2GB RAM allocated for Docker
-- Persistent storage path on array or cache (e.g., `/mnt/user/appdata/ea-turbo/`)
+- Persistent storage path on array or cache (e.g., `/mnt/user/appdata/turbo-ea/`)
 
 ### Option A: Docker Compose (Recommended)
 
@@ -340,13 +340,13 @@ All relations carry:
 
 2. **Create app directory:**
    ```bash
-   mkdir -p /mnt/user/appdata/ea-turbo
-   cd /mnt/user/appdata/ea-turbo
+   mkdir -p /mnt/user/appdata/turbo-ea
+   cd /mnt/user/appdata/turbo-ea
    ```
 
 3. **Clone or copy files:**
    ```bash
-   git clone https://github.com/vincentmakes/ea-turbo.git .
+   git clone https://github.com/vincentmakes/turbo-ea.git .
    ```
 
 4. **Create environment file:**
@@ -372,43 +372,43 @@ All relations carry:
 1. **PostgreSQL Container:**
    - Image: `postgres:16-alpine`
    - Port: `5432` (or custom)
-   - Env: `POSTGRES_DB=eaturbo`, `POSTGRES_USER=eaturbo`, `POSTGRES_PASSWORD=<secure>`
-   - Volume: `/mnt/user/appdata/ea-turbo/pgdata:/var/lib/postgresql/data`
-   - Network: Create custom bridge `ea-turbo-net`
+   - Env: `POSTGRES_DB=turboea`, `POSTGRES_USER=turboea`, `POSTGRES_PASSWORD=<secure>`
+   - Volume: `/mnt/user/appdata/turbo-ea/pgdata:/var/lib/postgresql/data`
+   - Network: Create custom bridge `turbo-ea-net`
 
 2. **Backend Container:**
-   - Image: `ghcr.io/vincentmakes/ea-turbo-backend:latest` (or build locally)
+   - Image: `ghcr.io/vincentmakes/turbo-ea-backend:latest` (or build locally)
    - Port: `8000`
-   - Env: `DATABASE_URL=postgresql://eaturbo:<pass>@ea-turbo-db:5432/eaturbo`
-   - Network: `ea-turbo-net`
+   - Env: `DATABASE_URL=postgresql://turboea:<pass>@turbo-ea-db:5432/turboea`
+   - Network: `turbo-ea-net`
 
 3. **Frontend + Nginx Container:**
-   - Image: `ghcr.io/vincentmakes/ea-turbo-frontend:latest` (or build locally)
+   - Image: `ghcr.io/vincentmakes/turbo-ea-frontend:latest` (or build locally)
    - Port: `8920`
-   - Network: `ea-turbo-net`
+   - Network: `turbo-ea-net`
 
 ### Data Persistence
 
 | Path on Unraid | Container Path | Purpose |
 |----------------|---------------|---------|
-| `/mnt/user/appdata/ea-turbo/pgdata` | `/var/lib/postgresql/data` | PostgreSQL data |
-| `/mnt/user/appdata/ea-turbo/uploads` | `/app/uploads` | File uploads |
-| `/mnt/user/appdata/ea-turbo/.env` | `/app/.env` | Environment config |
+| `/mnt/user/appdata/turbo-ea/pgdata` | `/var/lib/postgresql/data` | PostgreSQL data |
+| `/mnt/user/appdata/turbo-ea/uploads` | `/app/uploads` | File uploads |
+| `/mnt/user/appdata/turbo-ea/.env` | `/app/.env` | Environment config |
 
 ### Backup
 
 ```bash
 # Database backup
-docker exec ea-turbo-db pg_dump -U eaturbo eaturbo > /mnt/user/appdata/ea-turbo/backups/$(date +%Y%m%d).sql
+docker exec turbo-ea-db pg_dump -U turboea turboea > /mnt/user/appdata/turbo-ea/backups/$(date +%Y%m%d).sql
 
 # Restore
-docker exec -i ea-turbo-db psql -U eaturbo eaturbo < /mnt/user/appdata/ea-turbo/backups/YYYYMMDD.sql
+docker exec -i turbo-ea-db psql -U turboea turboea < /mnt/user/appdata/turbo-ea/backups/YYYYMMDD.sql
 ```
 
 ### Updating
 
 ```bash
-cd /mnt/user/appdata/ea-turbo
+cd /mnt/user/appdata/turbo-ea
 git pull
 docker compose build
 docker compose up -d
@@ -419,7 +419,7 @@ docker compose up -d
 ## Project Structure
 
 ```
-ea-turbo/
+turbo-ea/
 ├── backend/
 │   ├── Dockerfile
 │   ├── pyproject.toml

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql+asyncpg://eaturbo:changeme@localhost:5432/eaturbo
+sqlalchemy.url = postgresql+asyncpg://turboea:changeme@localhost:5432/turboea
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,11 +2,11 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    PROJECT_NAME: str = "EA Turbo"
+    PROJECT_NAME: str = "Turbo EA"
     VERSION: str = "0.1.0"
     API_V1_PREFIX: str = "/api/v1"
 
-    DATABASE_URL: str = "postgresql+asyncpg://eaturbo:changeme@localhost:5432/eaturbo"
+    DATABASE_URL: str = "postgresql+asyncpg://turboea:changeme@localhost:5432/turboea"
 
     SECRET_KEY: str = "dev-secret-key-change-in-production"
     ALGORITHM: str = "HS256"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,14 +31,14 @@ async def init_db() -> None:
         result = await session.execute(select(User).limit(1))
         if result.scalar_one_or_none() is None:
             admin = User(
-                email="admin@eaturbo.local",
+                email="admin@turboea.local",
                 hashed_password=hash_password("admin123"),
                 full_name="Admin",
                 role=UserRole.ADMIN,
             )
             session.add(admin)
             await session.commit()
-            logger.info("Default admin user created (admin@eaturbo.local / admin123)")
+            logger.info("Default admin user created (admin@turboea.local / admin123)")
 
 
 async def _on_fact_sheet_changed(event: dict) -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "ea-turbo-backend"
+name = "turbo-ea-backend"
 version = "0.1.0"
-description = "EA Turbo - Enterprise Architecture Management API"
+description = "Turbo EA - Enterprise Architecture Management API"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-eaturbo}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-eaturbo}
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-turboea}:${POSTGRES_PASSWORD:-changeme}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-turboea}
       SECRET_KEY: ${SECRET_KEY:-dev-secret-key-change-in-production}
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-1440}
     ports:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EA Turbo</title>
+    <title>Turbo EA</title>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ea-turbo-frontend",
+  "name": "turbo-ea-frontend",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -76,7 +76,7 @@ export default function AppLayout() {
             <MaterialSymbol icon="menu" />
           </IconButton>
           <Typography variant="h6" noWrap sx={{ fontWeight: 700, letterSpacing: "0.5px" }}>
-            EA Turbo
+            Turbo EA
           </Typography>
         </Toolbar>
       </AppBar>


### PR DESCRIPTION
- eaturbo → turboea (db name, user, email domain, config defaults)
- ea-turbo → turbo-ea (package names, docker image refs, paths)
- EA Turbo → Turbo EA (display name in UI, config, docs)

Updated across: docker-compose.yml, .env.example, PLAN.md, backend config/main/pyproject/alembic, frontend package.json/ index.html/AppLayout.

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF