### PR TITLE
feat: enrich LeanIX metamodel with full field schemas, subtypes, and …

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -20,119 +20,319 @@ Turbo EA is a self-hosted Enterprise Architecture Management (EAM) platform — 
 
 ---
 
-## LeanIX Feature Mapping
+## LeanIX Metamodel v4 — Complete Specification
 
-### Metamodel (12 Fact Sheet Types)
+### 12 Fact Sheet Types
 
-**Business Architecture:**
-| Type | Key Fields | Hierarchy |
-|------|-----------|-----------|
-| Business Capability | name, description, lifecycle | Parent/Child (L1→L2→L3) |
-| Business Context | name, description, lifecycle | Parent/Child |
-| Organization | name, description | Parent/Child |
+#### Business Architecture Layer
 
-**Application Architecture:**
-| Type | Key Fields | Hierarchy |
-|------|-----------|-----------|
-| Application | businessCriticality, functionalFit, technicalFit, hostingType, alias, totalAnnualCost | Parent/Child |
-| Interface | frequency, dataDirection, technicalFit | Flat |
-| Data Object | dataSensitivity, isPersonalData | Parent/Child |
+**1. Business Capability** (`BusinessCapability`)
+- Icon: `account_tree` | Color: `#4caf50` | Hierarchy: Yes (L1→L2→L3+)
+- Subtypes: none
+- Fields: alias (text)
+- Purpose: Stable functional decomposition of what the business does
 
-**Technology Architecture:**
-| Type | Key Fields | Hierarchy |
-|------|-----------|-----------|
-| IT Component | technicalFit, totalAnnualCost | Parent/Child |
-| Tech Category | name, description | Parent/Child |
-| Provider | website, headquarters | Flat |
+**2. Business Context** (`BusinessContext`)
+- Icon: `domain` | Color: `#66bb6a` | Hierarchy: Yes
+- Subtypes: Process, Value Stream, Customer Journey, Product
+- Fields: alias (text)
+- Purpose: Activities an org performs — value streams, products, processes
 
-**Transformation Architecture:**
-| Type | Key Fields | Hierarchy |
-|------|-----------|-----------|
-| Platform | name, description, lifecycle | Flat |
-| Objective | category, kpiDescription | Flat |
-| Initiative | budget, status, startDate, endDate | Parent/Child |
+**3. Organization** (`Organization`)
+- Icon: `corporate_fare` | Color: `#43a047` | Hierarchy: Yes
+- Subtypes: Business Unit, Region, Legal Entity, Team, Customer
+- Fields: alias (text)
+- Purpose: Business units, regions, teams, legal entities
 
-### Common Fact Sheet Properties
-- Name, Description (all types)
-- Lifecycle: plan → phaseIn → active → phaseOut → endOfLife (each with date)
-- Tags (multi-select from tag groups)
-- Subscriptions: Responsible, Accountable, Observer (user assignments)
-- Quality Seal: Approved / Broken (governance workflow)
-- Completion Score: auto-calculated % based on filled fields + relations
-- External ID, Alias
-- Documents/Resources (links)
-- Comments (threaded)
-- To-Dos (assigned tasks)
-- Full audit history
+#### Application & Data Architecture Layer
 
-### Enum Values
+**4. Application** (`Application`) — CENTER OF THE METAMODEL
+- Icon: `apps` | Color: `#1976d2` | Hierarchy: Yes
+- Subtypes: Business Application, Microservice, Deployment
+- Fields:
+  - *Information section*: alias (text), businessCriticality (single_select: missionCritical/businessCritical/businessOperational/administrativeService), functionalSuitability (single_select: perfect/appropriate/insufficient/unreasonable — UI: "Functional Fit"), technicalSuitability (single_select: fullyAppropriate/adequate/unreasonable/inappropriate — UI: "Technical Fit"), hostingType (single_select: onPremise/cloudSaaS/cloudPaaS/cloudIaaS/hybrid)
+  - *Cost section*: totalAnnualCost (number), costCurrency (text)
+- Purpose: Software systems, microservices, deployments — connects to more types than any other
 
-**Business Criticality:** Mission Critical, Business Critical, Business Operational, Administrative
+**5. Interface** (`Interface`)
+- Icon: `sync_alt` | Color: `#1565c0` | Hierarchy: No
+- Subtypes: Logical Interface, API
+- Fields:
+  - *Interface Information section*: frequency (single_select: realtime/daily/weekly/monthly/onDemand/batch), dataDirection (single_select: unidirectional/bidirectional), technicalSuitability (single_select — same as Application)
+- Purpose: Data exchange connections between applications (Provider/Consumer pattern)
 
-**Functional Fit:** Perfect, Appropriate, Insufficient, Unreasonable
+**6. Data Object** (`DataObject`)
+- Icon: `database` | Color: `#0d47a1` | Hierarchy: Yes
+- Subtypes: none
+- Fields:
+  - *Data Object Information section*: dataSensitivity (single_select: public/internal/confidential/restricted), isPersonalData (boolean)
+- Purpose: Business data entities (customer, order, product data)
 
-**Technical Fit:** Fully Appropriate, Adequate, Unreasonable, Inappropriate
+#### Technology Architecture Layer
 
-**Hosting Type:** On-Premise, Cloud SaaS, Cloud PaaS, Cloud IaaS, Hybrid
+**7. IT Component** (`ITComponent`)
+- Icon: `memory` | Color: `#7b1fa2` | Hierarchy: Yes
+- Subtypes: Software, Hardware, SaaS, IaaS, PaaS, Service
+- Fields:
+  - *IT Component Information section*: alias (text), technicalSuitability (single_select — same as Application)
+  - *Cost section*: totalAnnualCost (number)
+- Purpose: Technology dependencies — software, hardware, cloud services
 
-**Resource Classification** (IT Component ↔ Tech Category relation): Approved, Conditional, Investigating, Retiring, Unapproved
+**8. Tech Category** (`TechCategory`)
+- Icon: `category` | Color: `#9c27b0` | Hierarchy: Yes
+- Subtypes: none
+- Fields: alias (text)
+- Purpose: Standardized groupings for IT Components (e.g., DBMS, OS, Cloud Platform)
 
-**Data Sensitivity:** Public, Internal, Confidential, Restricted
+**9. Provider** (`Provider`)
+- Icon: `store` | Color: `#6a1b9a` | Hierarchy: No
+- Subtypes: none
+- Fields:
+  - *Provider Information section*: website (text), headquarters (text)
+- Purpose: Vendors and suppliers of technology and services
 
-**Initiative Status:** Proposed, Approved, In Progress, Completed, Cancelled
+#### Transformation Architecture Layer
 
-### Standard Relations (20 types)
+**10. Platform** (`Platform`)
+- Icon: `hub` | Color: `#e65100` | Hierarchy: No
+- Subtypes: Digital, Technical
+- Fields: alias (text)
+- Purpose: Strategic groupings of applications and technologies
 
-| # | Source → Target | Relation Key | Relation Attributes |
-|---|----------------|-------------|-------------------|
-| 1 | Application → Business Capability | relAppToBC | — |
-| 2 | Application → Organization | relAppToOrg | usageType (user/owner) |
-| 3 | Application → IT Component | relAppToITC | totalAnnualCost |
-| 4 | Application → Interface | relAppToInterface | direction (provider/consumer) |
-| 5 | Application → Data Object | relAppToDataObj | crudFlags (C/R/U/D) |
-| 6 | Application → Provider | relAppToProvider | — |
-| 7 | Application → Platform | relAppToPlatform | — |
-| 8 | Application → Application | relAppToApp | description |
-| 9 | Interface → Data Object | relInterfaceToDataObj | — |
-| 10 | IT Component → Tech Category | relITCToTechCat | resourceClassification |
-| 11 | IT Component → Provider | relITCToProvider | — |
-| 12 | Objective → Business Capability | relObjToBC | — |
-| 13 | Objective → Initiative | relObjToInitiative | — |
-| 14 | Initiative → Application | relInitToApp | — |
-| 15 | Initiative → IT Component | relInitToITC | — |
-| 16 | Platform → Application | relPlatformToApp | — |
-| 17 | Platform → IT Component | relPlatformToITC | — |
-| 18 | Organization → Application | relOrgToApp | — |
-| 19 | Business Context → Business Capability | relBCxToBC | — |
-| 20 | Business Context → Application | relBCxToApp | — |
+**11. Objective** (`Objective`)
+- Icon: `flag` | Color: `#ef6c00` | Hierarchy: No
+- Subtypes: none
+- Fields:
+  - *Objective Information section*: category (single_select: strategic/tactical/operational), kpiDescription (text)
+- Purpose: Strategic goals driving initiatives and transformation
 
-Plus parent/child (hierarchy) relations within: Business Capability, Business Context, Organization, Application, Data Object, IT Component, Tech Category, Initiative.
+**12. Initiative** (`Initiative`)
+- Icon: `rocket_launch` | Color: `#f57c00` | Hierarchy: Yes
+- Subtypes: Idea, Program, Project, Epic
+- Fields:
+  - *Initiative Information section*: status (single_select: proposed/approved/inProgress/completed/cancelled), budget (number), startDate (date), endDate (date)
+- Purpose: Transformation efforts — ideas, projects, programs, epics
+
+### Common Properties (ALL fact sheet types)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | text (required) | Primary identifier |
+| alias | text | Alternative name |
+| description | text (multiline) | Rich description |
+| lifecycle | JSONB | Dates for: plan, phaseIn, active, phaseOut, endOfLife |
+| tags | relation | Multi-select from tag groups |
+| subscriptions | relation | Responsible, Accountable, Observer |
+| quality_seal | enum | DRAFT / APPROVED / BROKEN / REJECTED |
+| completion | float | Auto-calculated 0–100% based on filled fields |
+| external_id | text | Integration identifier |
+| documents | relation | Links/attachments |
+| comments | relation | Threaded discussion |
+| todos | relation | Action items |
+| history | events | Full audit trail |
+
+### Lifecycle Model (5 phases)
+
+| Phase | Meaning | Color |
+|-------|---------|-------|
+| Plan | Envisioned in TO-BE landscape | `#9e9e9e` |
+| Phase In | Implementation underway | `#2196f3` |
+| Active | In production | `#4caf50` |
+| Phase Out | Being retired/replaced | `#ff9800` |
+| End of Life | Decommissioned | `#f44336` |
+
+### Quality Seal States
+
+| State | Description | Trigger |
+|-------|-------------|---------|
+| DRAFT | New/work-in-progress | Default on creation |
+| APPROVED | Data verified by Responsible/Accountable | Manual approval |
+| BROKEN | Data changed or inactivity timeout | Auto on field/relation change by non-subscriber |
+| REJECTED | Removed from quality process | Manual rejection |
+
+What breaks the seal: Changes to attributes, relations, lifecycle.
+What does NOT break it: Changes to comments, subscriptions, todos.
+
+### Relation Types (25+ including self-referencing)
+
+#### Cross-Type Relations
+
+| # | Key | Source → Target | Relation Attributes |
+|---|-----|----------------|-------------------|
+| 1 | relAppToBC | Application → Business Capability | functionalSuitability, supportType (leading/effective) |
+| 2 | relAppToOrg | Application → Organization | usageType (user/owner) |
+| 3 | relAppToITC | Application → IT Component | technicalSuitability, costTotalAnnual |
+| 4 | relProviderAppToInterface | Application → Interface | (provider side) |
+| 5 | relConsumerAppToInterface | Application → Interface | (consumer side) |
+| 6 | relAppToDataObj | Application → Data Object | crudFlags (C/R/U/D) |
+| 7 | relAppToProvider | Application → Provider | — |
+| 8 | relAppToPlatform | Application → Platform | — |
+| 9 | relAppToBCx | Application → Business Context | — |
+| 10 | relAppToInitiative | Application → Initiative | — |
+| 11 | relInterfaceToDataObj | Interface → Data Object | — |
+| 12 | relInterfaceToITC | Interface → IT Component | (middleware) |
+| 13 | relITCToTechCat | IT Component → Tech Category | resourceClassification (standard/phaseIn/tolerated/phaseOut/declined) |
+| 14 | relITCToProvider | IT Component → Provider | — |
+| 15 | relObjToBC | Objective → Business Capability | — |
+| 16 | relObjToInitiative | Objective → Initiative | — |
+| 17 | relInitToApp | Initiative → Application | — |
+| 18 | relInitToITC | Initiative → IT Component | — |
+| 19 | relInitToBC | Initiative → Business Capability | — |
+| 20 | relPlatformToApp | Platform → Application | — |
+| 21 | relPlatformToITC | Platform → IT Component | — |
+| 22 | relPlatformToBC | Platform → Business Capability | — |
+| 23 | relOrgToApp | Organization → Application | — |
+| 24 | relBCxToBC | Business Context → Business Capability | — |
+| 25 | relBCxToApp | Business Context → Application | — |
+| 26 | relBCToOrg | Business Capability → Organization | — |
+
+#### Self-Referencing Relations (ALL types support these)
+
+| Key | Label | Description |
+|-----|-------|-------------|
+| relToSuccessor | Successor | Planned replacement |
+| relToPredecessor | Predecessor | What this replaced |
+| relToRequires | Requires | Same-type dependency |
+| relToRequiredBy | Required By | Inverse dependency |
+
+Parent/Child hierarchy is handled by `parent_id` on the fact sheet model.
+
+### Tag Groups
+
+| Property | Values | Description |
+|----------|--------|-------------|
+| mode | single / multi | Single-select or multi-select per fact sheet |
+| create_mode | open / restricted | Who can create new tags |
+| restrict_to_types | JSONB array | Limit to specific fact sheet types |
+| mandatory | boolean | Required for quality seal approval |
+
+### Subscription Model
+
+| Role | Description | Limit |
+|------|-------------|-------|
+| Responsible | Maintains/updates the fact sheet | Multiple per FS |
+| Accountable | Overall ownership (must be enabled) | One per FS |
+| Observer | Notified of changes | Multiple per FS |
+
+### Completion Score Calculation
+
+Score = (filled weighted fields / total weighted fields) × 100
+
+Each field in `fields_schema` has a `weight` (default 1). Weight 0 = excluded.
+Completion only counts fields and relations, NOT tags or subscriptions.
 
 ---
 
-## Navigation Structure (LeanIX-like)
+## Current Implementation Plan — Phase 2: Rich Fact Sheets
 
-```
-┌─────────────────────────────────────────────────────┐
-│  [Logo] Turbo EA          [Search] [+ Create] [User]│
-├──────────┬──────────────────────────────────────────┤
-│ Dashboard│                                          │
-│ Inventory│           Main Content Area              │
-│ Reports ▸│                                          │
-│  ├ Landscape                                        │
-│  ├ Portfolio                                        │
-│  ├ Matrix                                           │
-│  ├ Roadmap                                          │
-│  └ Cost                                             │
-│ Diagrams │                                          │
-│ Todos    │                                          │
-│──────────│                                          │
-│ Admin   ▸│                                          │
-│  ├ Metamodel                                        │
-│  ├ Tags                                             │
-│  └ Users                                            │
-└──────────┴──────────────────────────────────────────┘
-```
+### Backend Changes
+
+#### 1. Enrich FactSheetType model
+- Add `subtypes` JSONB column: `[{key, label}]`
+- Add `completion_weights` JSONB column (or embed weights in fields_schema)
+
+#### 2. Enrich TagGroup model
+- Add `create_mode` column: "open" / "restricted" (default: "open")
+- Add `restrict_to_types` JSONB column: list of fact sheet type keys (null = all)
+
+#### 3. Quality Seal states
+- Change default from "UNSET" to "DRAFT"
+- Support 4 states: DRAFT, APPROVED, BROKEN, REJECTED
+- Auto-break seal on attribute/relation/lifecycle changes (except by responsible/accountable)
+
+#### 4. Overhaul seed data
+Complete LeanIX-faithful field schemas for all 12 types with:
+- Multiple sections per type (Information, Cost, etc.)
+- Proper field keys matching LeanIX GraphQL names (functionalSuitability not functionalFit)
+- Required flags on key fields
+- Weight values for completion
+- Subtypes for Application, Interface, ITComponent, Organization, BusinessContext, Initiative, Platform
+
+Enriched relation types with proper attributes:
+- relAppToBC: functionalSuitability, supportType
+- relAppToITC: technicalSuitability, costTotalAnnual
+- relAppToOrg: usageType
+- relITCToTechCat: resourceClassification (5 values with colors)
+- relAppToDataObj: crudFlags
+- Provider/Consumer interface pattern
+- Self-referencing: successor, predecessor, requires, requiredBy
+
+#### 5. Completion score calculation
+- Backend computes score on fact sheet create/update
+- Reads fields_schema weights, checks which fields in `attributes` are filled
+- Returns completion as 0–100 integer
+
+#### 6. Fact sheet PATCH improvements
+- Break quality seal on attribute/relation change (check if user is subscriber)
+- Record field-level changes in events (old_value → new_value)
+- Validate against fields_schema types
+
+### Frontend Changes
+
+#### 1. FactSheetDetail — Complete Overhaul
+**Header area:**
+- Fact sheet type badge (colored chip with icon)
+- Name (large, editable inline)
+- Completion score ring (circular progress %)
+- Quality seal badge with approve/reject actions
+- Tags displayed as colored chips
+- Action menu: Edit, Delete, Clone, Subscribe
+
+**Body — Section-based layout (NOT tabs for content):**
+Replace current tab-based layout with scrollable sections like real LeanIX:
+
+1. **Information Section** (collapsible)
+   - Subsections from fields_schema, each with header
+   - Edit button per subsection → inline form
+   - Field types: text input, single_select dropdown (colored chips), number, boolean switch, date picker
+   - Required fields marked with asterisk
+
+2. **Lifecycle Section** (collapsible)
+   - 5-phase horizontal timeline visualization
+   - Date pickers for each phase
+   - Color-coded current phase indicator
+
+3. **Relations Sections** (one per relation type, collapsible)
+   - Grouped by relation type (e.g., "Business Capabilities", "IT Components")
+   - Each shows list of related fact sheets with relation attributes
+   - Add relation: search dialog with fact sheet type filter
+   - Relation attributes editable inline
+
+4. **Tags Section** (collapsible)
+   - Tag groups with assigned tags
+   - Add/remove tags
+
+5. **Subscriptions Section** (collapsible)
+   - Grouped by role (Responsible, Accountable, Observer)
+   - Add/remove subscribers
+
+6. **Documents Section** (collapsible)
+   - List of links/resources
+   - Add new link
+
+**Sidebar tabs (Comments, Todos, History):**
+- Right sidebar or bottom tabs for collaborative features
+
+#### 2. CreateFactSheetDialog — Enhanced
+- Type selector with icons
+- **Subtype selector** (shows subtypes for selected type)
+- **Parent selector** (for hierarchical types — search existing fact sheets)
+- Name (required)
+- Description
+- Mandatory fields from fields_schema (marked with asterisk)
+
+#### 3. InventoryPage — Enhanced Filters
+- Quality seal filter (Draft/Approved/Broken/Rejected chips)
+- Lifecycle phase filter
+- Tag filter (multi-select from tag groups)
+- Subscription filter (my fact sheets)
+- Completion range filter
+- Column for subtype
+
+#### 4. QualitySealBadge — Enhanced
+- Show all 4 states with distinct colors
+- DRAFT: gray, APPROVED: green, BROKEN: amber, REJECTED: red
+- Approve button only shown to subscribers
 
 ---
 
@@ -141,17 +341,17 @@ Plus parent/child (hierarchy) relations within: Business Capability, Business Co
 ### Core Tables
 
 ```sql
--- Configurable metamodel
 fact_sheet_types (
   id UUID PK,
-  key VARCHAR(100) UNIQUE,     -- e.g. "Application"
+  key VARCHAR(100) UNIQUE,
   label VARCHAR(200),
   description TEXT,
   icon VARCHAR(100),
   color VARCHAR(20),
   category VARCHAR(50),        -- business/application/technology/transformation
   has_hierarchy BOOLEAN,
-  fields_schema JSONB,         -- [{section, subsection, fields: [{key, label, type, options, required}]}]
+  subtypes JSONB,              -- [{key, label}] — NEW
+  fields_schema JSONB,         -- [{section, fields: [{key, label, type, options, required, weight}]}]
   built_in BOOLEAN DEFAULT true,
   sort_order INT,
   created_at, updated_at
@@ -161,348 +361,52 @@ relation_types (
   id UUID PK,
   key VARCHAR(100) UNIQUE,
   label VARCHAR(200),
-  source_type_key VARCHAR(100) FK,
-  target_type_key VARCHAR(100) FK,
-  attributes_schema JSONB,     -- [{key, label, type, options}]
+  source_type_key VARCHAR(100),
+  target_type_key VARCHAR(100),
+  attributes_schema JSONB,
   built_in BOOLEAN DEFAULT true,
   created_at, updated_at
 )
 
--- Fact sheets (single polymorphic table)
 fact_sheets (
   id UUID PK,
-  type VARCHAR(100) FK → fact_sheet_types.key,
+  type VARCHAR(100),
+  subtype VARCHAR(100),        -- NEW
   name VARCHAR(500) NOT NULL,
   description TEXT,
-  parent_id UUID FK → fact_sheets.id,  -- hierarchy
-  lifecycle JSONB,             -- {plan, phaseIn, active, phaseOut, endOfLife}
-  attributes JSONB,            -- type-specific fields
+  parent_id UUID FK,
+  lifecycle JSONB,
+  attributes JSONB,
   status VARCHAR(20) DEFAULT 'ACTIVE',
-  quality_seal VARCHAR(20) DEFAULT 'UNSET',  -- UNSET/APPROVED/BROKEN
+  quality_seal VARCHAR(20) DEFAULT 'DRAFT',  -- CHANGED from UNSET
   completion FLOAT DEFAULT 0,
   external_id VARCHAR(500),
   alias VARCHAR(500),
-  created_by UUID FK, updated_by UUID FK,
+  created_by UUID FK,
+  updated_by UUID FK,
   created_at, updated_at
 )
 
--- Relations between fact sheets
-relations (
-  id UUID PK,
-  type VARCHAR(100) FK → relation_types.key,
-  source_id UUID FK → fact_sheets.id,
-  target_id UUID FK → fact_sheets.id,
-  attributes JSONB,
-  description TEXT,
-  created_at, updated_at
-)
-
--- Subscriptions (data ownership)
-subscriptions (
-  id UUID PK,
-  fact_sheet_id UUID FK,
-  user_id UUID FK,
-  role VARCHAR(20),            -- responsible/accountable/observer
-  created_at
-)
-
--- Tag system
 tag_groups (
   id UUID PK,
   name VARCHAR(200),
   description TEXT,
-  mode VARCHAR(20),            -- single/multi
+  mode VARCHAR(20) DEFAULT 'multi',
+  create_mode VARCHAR(20) DEFAULT 'open',    -- NEW
+  restrict_to_types JSONB,                    -- NEW
   mandatory BOOLEAN DEFAULT false,
   created_at
 )
 
-tags (
-  id UUID PK,
-  tag_group_id UUID FK,
-  name VARCHAR(200),
-  color VARCHAR(20),
-  sort_order INT
-)
-
-fact_sheet_tags (
-  fact_sheet_id UUID FK,
-  tag_id UUID FK,
-  PRIMARY KEY (fact_sheet_id, tag_id)
-)
-
--- Comments
-comments (
-  id UUID PK,
-  fact_sheet_id UUID FK,
-  user_id UUID FK,
-  content TEXT,
-  parent_id UUID FK → comments.id,  -- threading
-  created_at, updated_at
-)
-
--- Todos
-todos (
-  id UUID PK,
-  fact_sheet_id UUID FK,
-  description TEXT,
-  status VARCHAR(20),          -- open/done
-  assigned_to UUID FK,
-  created_by UUID FK,
-  due_date DATE,
-  created_at, updated_at
-)
-
--- Audit events
-events (
-  id UUID PK,
-  fact_sheet_id UUID FK,
-  user_id UUID FK,
-  event_type VARCHAR(100),
-  data JSONB,
-  created_at
-)
-
--- Documents/Resources
-documents (
-  id UUID PK,
-  fact_sheet_id UUID FK,
-  name VARCHAR(500),
-  url TEXT,
-  type VARCHAR(50),            -- link/document
-  created_by UUID FK,
-  created_at
-)
-
--- Saved views / bookmarks
-bookmarks (
-  id UUID PK,
-  user_id UUID FK,
-  name VARCHAR(200),
-  fact_sheet_type VARCHAR(100),
-  filters JSONB,
-  columns JSONB,
-  sort JSONB,
-  is_default BOOLEAN DEFAULT false,
-  created_at, updated_at
-)
-
--- Diagrams
-diagrams (
-  id UUID PK,
-  name VARCHAR(500),
-  type VARCHAR(50),            -- free_draw/data_flow
-  data JSONB,                  -- diagram state (nodes, edges, positions)
-  created_by UUID FK,
-  created_at, updated_at
-)
-
--- Users
-users (
-  id UUID PK,
-  email VARCHAR(320) UNIQUE,
-  display_name VARCHAR(200),
-  password_hash VARCHAR(200),
-  role VARCHAR(20) DEFAULT 'member',  -- admin/member/viewer
-  is_active BOOLEAN DEFAULT true,
-  created_at, updated_at
-)
+-- All other tables unchanged from Phase 1
 ```
 
 ---
 
-## API Routes
+## API Routes (unchanged from Phase 1, plus)
 
-### Auth
-- `POST /api/v1/auth/register` — Register user
-- `POST /api/v1/auth/login` — Login → JWT
-- `GET /api/v1/auth/me` — Current user
-
-### Fact Sheets
-- `GET /api/v1/fact-sheets` — List (filtered, paginated, sorted)
-- `POST /api/v1/fact-sheets` — Create
-- `GET /api/v1/fact-sheets/{id}` — Detail (with relations, subscriptions, tags)
-- `PATCH /api/v1/fact-sheets/{id}` — Update
-- `DELETE /api/v1/fact-sheets/{id}` — Archive
-- `PATCH /api/v1/fact-sheets/bulk` — Bulk update
-- `GET /api/v1/fact-sheets/{id}/history` — Audit log
-- `POST /api/v1/fact-sheets/{id}/quality-seal` — Approve/break seal
-- `GET /api/v1/fact-sheets/export` — CSV export
-
-### Relations
-- `GET /api/v1/relations` — List (filtered by fact_sheet_id, type)
-- `POST /api/v1/relations` — Create
-- `PATCH /api/v1/relations/{id}` — Update
-- `DELETE /api/v1/relations/{id}` — Delete
-
-### Subscriptions
-- `GET /api/v1/fact-sheets/{id}/subscriptions`
-- `POST /api/v1/fact-sheets/{id}/subscriptions`
-- `DELETE /api/v1/subscriptions/{id}`
-
-### Comments
-- `GET /api/v1/fact-sheets/{id}/comments`
-- `POST /api/v1/fact-sheets/{id}/comments`
-- `PATCH /api/v1/comments/{id}`
-- `DELETE /api/v1/comments/{id}`
-
-### Todos
-- `GET /api/v1/todos` — All todos (with filters)
-- `GET /api/v1/fact-sheets/{id}/todos`
-- `POST /api/v1/fact-sheets/{id}/todos`
-- `PATCH /api/v1/todos/{id}`
-- `DELETE /api/v1/todos/{id}`
-
-### Tags
-- `GET /api/v1/tag-groups` — List tag groups with tags
-- `POST /api/v1/tag-groups` — Create group
-- `POST /api/v1/tag-groups/{id}/tags` — Create tag in group
-- `POST /api/v1/fact-sheets/{id}/tags` — Assign tags
-- `DELETE /api/v1/fact-sheets/{id}/tags/{tagId}` — Remove tag
-
-### Metamodel
-- `GET /api/v1/metamodel/types` — List fact sheet type configs
-- `POST /api/v1/metamodel/types` — Create custom type
-- `PATCH /api/v1/metamodel/types/{key}` — Update type config
-- `GET /api/v1/metamodel/relation-types` — List relation type configs
-- `POST /api/v1/metamodel/relation-types` — Create custom relation type
-
-### Reports
-- `GET /api/v1/reports/dashboard` — Dashboard KPIs
-- `GET /api/v1/reports/landscape` — Landscape data
-- `GET /api/v1/reports/portfolio` — Portfolio scatter data
-- `GET /api/v1/reports/matrix` — Matrix cross-reference
-- `GET /api/v1/reports/roadmap` — Timeline data
-- `GET /api/v1/reports/cost` — Cost aggregation
-
-### Diagrams
-- `GET /api/v1/diagrams`
-- `POST /api/v1/diagrams`
-- `GET /api/v1/diagrams/{id}`
-- `PATCH /api/v1/diagrams/{id}`
-- `DELETE /api/v1/diagrams/{id}`
-
-### Documents
-- `GET /api/v1/fact-sheets/{id}/documents`
-- `POST /api/v1/fact-sheets/{id}/documents`
-- `DELETE /api/v1/documents/{id}`
-
-### Bookmarks
-- `GET /api/v1/bookmarks`
-- `POST /api/v1/bookmarks`
-- `PATCH /api/v1/bookmarks/{id}`
-- `DELETE /api/v1/bookmarks/{id}`
-
-### Events
-- `GET /api/v1/events/stream` — SSE real-time
-- `GET /api/v1/events` — Query events
-
-### Users (admin)
-- `GET /api/v1/users`
-- `PATCH /api/v1/users/{id}`
-
----
-
-## Frontend Routes
-
-| Route | Page | Description |
-|-------|------|-------------|
-| `/` | Dashboard | KPI widgets, recent activity, quick links |
-| `/inventory` | Inventory | AG Grid with type filter, saved views |
-| `/fact-sheets/:id` | Fact Sheet Detail | Tabbed detail: Overview, Relations, Subscriptions, Comments, Todos, History |
-| `/reports/landscape` | Landscape Report | Grouped tiles with heat map coloring |
-| `/reports/portfolio` | Portfolio Report | Bubble chart (functionalFit vs technicalFit) |
-| `/reports/matrix` | Matrix Report | Cross-reference grid |
-| `/reports/roadmap` | Roadmap | Timeline of lifecycle transitions |
-| `/reports/cost` | Cost Report | Cost breakdowns by provider/app/capability |
-| `/diagrams` | Diagram List | List of saved diagrams |
-| `/diagrams/:id` | Diagram Editor | Free draw / data flow canvas |
-| `/todos` | Todo List | All todos across fact sheets |
-| `/admin/metamodel` | Metamodel Config | Configure fact sheet types, fields, relations |
-| `/admin/tags` | Tag Management | Tag groups and tags CRUD |
-| `/admin/users` | User Management | User roles and access |
-| `/login` | Login | Auth page |
-
----
-
-## Implementation Phases
-
-### Phase 1: Foundation — Database + Metamodel + Auth + App Shell
-**Backend:**
-- Clean FastAPI app structure (config, database, models, schemas, API, services)
-- All database models (fact_sheets, relations, subscriptions, comments, todos, tags, events, documents, bookmarks, diagrams, users, fact_sheet_types, relation_types)
-- Seed 12 default fact sheet types with full fields_schema
-- Seed 20+ default relation types
-- JWT auth (stdlib HMAC-SHA256 + bcrypt)
-- Event bus + SSE
-
-**Frontend:**
-- React + Vite + MUI app shell
-- Sidebar navigation (LeanIX-like)
-- Top bar with global search + quick create
-- Auth (login/register)
-- API client with JWT interceptor
-- SSE hook for real-time updates
-
-**Infrastructure:**
-- Docker Compose (backend + frontend/nginx)
-- External PostgreSQL support
-- .env.example
-
-### Phase 2: Fact Sheet CRUD + Detail Page + Inventory
-**Backend:**
-- Complete fact sheet CRUD API
-- Dynamic field validation from metamodel
-- Lifecycle management
-- Hierarchy (parent/child)
-- Completion score calculation
-- Quality seal workflow
-- Tag assignment
-- Subscription management
-- Comment CRUD
-- Todo CRUD
-- Document/resource links
-- History/audit events
-- Bulk update endpoint
-- CSV export
-- Bookmark/saved view CRUD
-
-**Frontend:**
-- **Inventory page**: AG Grid with dynamic columns from metamodel, type filter, lifecycle filter, tag filter, inline editing, multi-select bulk edit, saved views, CSV export
-- **Fact sheet detail page**: Tabbed layout with:
-  - Overview tab: Dynamic sections/subsections/fields from metamodel, lifecycle display, tags, documents
-  - Relations tab: Grouped by relation type, add/remove relations
-  - Subscriptions tab: Responsible/Accountable/Observer management
-  - Comments tab: Threaded discussion
-  - Todos tab: Task list
-  - History tab: Audit log timeline
-- **Create dialog**: Type selector + name + initial fields
-- Quality seal badge + approve/break workflow
-
-### Phase 3: Reports + Dashboard
-**Backend:**
-- Report data aggregation endpoints (landscape, portfolio, matrix, roadmap, cost, dashboard KPIs)
-
-**Frontend:**
-- **Dashboard**: KPI cards (total fact sheets by type, completion avg, lifecycle distribution, cost totals), recent activity feed, quick actions
-- **Landscape Report**: Fact sheets as colored tiles grouped by a parent type (e.g., Apps by Business Capability), color = lifecycle/fit/criticality
-- **Portfolio Report**: Bubble chart with configurable X/Y axes (functional fit vs technical fit, with size = cost, color = criticality)
-- **Matrix Report**: Two-axis grid (e.g., Apps × Business Capabilities, colored by relation presence)
-- **Roadmap**: Timeline visualization of lifecycle phases across fact sheets
-- **Cost Report**: Bar/pie charts of cost by provider, by app, by capability
-
-### Phase 4: Diagrams + Admin + Polish
-**Backend:**
-- Diagram CRUD
-- Metamodel admin endpoints (add/edit types, fields, relation types)
-- User management endpoints
-
-**Frontend:**
-- **Free Draw Diagram Editor**: Canvas with draggable fact sheet nodes, connectors, labels (using React Flow or similar)
-- **Data Flow Diagram**: Auto-layout of interfaces between applications
-- **Admin - Metamodel**: Configure fact sheet types, sections, fields, relation types
-- **Admin - Tags**: Tag group and tag CRUD
-- **Admin - Users**: User list, role assignment
-- **Todos page**: Cross-fact-sheet todo list with filters
+- `POST /api/v1/fact-sheets/{id}/quality-seal` body: `{action: "approve"|"reject"|"reset"}`
+- `GET /api/v1/fact-sheets/{id}` now returns computed completion, resolved relations with attributes
 
 ---
 
@@ -521,10 +425,6 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
-Access: `http://<unraid-ip>:8920`
+First run with old database: `RESET_DB=true docker compose up -d`
 
-### Updating
-```bash
-cd /mnt/user/appdata/turbo-ea
-git pull && docker compose up -d --build
-```
+Access: `http://<unraid-ip>:8920`

--- a/backend/app/models/fact_sheet.py
+++ b/backend/app/models/fact_sheet.py
@@ -13,6 +13,7 @@ class FactSheet(Base, UUIDMixin, TimestampMixin):
     __tablename__ = "fact_sheets"
 
     type: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    subtype: Mapped[str | None] = mapped_column(String(100))
     name: Mapped[str] = mapped_column(String(500), nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     parent_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -21,7 +22,7 @@ class FactSheet(Base, UUIDMixin, TimestampMixin):
     lifecycle: Mapped[dict | None] = mapped_column(JSONB, default=dict)
     attributes: Mapped[dict | None] = mapped_column(JSONB, default=dict)
     status: Mapped[str] = mapped_column(String(20), default="ACTIVE")
-    quality_seal: Mapped[str] = mapped_column(String(20), default="UNSET")
+    quality_seal: Mapped[str] = mapped_column(String(20), default="DRAFT")
     completion: Mapped[float] = mapped_column(Float, default=0.0)
     external_id: Mapped[str | None] = mapped_column(String(500))
     alias: Mapped[str | None] = mapped_column(String(500))

--- a/backend/app/models/fact_sheet_type.py
+++ b/backend/app/models/fact_sheet_type.py
@@ -19,6 +19,7 @@ class FactSheetType(Base, UUIDMixin, TimestampMixin):
     color: Mapped[str] = mapped_column(String(20), default="#1976d2")
     category: Mapped[str] = mapped_column(String(50), default="application")
     has_hierarchy: Mapped[bool] = mapped_column(Boolean, default=False)
+    subtypes: Mapped[list | None] = mapped_column(JSONB, default=list)  # [{key, label}]
     fields_schema: Mapped[list] = mapped_column(JSONB, default=list)
     built_in: Mapped[bool] = mapped_column(Boolean, default=True)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, UUIDMixin
@@ -16,6 +16,8 @@ class TagGroup(Base, UUIDMixin):
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     mode: Mapped[str] = mapped_column(String(20), default="multi")  # single/multi
+    create_mode: Mapped[str] = mapped_column(String(20), default="open")  # open/restricted
+    restrict_to_types: Mapped[list | None] = mapped_column(JSONB)  # list of FS type keys, null=all
     mandatory: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/schemas/fact_sheet.py
+++ b/backend/app/schemas/fact_sheet.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 class FactSheetCreate(BaseModel):
     type: str
+    subtype: str | None = None
     name: str
     description: str | None = None
     parent_id: str | None = None
@@ -19,6 +20,7 @@ class FactSheetCreate(BaseModel):
 
 class FactSheetUpdate(BaseModel):
     name: str | None = None
+    subtype: str | None = None
     description: str | None = None
     parent_id: str | None = None
     lifecycle: dict | None = None
@@ -55,6 +57,7 @@ class SubscriptionRef(BaseModel):
 class FactSheetResponse(BaseModel):
     id: str
     type: str
+    subtype: str | None = None
     name: str
     description: str | None = None
     parent_id: str | None = None

--- a/frontend/src/components/CreateFactSheetDialog.tsx
+++ b/frontend/src/components/CreateFactSheetDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -11,77 +11,323 @@ import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
-import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
+import Alert from "@mui/material/Alert";
+import Autocomplete from "@mui/material/Autocomplete";
+import CircularProgress from "@mui/material/CircularProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
-import type { FactSheet } from "@/types";
+import type { FieldDef, FactSheet } from "@/types";
 
 interface Props {
   open: boolean;
   onClose: () => void;
-  onCreate: (fs: FactSheet) => void;
+  onCreate: (data: {
+    type: string;
+    subtype?: string;
+    name: string;
+    description?: string;
+    parent_id?: string;
+    attributes?: Record<string, unknown>;
+  }) => Promise<void>;
   initialType?: string;
 }
 
-export default function CreateFactSheetDialog({ open, onClose, onCreate, initialType }: Props) {
+interface ParentOption {
+  id: string;
+  name: string;
+}
+
+export default function CreateFactSheetDialog({
+  open,
+  onClose,
+  onCreate,
+  initialType,
+}: Props) {
   const { types } = useMetamodel();
+
   const [selectedType, setSelectedType] = useState(initialType || "");
+  const [subtype, setSubtype] = useState("");
+  const [parentId, setParentId] = useState<string | null>(null);
+  const [parentInputValue, setParentInputValue] = useState("");
+  const [parentOptions, setParentOptions] = useState<ParentOption[]>([]);
+  const [parentLoading, setParentLoading] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [attributes, setAttributes] = useState<Record<string, unknown>>({});
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-  const typeConfig = types.find((t) => t.key === selectedType);
+  const typeConfig = useMemo(
+    () => types.find((t) => t.key === selectedType),
+    [types, selectedType],
+  );
 
-  const handleCreate = async () => {
-    if (!selectedType || !name.trim()) return;
-    setLoading(true);
-    try {
-      const fs = await api.post<FactSheet>("/fact-sheets", {
-        type: selectedType,
-        name: name.trim(),
-        description: description.trim() || undefined,
-        attributes,
-      });
-      onCreate(fs);
-      // Reset
+  const hasSubtypes = !!(typeConfig?.subtypes && typeConfig.subtypes.length > 0);
+  const hasHierarchy = !!typeConfig?.has_hierarchy;
+
+  // Collect all required fields across all sections for the selected type
+  const requiredFields = useMemo(() => {
+    if (!typeConfig) return [];
+    const fields: (FieldDef & { sectionName: string })[] = [];
+    for (const section of typeConfig.fields_schema) {
+      for (const field of section.fields) {
+        if (field.required) {
+          fields.push({ ...field, sectionName: section.section });
+        }
+      }
+    }
+    return fields;
+  }, [typeConfig]);
+
+  // Reset dependent fields when type changes
+  useEffect(() => {
+    setSubtype("");
+    setParentId(null);
+    setParentInputValue("");
+    setParentOptions([]);
+    setAttributes({});
+    setError("");
+  }, [selectedType]);
+
+  // Set initial type when dialog opens
+  useEffect(() => {
+    if (open && initialType) {
+      setSelectedType(initialType);
+    }
+  }, [open, initialType]);
+
+  // Reset form when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setSelectedType(initialType || "");
+      setSubtype("");
+      setParentId(null);
+      setParentInputValue("");
+      setParentOptions([]);
       setName("");
       setDescription("");
       setAttributes({});
-      onClose();
-    } finally {
       setLoading(false);
+      setError("");
     }
-  };
+  }, [open, initialType]);
+
+  // Fetch parent options when search query changes
+  const fetchParentOptions = useCallback(
+    async (query: string) => {
+      if (!selectedType || !hasHierarchy) return;
+      setParentLoading(true);
+      try {
+        const params = new URLSearchParams({
+          type: selectedType,
+          search: query,
+          page_size: "20",
+        });
+        const res = await api.get<{ items: FactSheet[] }>(
+          `/fact-sheets?${params.toString()}`,
+        );
+        setParentOptions(
+          res.items.map((fs) => ({ id: fs.id, name: fs.name })),
+        );
+      } catch {
+        setParentOptions([]);
+      } finally {
+        setParentLoading(false);
+      }
+    },
+    [selectedType, hasHierarchy],
+  );
+
+  // Debounced parent search
+  useEffect(() => {
+    if (!hasHierarchy) return;
+    const timer = setTimeout(() => {
+      fetchParentOptions(parentInputValue);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [parentInputValue, hasHierarchy, fetchParentOptions]);
 
   const setAttr = (key: string, value: unknown) => {
     setAttributes((prev) => ({ ...prev, [key]: value }));
   };
 
+  const handleSubmit = async () => {
+    if (!selectedType || !name.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      await onCreate({
+        type: selectedType,
+        subtype: subtype || undefined,
+        name: name.trim(),
+        description: description.trim() || undefined,
+        parent_id: parentId || undefined,
+        attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
+      });
+      onClose();
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to create fact sheet";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderField = (field: FieldDef) => {
+    switch (field.type) {
+      case "single_select":
+        return (
+          <FormControl fullWidth key={field.key} sx={{ mb: 2 }}>
+            <InputLabel>{field.label}</InputLabel>
+            <Select
+              value={(attributes[field.key] as string) ?? ""}
+              label={field.label}
+              onChange={(e) => setAttr(field.key, e.target.value || undefined)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {field.options?.map((opt) => (
+                <MenuItem key={opt.key} value={opt.key}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    {opt.color && (
+                      <Box
+                        sx={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: "50%",
+                          bgcolor: opt.color,
+                          flexShrink: 0,
+                        }}
+                      />
+                    )}
+                    {opt.label}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        );
+
+      case "number":
+        return (
+          <TextField
+            key={field.key}
+            fullWidth
+            label={field.label}
+            type="number"
+            value={attributes[field.key] ?? ""}
+            onChange={(e) =>
+              setAttr(
+                field.key,
+                e.target.value ? Number(e.target.value) : undefined,
+              )
+            }
+            sx={{ mb: 2 }}
+          />
+        );
+
+      case "boolean":
+        return (
+          <FormControlLabel
+            key={field.key}
+            control={
+              <Switch
+                checked={!!attributes[field.key]}
+                onChange={(e) => setAttr(field.key, e.target.checked)}
+              />
+            }
+            label={field.label}
+            sx={{ mb: 1, display: "block" }}
+          />
+        );
+
+      case "date":
+        return (
+          <TextField
+            key={field.key}
+            fullWidth
+            label={field.label}
+            type="date"
+            value={(attributes[field.key] as string) ?? ""}
+            onChange={(e) => setAttr(field.key, e.target.value || undefined)}
+            InputLabelProps={{ shrink: true }}
+            sx={{ mb: 2 }}
+          />
+        );
+
+      case "text":
+      default:
+        return (
+          <TextField
+            key={field.key}
+            fullWidth
+            label={field.label}
+            value={(attributes[field.key] as string) ?? ""}
+            onChange={(e) => setAttr(field.key, e.target.value || undefined)}
+            sx={{ mb: 2 }}
+          />
+        );
+    }
+  };
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-        <MaterialSymbol icon="add_circle" size={24} color="#1976d2" />
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { maxWidth: 560, width: "100%" } }}
+    >
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          pb: 1,
+        }}
+      >
         Create Fact Sheet
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          size="small"
+          sx={{ color: "text.secondary" }}
+        >
+          <MaterialSymbol icon="close" size={20} />
+        </IconButton>
       </DialogTitle>
-      <DialogContent>
-        <FormControl fullWidth sx={{ mt: 1, mb: 2 }}>
-          <InputLabel>Fact Sheet Type</InputLabel>
+
+      <DialogContent dividers sx={{ pt: 2 }}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Type selector */}
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Type</InputLabel>
           <Select
             value={selectedType}
-            label="Fact Sheet Type"
-            onChange={(e) => {
-              setSelectedType(e.target.value);
-              setAttributes({});
-            }}
+            label="Type"
+            onChange={(e) => setSelectedType(e.target.value)}
           >
             {types.map((t) => (
               <MenuItem key={t.key} value={t.key}>
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <MaterialSymbol icon={t.icon} size={18} color={t.color} />
+                  <Box
+                    sx={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: "50%",
+                      bgcolor: t.color,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <MaterialSymbol icon={t.icon} size={20} color={t.color} />
                   {t.label}
                 </Box>
               </MenuItem>
@@ -89,6 +335,68 @@ export default function CreateFactSheetDialog({ open, onClose, onCreate, initial
           </Select>
         </FormControl>
 
+        {/* Subtype selector */}
+        {hasSubtypes && (
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel>Subtype</InputLabel>
+            <Select
+              value={subtype}
+              label="Subtype"
+              onChange={(e) => setSubtype(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {typeConfig!.subtypes!.map((st) => (
+                <MenuItem key={st.key} value={st.key}>
+                  {st.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        {/* Parent selector */}
+        {hasHierarchy && (
+          <Autocomplete
+            sx={{ mb: 2 }}
+            options={parentOptions}
+            getOptionLabel={(opt) => opt.name}
+            isOptionEqualToValue={(opt, val) => opt.id === val.id}
+            loading={parentLoading}
+            value={
+              parentId
+                ? parentOptions.find((o) => o.id === parentId) || null
+                : null
+            }
+            onChange={(_e, newValue) => {
+              setParentId(newValue ? newValue.id : null);
+            }}
+            inputValue={parentInputValue}
+            onInputChange={(_e, newInputValue) => {
+              setParentInputValue(newInputValue);
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Parent"
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <>
+                      {parentLoading ? (
+                        <CircularProgress color="inherit" size={18} />
+                      ) : null}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+          />
+        )}
+
+        {/* Name */}
         <TextField
           fullWidth
           label="Name"
@@ -97,6 +405,8 @@ export default function CreateFactSheetDialog({ open, onClose, onCreate, initial
           required
           sx={{ mb: 2 }}
         />
+
+        {/* Description */}
         <TextField
           fullWidth
           label="Description"
@@ -107,114 +417,23 @@ export default function CreateFactSheetDialog({ open, onClose, onCreate, initial
           sx={{ mb: 2 }}
         />
 
-        {typeConfig && typeConfig.fields_schema.length > 0 && (
-          <>
-            <Divider sx={{ my: 2 }} />
-            {typeConfig.fields_schema.map((section) => (
-              <Box key={section.section} sx={{ mb: 2 }}>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                  {section.section}
-                </Typography>
-                {section.fields.map((field) => {
-                  if (field.type === "single_select" && field.options) {
-                    return (
-                      <FormControl fullWidth key={field.key} sx={{ mb: 1.5 }}>
-                        <InputLabel>{field.label}</InputLabel>
-                        <Select
-                          value={(attributes[field.key] as string) || ""}
-                          label={field.label}
-                          onChange={(e) => setAttr(field.key, e.target.value)}
-                        >
-                          <MenuItem value="">
-                            <em>None</em>
-                          </MenuItem>
-                          {field.options.map((opt) => (
-                            <MenuItem key={opt.key} value={opt.key}>
-                              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                {opt.color && (
-                                  <Box
-                                    sx={{
-                                      width: 12,
-                                      height: 12,
-                                      borderRadius: "50%",
-                                      bgcolor: opt.color,
-                                    }}
-                                  />
-                                )}
-                                {opt.label}
-                              </Box>
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    );
-                  }
-                  if (field.type === "number") {
-                    return (
-                      <TextField
-                        key={field.key}
-                        fullWidth
-                        label={field.label}
-                        type="number"
-                        value={attributes[field.key] ?? ""}
-                        onChange={(e) => setAttr(field.key, e.target.value ? Number(e.target.value) : undefined)}
-                        sx={{ mb: 1.5 }}
-                      />
-                    );
-                  }
-                  if (field.type === "boolean") {
-                    return (
-                      <FormControlLabel
-                        key={field.key}
-                        control={
-                          <Switch
-                            checked={!!attributes[field.key]}
-                            onChange={(e) => setAttr(field.key, e.target.checked)}
-                          />
-                        }
-                        label={field.label}
-                        sx={{ mb: 1 }}
-                      />
-                    );
-                  }
-                  if (field.type === "date") {
-                    return (
-                      <TextField
-                        key={field.key}
-                        fullWidth
-                        label={field.label}
-                        type="date"
-                        value={(attributes[field.key] as string) || ""}
-                        onChange={(e) => setAttr(field.key, e.target.value)}
-                        InputLabelProps={{ shrink: true }}
-                        sx={{ mb: 1.5 }}
-                      />
-                    );
-                  }
-                  return (
-                    <TextField
-                      key={field.key}
-                      fullWidth
-                      label={field.label}
-                      value={(attributes[field.key] as string) || ""}
-                      onChange={(e) => setAttr(field.key, e.target.value)}
-                      sx={{ mb: 1.5 }}
-                    />
-                  );
-                })}
-              </Box>
-            ))}
-          </>
-        )}
+        {/* Required fields from schema */}
+        {requiredFields.length > 0 && requiredFields.map((f) => renderField(f))}
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
+
+      <DialogActions sx={{ px: 3, py: 1.5 }}>
+        <Button onClick={onClose} color="inherit">
+          Cancel
+        </Button>
         <Button
           variant="contained"
-          onClick={handleCreate}
+          onClick={handleSubmit}
           disabled={!selectedType || !name.trim() || loading}
+          startIcon={
+            loading ? <CircularProgress size={18} color="inherit" /> : undefined
+          }
         >
-          {loading ? "Creating..." : "Create"}
+          Create
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/QualitySealBadge.tsx
+++ b/frontend/src/components/QualitySealBadge.tsx
@@ -6,26 +6,25 @@ interface Props {
   size?: "small" | "medium";
 }
 
+const SEAL_CONFIG: Record<
+  string,
+  { label: string; color: "default" | "success" | "warning" | "error"; icon: string }
+> = {
+  DRAFT: { label: "Draft", color: "default", icon: "edit_note" },
+  APPROVED: { label: "Approved", color: "success", icon: "verified" },
+  BROKEN: { label: "Broken", color: "warning", icon: "warning" },
+  REJECTED: { label: "Rejected", color: "error", icon: "cancel" },
+};
+
 export default function QualitySealBadge({ seal, size = "small" }: Props) {
-  if (seal === "APPROVED") {
-    return (
-      <Chip
-        size={size}
-        label="Approved"
-        color="success"
-        icon={<MaterialSymbol icon="verified" size={16} />}
-      />
-    );
-  }
-  if (seal === "BROKEN") {
-    return (
-      <Chip
-        size={size}
-        label="Broken"
-        color="warning"
-        icon={<MaterialSymbol icon="warning" size={16} />}
-      />
-    );
-  }
-  return null;
+  const cfg = SEAL_CONFIG[seal];
+  if (!cfg) return null;
+  return (
+    <Chip
+      size={size}
+      label={cfg.label}
+      color={cfg.color}
+      icon={<MaterialSymbol icon={cfg.icon} size={16} />}
+    />
+  );
 }

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -12,6 +12,9 @@ import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import Chip from "@mui/material/Chip";
+import LinearProgress from "@mui/material/LinearProgress";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import CreateFactSheetDialog from "@/components/CreateFactSheetDialog";
 import { useMetamodel } from "@/hooks/useMetamodel";
@@ -20,16 +23,28 @@ import type { FactSheet, FactSheetListResponse } from "@/types";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
 
+const SEAL_COLORS: Record<string, string> = {
+  DRAFT: "#9e9e9e",
+  APPROVED: "#4caf50",
+  BROKEN: "#ff9800",
+  REJECTED: "#f44336",
+};
+
 export default function InventoryPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { types } = useMetamodel();
-  const [selectedType, setSelectedType] = useState(searchParams.get("type") || "");
+  const [selectedType, setSelectedType] = useState(
+    searchParams.get("type") || ""
+  );
   const [search, setSearch] = useState(searchParams.get("search") || "");
+  const [sealFilter, setSealFilter] = useState<string[]>([]);
   const [data, setData] = useState<FactSheet[]>([]);
-  const [total, setTotal] = useState(0);
+  const [, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [createOpen, setCreateOpen] = useState(searchParams.get("create") === "true");
+  const [createOpen, setCreateOpen] = useState(
+    searchParams.get("create") === "true"
+  );
 
   const typeConfig = types.find((t) => t.key === selectedType);
 
@@ -40,7 +55,9 @@ export default function InventoryPage() {
       if (selectedType) params.set("type", selectedType);
       if (search) params.set("search", search);
       params.set("page_size", "500");
-      const res = await api.get<FactSheetListResponse>(`/fact-sheets?${params}`);
+      const res = await api.get<FactSheetListResponse>(
+        `/fact-sheets?${params}`
+      );
       setData(res.items);
       setTotal(res.total);
     } finally {
@@ -52,6 +69,12 @@ export default function InventoryPage() {
     loadData();
   }, [loadData]);
 
+  // Client-side seal filter
+  const filteredData = useMemo(() => {
+    if (sealFilter.length === 0) return data;
+    return data.filter((fs) => sealFilter.includes(fs.quality_seal));
+  }, [data, sealFilter]);
+
   const handleCellEdit = async (event: CellValueChangedEvent) => {
     const fs = event.data as FactSheet;
     const field = event.colDef.field!;
@@ -62,6 +85,18 @@ export default function InventoryPage() {
       const attrs = { ...fs.attributes, [key]: event.newValue };
       await api.patch(`/fact-sheets/${fs.id}`, { attributes: attrs });
     }
+  };
+
+  const handleCreate = async (createData: {
+    type: string;
+    subtype?: string;
+    name: string;
+    description?: string;
+    parent_id?: string;
+    attributes?: Record<string, unknown>;
+  }) => {
+    await api.post("/fact-sheets", createData);
+    loadData();
   };
 
   const columnDefs = useMemo<ColDef[]>(() => {
@@ -78,7 +113,9 @@ export default function InventoryPage() {
               label={t.label}
               sx={{ bgcolor: t.color, color: "#fff", fontWeight: 500 }}
             />
-          ) : p.value;
+          ) : (
+            p.value
+          );
         },
       },
       {
@@ -89,14 +126,49 @@ export default function InventoryPage() {
         editable: true,
         cellStyle: { cursor: "pointer", fontWeight: 500 },
       },
-      { field: "description", headerName: "Description", flex: 1, minWidth: 200, editable: true },
+      {
+        field: "description",
+        headerName: "Description",
+        flex: 1,
+        minWidth: 200,
+        editable: true,
+      },
+    ];
+
+    // Add subtype column when a type with subtypes is selected
+    if (typeConfig?.subtypes && typeConfig.subtypes.length > 0) {
+      cols.push({
+        field: "subtype",
+        headerName: "Subtype",
+        width: 140,
+        cellRenderer: (p: { value: string }) => {
+          if (!p.value) return "";
+          const st = typeConfig.subtypes?.find((s) => s.key === p.value);
+          return (
+            <Chip
+              size="small"
+              label={st?.label || p.value}
+              variant="outlined"
+            />
+          );
+        },
+      });
+    }
+
+    cols.push(
       {
         headerName: "Lifecycle",
         width: 120,
         valueGetter: (p: { data: FactSheet }) => {
           const lc = p.data?.lifecycle || {};
           const now = new Date().toISOString().slice(0, 10);
-          for (const phase of ["endOfLife", "phaseOut", "active", "phaseIn", "plan"]) {
+          for (const phase of [
+            "endOfLife",
+            "phaseOut",
+            "active",
+            "phaseIn",
+            "plan",
+          ]) {
             if (lc[phase] && lc[phase] <= now) return phase;
           }
           return "";
@@ -105,20 +177,62 @@ export default function InventoryPage() {
       {
         field: "quality_seal",
         headerName: "Seal",
-        width: 100,
+        width: 110,
         cellRenderer: (p: { value: string }) => {
-          if (p.value === "APPROVED") return <Chip size="small" label="OK" color="success" />;
-          if (p.value === "BROKEN") return <Chip size="small" label="!" color="warning" />;
-          return "";
+          const color = SEAL_COLORS[p.value];
+          if (!color) return "";
+          const labels: Record<string, string> = {
+            DRAFT: "Draft",
+            APPROVED: "Approved",
+            BROKEN: "Broken",
+            REJECTED: "Rejected",
+          };
+          return (
+            <Chip
+              size="small"
+              label={labels[p.value] || p.value}
+              sx={{ bgcolor: color, color: "#fff", fontWeight: 500 }}
+            />
+          );
         },
       },
       {
         field: "completion",
         headerName: "Completion",
-        width: 110,
-        valueFormatter: (p: { value: number }) => `${Math.round(p.value || 0)}%`,
-      },
-    ];
+        width: 130,
+        cellRenderer: (p: { value: number }) => {
+          const v = Math.round(p.value || 0);
+          const color =
+            v >= 80 ? "#4caf50" : v >= 50 ? "#ff9800" : "#f44336";
+          return (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                width: "100%",
+                pr: 1,
+              }}
+            >
+              <LinearProgress
+                variant="determinate"
+                value={v}
+                sx={{
+                  flex: 1,
+                  height: 6,
+                  borderRadius: 3,
+                  bgcolor: "#e0e0e0",
+                  "& .MuiLinearProgress-bar": { bgcolor: color, borderRadius: 3 },
+                }}
+              />
+              <Typography variant="caption" sx={{ minWidth: 32, textAlign: "right" }}>
+                {v}%
+              </Typography>
+            </Box>
+          );
+        },
+      }
+    );
 
     // Add type-specific attribute columns
     if (typeConfig) {
@@ -133,7 +247,8 @@ export default function InventoryPage() {
               (p.data?.attributes || {})[field.key] ?? "",
             valueSetter: (p) => {
               if (!p.data.attributes) p.data.attributes = {};
-              (p.data.attributes as Record<string, unknown>)[field.key] = p.newValue;
+              (p.data.attributes as Record<string, unknown>)[field.key] =
+                p.newValue;
               return true;
             },
             ...(field.type === "single_select" && field.options
@@ -148,7 +263,11 @@ export default function InventoryPage() {
                       <Chip
                         size="small"
                         label={opt.label}
-                        sx={opt.color ? { bgcolor: opt.color, color: "#fff" } : {}}
+                        sx={
+                          opt.color
+                            ? { bgcolor: opt.color, color: "#fff" }
+                            : {}
+                        }
                       />
                     ) : (
                       p.value || ""
@@ -170,7 +289,7 @@ export default function InventoryPage() {
         <Typography variant="h5" fontWeight={600}>
           Inventory
         </Typography>
-        <Chip label={`${total} items`} size="small" />
+        <Chip label={`${filteredData.length} items`} size="small" />
         <Box sx={{ flex: 1 }} />
         <Button
           variant="contained"
@@ -182,7 +301,15 @@ export default function InventoryPage() {
         </Button>
       </Box>
 
-      <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          mb: 2,
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
         <FormControl size="small" sx={{ minWidth: 200 }}>
           <InputLabel>Type</InputLabel>
           <Select
@@ -215,11 +342,40 @@ export default function InventoryPage() {
           }}
           sx={{ minWidth: 250 }}
         />
+        <ToggleButtonGroup
+          size="small"
+          value={sealFilter}
+          onChange={(_, v) => setSealFilter(v)}
+        >
+          {(["DRAFT", "APPROVED", "BROKEN", "REJECTED"] as const).map(
+            (seal) => (
+              <ToggleButton
+                key={seal}
+                value={seal}
+                sx={{
+                  textTransform: "none",
+                  px: 1.5,
+                  fontSize: "0.75rem",
+                  "&.Mui-selected": {
+                    bgcolor: SEAL_COLORS[seal] + "22",
+                    borderColor: SEAL_COLORS[seal],
+                    color: SEAL_COLORS[seal],
+                  },
+                }}
+              >
+                {seal.charAt(0) + seal.slice(1).toLowerCase()}
+              </ToggleButton>
+            )
+          )}
+        </ToggleButtonGroup>
       </Box>
 
-      <Box className="ag-theme-quartz" sx={{ height: "calc(100vh - 240px)", width: "100%" }}>
+      <Box
+        className="ag-theme-quartz"
+        sx={{ height: "calc(100vh - 240px)", width: "100%" }}
+      >
         <AgGridReact
-          rowData={data}
+          rowData={filteredData}
           columnDefs={columnDefs}
           loading={loading}
           rowSelection={{ mode: "multiRow", enableClickSelection: false }}
@@ -245,7 +401,7 @@ export default function InventoryPage() {
           setCreateOpen(false);
           setSearchParams({});
         }}
-        onCreate={() => loadData()}
+        onCreate={handleCreate}
         initialType={selectedType}
       />
     </Box>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,12 @@ export interface FieldDef {
   type: "text" | "number" | "boolean" | "date" | "single_select";
   options?: FieldOption[];
   required?: boolean;
+  weight?: number;
+}
+
+export interface SubtypeDef {
+  key: string;
+  label: string;
 }
 
 export interface SectionDef {
@@ -33,6 +39,7 @@ export interface FactSheetType {
   color: string;
   category: string;
   has_hierarchy: boolean;
+  subtypes?: SubtypeDef[];
   fields_schema: SectionDef[];
   built_in: boolean;
 }
@@ -64,6 +71,7 @@ export interface SubscriptionRef {
 export interface FactSheet {
   id: string;
   type: string;
+  subtype?: string;
   name: string;
   description?: string;
   parent_id?: string;


### PR DESCRIPTION
…section-based detail page

Backend:
- Add subtypes JSONB to FactSheetType model, subtype column to FactSheet
- Add create_mode/restrict_to_types to TagGroup model
- Change quality_seal default from UNSET to DRAFT (4 states: DRAFT/APPROVED/BROKEN/REJECTED)
- Overhaul seed data: all 12 types with subtypes, required/weight on fields, 26 relation types with attributes
- Add server-side completion score calculation from fields_schema weights
- Quality seal workflow: approve/reject/reset actions, auto-break on field changes

Frontend:
- Rewrite FactSheetDetail with section-based Accordion layout, inline editing per section
- Add completion ring, lifecycle timeline visualization, quality seal action menu
- Rewrite CreateFactSheetDialog with subtype selector, parent autocomplete, required fields
- Update QualitySealBadge to support all 4 states (DRAFT/APPROVED/BROKEN/REJECTED)
- Update InventoryPage: fix onCreate, add subtype column, seal filter toggles, completion progress bar

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF