### PR TITLE
fix: handle FastAPI 422 error display + add RESET_DB for old schema

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,8 @@ class Settings:
     POSTGRES_USER: str = os.getenv("POSTGRES_USER", "turboea")
     POSTGRES_PASSWORD: str = os.getenv("POSTGRES_PASSWORD", "turboea")
 
+    RESET_DB: bool = os.getenv("RESET_DB", "").lower() in ("1", "true", "yes")
+
     SECRET_KEY: str = os.getenv("SECRET_KEY", "change-me-in-production")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "1440"))
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,8 +13,10 @@ from app.api.v1.router import api_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Create all tables on startup
+    # Drop and recreate tables if RESET_DB is set (handles old schema migration)
     async with engine.begin() as conn:
+        if settings.RESET_DB:
+            await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
     # Seed default metamodel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-turboea}
       POSTGRES_USER: ${POSTGRES_USER:-turboea}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      RESET_DB: ${RESET_DB:-false}
       SECRET_KEY: ${SECRET_KEY:-dev-secret-key-change-in-production}
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-1440}
     ports:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,7 +19,11 @@ async function request<T>(
   if (res.status === 204) return undefined as T;
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error(err.detail || res.statusText);
+    // FastAPI 422 returns detail as array of validation error objects
+    const msg = Array.isArray(err.detail)
+      ? err.detail.map((e: { msg?: string }) => e.msg || JSON.stringify(e)).join("; ")
+      : err.detail || res.statusText;
+    throw new Error(msg);
   }
   return res.json();
 }


### PR DESCRIPTION
- Fix [object Object] error: FastAPI 422 returns detail as array of validation error objects, not a string. Now properly extracts msg from each validation error.
- Add RESET_DB env var: when set to true, drops all tables before create_all on startup. Needed when migrating from old DB schema since create_all won't modify existing tables.

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF