### PR TITLE
feat: fully dynamic metamodel with CRUD, graph visualization, and Lea…

### DIFF
--- a/backend/app/api/v1/metamodel.py
+++ b/backend/app/api/v1/metamodel.py
@@ -1,42 +1,21 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.fact_sheet_type import FactSheetType
 from app.models.relation_type import RelationType
+from app.models.fact_sheet import FactSheet
+from app.models.relation import Relation
 
 router = APIRouter(prefix="/metamodel", tags=["metamodel"])
 
 
-@router.get("/types")
-async def list_types(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(FactSheetType).order_by(FactSheetType.sort_order))
-    types = result.scalars().all()
-    return [
-        {
-            "key": t.key,
-            "label": t.label,
-            "description": t.description,
-            "icon": t.icon,
-            "color": t.color,
-            "category": t.category,
-            "has_hierarchy": t.has_hierarchy,
-            "fields_schema": t.fields_schema,
-            "built_in": t.built_in,
-        }
-        for t in types
-    ]
+# ── Helpers ────────────────────────────────────────────────────────────
 
-
-@router.get("/types/{key}")
-async def get_type(key: str, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(FactSheetType).where(FactSheetType.key == key))
-    t = result.scalar_one_or_none()
-    if not t:
-        raise HTTPException(404, "Fact sheet type not found")
+def _serialize_type(t: FactSheetType) -> dict:
     return {
         "key": t.key,
         "label": t.label,
@@ -45,31 +24,83 @@ async def get_type(key: str, db: AsyncSession = Depends(get_db)):
         "color": t.color,
         "category": t.category,
         "has_hierarchy": t.has_hierarchy,
-        "fields_schema": t.fields_schema,
+        "subtypes": t.subtypes or [],
+        "fields_schema": t.fields_schema or [],
         "built_in": t.built_in,
+        "is_hidden": t.is_hidden,
+        "sort_order": t.sort_order,
     }
+
+
+def _serialize_relation_type(r: RelationType) -> dict:
+    return {
+        "key": r.key,
+        "label": r.label,
+        "reverse_label": r.reverse_label,
+        "description": r.description,
+        "source_type_key": r.source_type_key,
+        "target_type_key": r.target_type_key,
+        "cardinality": r.cardinality,
+        "attributes_schema": r.attributes_schema or [],
+        "built_in": r.built_in,
+        "is_hidden": r.is_hidden,
+        "sort_order": r.sort_order,
+    }
+
+
+# ── Fact Sheet Types ───────────────────────────────────────────────────
+
+@router.get("/types")
+async def list_types(
+    include_hidden: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(FactSheetType).order_by(FactSheetType.sort_order)
+    if not include_hidden:
+        q = q.where(FactSheetType.is_hidden == False)  # noqa: E712
+    result = await db.execute(q)
+    return [_serialize_type(t) for t in result.scalars().all()]
+
+
+@router.get("/types/{key}")
+async def get_type(key: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(FactSheetType).where(FactSheetType.key == key))
+    t = result.scalar_one_or_none()
+    if not t:
+        raise HTTPException(404, "Fact sheet type not found")
+    return _serialize_type(t)
 
 
 @router.post("/types", status_code=201)
 async def create_type(body: dict, db: AsyncSession = Depends(get_db)):
-    existing = await db.execute(select(FactSheetType).where(FactSheetType.key == body.get("key", "")))
+    existing = await db.execute(
+        select(FactSheetType).where(FactSheetType.key == body.get("key", ""))
+    )
     if existing.scalar_one_or_none():
         raise HTTPException(400, "Type key already exists")
+
+    # Determine next sort_order
+    max_order = await db.execute(select(func.max(FactSheetType.sort_order)))
+    next_order = (max_order.scalar() or 0) + 1
+
     t = FactSheetType(
         key=body["key"],
         label=body["label"],
         description=body.get("description"),
         icon=body.get("icon", "category"),
         color=body.get("color", "#1976d2"),
-        category=body.get("category", "application"),
+        category=body.get("category"),
         has_hierarchy=body.get("has_hierarchy", False),
+        subtypes=body.get("subtypes", []),
         fields_schema=body.get("fields_schema", []),
         built_in=False,
-        sort_order=99,
+        is_hidden=False,
+        sort_order=body.get("sort_order", next_order),
     )
     db.add(t)
     await db.commit()
-    return {"key": t.key, "label": t.label}
+    await db.refresh(t)
+    return _serialize_type(t)
 
 
 @router.patch("/types/{key}")
@@ -78,43 +109,182 @@ async def update_type(key: str, body: dict, db: AsyncSession = Depends(get_db)):
     t = result.scalar_one_or_none()
     if not t:
         raise HTTPException(404, "Type not found")
-    for field in ["label", "description", "icon", "color", "category", "has_hierarchy", "fields_schema"]:
+
+    updatable = [
+        "label", "description", "icon", "color", "category",
+        "has_hierarchy", "subtypes", "fields_schema", "sort_order", "is_hidden",
+    ]
+    for field in updatable:
         if field in body:
             setattr(t, field, body[field])
-    await db.commit()
-    return {"key": t.key, "label": t.label}
 
+    await db.commit()
+    await db.refresh(t)
+    return _serialize_type(t)
+
+
+@router.delete("/types/{key}")
+async def delete_type(key: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(FactSheetType).where(FactSheetType.key == key))
+    t = result.scalar_one_or_none()
+    if not t:
+        raise HTTPException(404, "Type not found")
+
+    # Check for existing fact sheets of this type
+    count_result = await db.execute(
+        select(func.count()).select_from(FactSheet).where(FactSheet.type == key)
+    )
+    instance_count = count_result.scalar() or 0
+
+    if t.built_in:
+        # Soft-delete built-in types
+        t.is_hidden = True
+        await db.commit()
+        return {"status": "hidden", "key": key, "instance_count": instance_count}
+
+    if instance_count > 0:
+        raise HTTPException(
+            400,
+            f"Cannot delete type '{key}': {instance_count} fact sheet(s) exist. "
+            "Delete them first or hide the type instead.",
+        )
+
+    # Also delete relation types that reference this type
+    await db.execute(
+        select(RelationType).where(
+            (RelationType.source_type_key == key)
+            | (RelationType.target_type_key == key)
+        )
+    )
+    rel_result = await db.execute(
+        select(RelationType).where(
+            (RelationType.source_type_key == key)
+            | (RelationType.target_type_key == key)
+        )
+    )
+    for rt in rel_result.scalars().all():
+        await db.delete(rt)
+
+    await db.delete(t)
+    await db.commit()
+    return {"status": "deleted", "key": key}
+
+
+# ── Relation Types ─────────────────────────────────────────────────────
 
 @router.get("/relation-types")
-async def list_relation_types(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(RelationType))
-    rtypes = result.scalars().all()
-    return [
-        {
-            "key": r.key,
-            "label": r.label,
-            "source_type_key": r.source_type_key,
-            "target_type_key": r.target_type_key,
-            "attributes_schema": r.attributes_schema,
-            "built_in": r.built_in,
-        }
-        for r in rtypes
-    ]
+async def list_relation_types(
+    type_key: str | None = Query(None, description="Filter relations connected to this type"),
+    include_hidden: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(RelationType).order_by(RelationType.sort_order)
+    if not include_hidden:
+        q = q.where(RelationType.is_hidden == False)  # noqa: E712
+    if type_key:
+        q = q.where(
+            (RelationType.source_type_key == type_key)
+            | (RelationType.target_type_key == type_key)
+        )
+    result = await db.execute(q)
+    return [_serialize_relation_type(r) for r in result.scalars().all()]
+
+
+@router.get("/relation-types/{key}")
+async def get_relation_type(key: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(RelationType).where(RelationType.key == key))
+    r = result.scalar_one_or_none()
+    if not r:
+        raise HTTPException(404, "Relation type not found")
+    return _serialize_relation_type(r)
 
 
 @router.post("/relation-types", status_code=201)
 async def create_relation_type(body: dict, db: AsyncSession = Depends(get_db)):
-    existing = await db.execute(select(RelationType).where(RelationType.key == body.get("key", "")))
+    existing = await db.execute(
+        select(RelationType).where(RelationType.key == body.get("key", ""))
+    )
     if existing.scalar_one_or_none():
         raise HTTPException(400, "Relation type key already exists")
+
+    # Validate source and target types exist
+    for fk in ("source_type_key", "target_type_key"):
+        type_key = body.get(fk)
+        if not type_key:
+            raise HTTPException(400, f"{fk} is required")
+        exists = await db.execute(
+            select(FactSheetType.key).where(FactSheetType.key == type_key)
+        )
+        if not exists.scalar_one_or_none():
+            raise HTTPException(400, f"Type '{type_key}' does not exist")
+
+    max_order = await db.execute(select(func.max(RelationType.sort_order)))
+    next_order = (max_order.scalar() or 0) + 1
+
     rt = RelationType(
         key=body["key"],
         label=body["label"],
+        reverse_label=body.get("reverse_label"),
+        description=body.get("description"),
         source_type_key=body["source_type_key"],
         target_type_key=body["target_type_key"],
+        cardinality=body.get("cardinality", "n:m"),
         attributes_schema=body.get("attributes_schema", []),
         built_in=False,
+        is_hidden=False,
+        sort_order=body.get("sort_order", next_order),
     )
     db.add(rt)
     await db.commit()
-    return {"key": rt.key, "label": rt.label}
+    await db.refresh(rt)
+    return _serialize_relation_type(rt)
+
+
+@router.patch("/relation-types/{key}")
+async def update_relation_type(key: str, body: dict, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(RelationType).where(RelationType.key == key))
+    r = result.scalar_one_or_none()
+    if not r:
+        raise HTTPException(404, "Relation type not found")
+
+    updatable = [
+        "label", "reverse_label", "description", "cardinality",
+        "attributes_schema", "sort_order", "is_hidden",
+    ]
+    for field in updatable:
+        if field in body:
+            setattr(r, field, body[field])
+
+    await db.commit()
+    await db.refresh(r)
+    return _serialize_relation_type(r)
+
+
+@router.delete("/relation-types/{key}")
+async def delete_relation_type(key: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(RelationType).where(RelationType.key == key))
+    r = result.scalar_one_or_none()
+    if not r:
+        raise HTTPException(404, "Relation type not found")
+
+    # Check for existing relation instances
+    count_result = await db.execute(
+        select(func.count()).select_from(Relation).where(Relation.type == key)
+    )
+    instance_count = count_result.scalar() or 0
+
+    if r.built_in:
+        r.is_hidden = True
+        await db.commit()
+        return {"status": "hidden", "key": key, "instance_count": instance_count}
+
+    if instance_count > 0:
+        raise HTTPException(
+            400,
+            f"Cannot delete relation type '{key}': {instance_count} relation(s) exist. "
+            "Delete them first or hide the type instead.",
+        )
+
+    await db.delete(r)
+    await db.commit()
+    return {"status": "deleted", "key": key}

--- a/backend/app/models/fact_sheet_type.py
+++ b/backend/app/models/fact_sheet_type.py
@@ -17,9 +17,10 @@ class FactSheetType(Base, UUIDMixin, TimestampMixin):
     description: Mapped[str | None] = mapped_column(Text)
     icon: Mapped[str] = mapped_column(String(100), default="category")
     color: Mapped[str] = mapped_column(String(20), default="#1976d2")
-    category: Mapped[str] = mapped_column(String(50), default="application")
+    category: Mapped[str | None] = mapped_column(String(100))  # free-text layer label, not enum
     has_hierarchy: Mapped[bool] = mapped_column(Boolean, default=False)
     subtypes: Mapped[list | None] = mapped_column(JSONB, default=list)  # [{key, label}]
     fields_schema: Mapped[list] = mapped_column(JSONB, default=list)
     built_in: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_hidden: Mapped[bool] = mapped_column(Boolean, default=False)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/models/relation_type.py
+++ b/backend/app/models/relation_type.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Boolean, String
+from sqlalchemy import Boolean, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,7 +14,12 @@ class RelationType(Base, UUIDMixin, TimestampMixin):
 
     key: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     label: Mapped[str] = mapped_column(String(200), nullable=False)
+    reverse_label: Mapped[str | None] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text)
     source_type_key: Mapped[str] = mapped_column(String(100), nullable=False)
     target_type_key: Mapped[str] = mapped_column(String(100), nullable=False)
+    cardinality: Mapped[str] = mapped_column(String(10), default="n:m")  # "1:1", "1:n", "n:m"
     attributes_schema: Mapped[list] = mapped_column(JSONB, default=list)
     built_in: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_hidden: Mapped[bool] = mapped_column(Boolean, default=False)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -1,4 +1,4 @@
-"""Seed default LeanIX metamodel v4 fact sheet types and relation types."""
+"""Seed the default LeanIX metamodel v4 — matched to the official Meta_Model.xml."""
 from __future__ import annotations
 
 from sqlalchemy import select
@@ -49,20 +49,20 @@ RESOURCE_CLASSIFICATION_OPTIONS = [
 DATA_SENSITIVITY_OPTIONS = [
     {"key": "public", "label": "Public", "color": "#4caf50"},
     {"key": "internal", "label": "Internal", "color": "#2196f3"},
-    {"key": "confidential", "label": "Confidential", "color": "#f57c00"},
+    {"key": "confidential", "label": "Confidential", "color": "#ff9800"},
     {"key": "restricted", "label": "Restricted", "color": "#d32f2f"},
 ]
 
 INITIATIVE_STATUS_OPTIONS = [
-    {"key": "proposed", "label": "Proposed", "color": "#9e9e9e"},
-    {"key": "approved", "label": "Approved", "color": "#2196f3"},
-    {"key": "inProgress", "label": "In Progress", "color": "#ff9800"},
-    {"key": "completed", "label": "Completed", "color": "#4caf50"},
-    {"key": "cancelled", "label": "Cancelled", "color": "#d32f2f"},
+    {"key": "onTrack", "label": "On Track", "color": "#4caf50"},
+    {"key": "atRisk", "label": "At Risk", "color": "#ff9800"},
+    {"key": "offTrack", "label": "Off Track", "color": "#d32f2f"},
+    {"key": "onHold", "label": "On Hold", "color": "#9e9e9e"},
+    {"key": "completed", "label": "Completed", "color": "#1976d2"},
 ]
 
 FREQUENCY_OPTIONS = [
-    {"key": "realtime", "label": "Real-time"},
+    {"key": "realTime", "label": "Real-Time"},
     {"key": "daily", "label": "Daily"},
     {"key": "weekly", "label": "Weekly"},
     {"key": "monthly", "label": "Monthly"},
@@ -70,342 +70,69 @@ FREQUENCY_OPTIONS = [
     {"key": "batch", "label": "Batch"},
 ]
 
-# ── Fact Sheet Types ───────────────────────────────────────────────────
+SUPPORT_TYPE_OPTIONS = [
+    {"key": "leading", "label": "Leading", "color": "#2e7d32"},
+    {"key": "supporting", "label": "Supporting", "color": "#66bb6a"},
+    {"key": "noSupport", "label": "No Support", "color": "#9e9e9e"},
+]
 
-FACT_SHEET_TYPES = [
-    # ── Business Architecture ──
-    {
-        "key": "BusinessCapability",
-        "label": "Business Capability",
-        "description": "What the business can do — stable functional decomposition (L1→L2→L3).",
-        "icon": "account_tree",
-        "color": "#4caf50",
-        "category": "business",
-        "has_hierarchy": True,
-        "sort_order": 1,
-        "subtypes": [],
-        "fields_schema": [
-            {
-                "section": "Business Capability Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    {
-        "key": "BusinessContext",
-        "label": "Business Context",
-        "description": "Activities: value streams, business products, processes, customer journeys.",
-        "icon": "domain",
-        "color": "#66bb6a",
-        "category": "business",
-        "has_hierarchy": True,
-        "sort_order": 2,
-        "subtypes": [
-            {"key": "process", "label": "Process"},
-            {"key": "valueStream", "label": "Value Stream"},
-            {"key": "customerJourney", "label": "Customer Journey"},
-            {"key": "product", "label": "Product"},
-        ],
-        "fields_schema": [
-            {
-                "section": "Business Context Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    {
-        "key": "Organization",
-        "label": "Organization",
-        "description": "Business units, regions, teams, legal entities, customers.",
-        "icon": "corporate_fare",
-        "color": "#43a047",
-        "category": "business",
-        "has_hierarchy": True,
-        "sort_order": 3,
-        "subtypes": [
-            {"key": "businessUnit", "label": "Business Unit"},
-            {"key": "region", "label": "Region"},
-            {"key": "legalEntity", "label": "Legal Entity"},
-            {"key": "team", "label": "Team"},
-            {"key": "customer", "label": "Customer"},
-        ],
-        "fields_schema": [
-            {
-                "section": "Organization Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    # ── Application Architecture ──
-    {
-        "key": "Application",
-        "label": "Application",
-        "description": "Central entity — software systems, microservices, deployments.",
-        "icon": "apps",
-        "color": "#1976d2",
-        "category": "application",
-        "has_hierarchy": True,
-        "sort_order": 4,
-        "subtypes": [
-            {"key": "businessApplication", "label": "Business Application"},
-            {"key": "microservice", "label": "Microservice"},
-            {"key": "deployment", "label": "Deployment"},
-        ],
-        "fields_schema": [
-            {
-                "section": "Application Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                    {
-                        "key": "businessCriticality",
-                        "label": "Business Criticality",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": BUSINESS_CRITICALITY_OPTIONS,
-                    },
-                    {
-                        "key": "functionalSuitability",
-                        "label": "Functional Fit",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": FUNCTIONAL_SUITABILITY_OPTIONS,
-                    },
-                    {
-                        "key": "technicalSuitability",
-                        "label": "Technical Fit",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": TECHNICAL_SUITABILITY_OPTIONS,
-                    },
-                    {
-                        "key": "hostingType",
-                        "label": "Hosting Type",
-                        "type": "single_select",
-                        "required": False,
-                        "weight": 1,
-                        "options": HOSTING_TYPE_OPTIONS,
-                    },
-                ],
-            },
-            {
-                "section": "Cost",
-                "fields": [
-                    {"key": "totalAnnualCost", "label": "Total Annual Cost", "type": "number", "weight": 1},
-                    {"key": "costCurrency", "label": "Currency", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    {
-        "key": "Interface",
-        "label": "Interface",
-        "description": "Data exchange connections between applications (APIs, data feeds).",
-        "icon": "sync_alt",
-        "color": "#1565c0",
-        "category": "application",
-        "has_hierarchy": False,
-        "sort_order": 5,
-        "subtypes": [
-            {"key": "logicalInterface", "label": "Logical Interface"},
-            {"key": "api", "label": "API"},
-        ],
-        "fields_schema": [
-            {
-                "section": "Interface Information",
-                "fields": [
-                    {
-                        "key": "frequency",
-                        "label": "Frequency",
-                        "type": "single_select",
-                        "weight": 1,
-                        "options": FREQUENCY_OPTIONS,
-                    },
-                    {
-                        "key": "dataDirection",
-                        "label": "Data Direction",
-                        "type": "single_select",
-                        "weight": 1,
-                        "options": [
-                            {"key": "unidirectional", "label": "Unidirectional"},
-                            {"key": "bidirectional", "label": "Bidirectional"},
-                        ],
-                    },
-                    {
-                        "key": "technicalSuitability",
-                        "label": "Technical Fit",
-                        "type": "single_select",
-                        "weight": 1,
-                        "options": TECHNICAL_SUITABILITY_OPTIONS,
-                    },
-                ],
-            },
-        ],
-    },
-    {
-        "key": "DataObject",
-        "label": "Data Object",
-        "description": "Business data entities (customer, order, product data).",
-        "icon": "database",
-        "color": "#0d47a1",
-        "category": "application",
-        "has_hierarchy": True,
-        "sort_order": 6,
-        "subtypes": [],
-        "fields_schema": [
-            {
-                "section": "Data Object Information",
-                "fields": [
-                    {
-                        "key": "dataSensitivity",
-                        "label": "Data Sensitivity",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": DATA_SENSITIVITY_OPTIONS,
-                    },
-                    {"key": "isPersonalData", "label": "Contains Personal Data", "type": "boolean", "weight": 1},
-                ],
-            },
-        ],
-    },
-    # ── Technology Architecture ──
-    {
-        "key": "ITComponent",
-        "label": "IT Component",
-        "description": "Technology dependencies — software, hardware, SaaS, infrastructure.",
-        "icon": "memory",
-        "color": "#7b1fa2",
-        "category": "technology",
-        "has_hierarchy": True,
-        "sort_order": 7,
-        "subtypes": [
-            {"key": "software", "label": "Software"},
-            {"key": "hardware", "label": "Hardware"},
-            {"key": "saas", "label": "SaaS"},
-            {"key": "iaas", "label": "IaaS"},
-            {"key": "paas", "label": "PaaS"},
-            {"key": "service", "label": "Service"},
-        ],
-        "fields_schema": [
-            {
-                "section": "IT Component Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                    {
-                        "key": "technicalSuitability",
-                        "label": "Technical Fit",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": TECHNICAL_SUITABILITY_OPTIONS,
-                    },
-                ],
-            },
-            {
-                "section": "Cost",
-                "fields": [
-                    {"key": "totalAnnualCost", "label": "Total Annual Cost", "type": "number", "weight": 1},
-                ],
-            },
-        ],
-    },
-    {
-        "key": "TechCategory",
-        "label": "Tech Category",
-        "description": "Taxonomy for grouping IT Components (e.g., DBMS, OS, Cloud Platform).",
-        "icon": "category",
-        "color": "#9c27b0",
-        "category": "technology",
-        "has_hierarchy": True,
-        "sort_order": 8,
-        "subtypes": [],
-        "fields_schema": [
-            {
-                "section": "Tech Category Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    {
-        "key": "Provider",
-        "label": "Provider",
-        "description": "Vendors and suppliers of technology and services.",
-        "icon": "store",
-        "color": "#6a1b9a",
-        "category": "technology",
-        "has_hierarchy": False,
-        "sort_order": 9,
-        "subtypes": [],
-        "fields_schema": [
-            {
-                "section": "Provider Information",
-                "fields": [
-                    {"key": "website", "label": "Website", "type": "text", "weight": 1},
-                    {"key": "headquarters", "label": "Headquarters", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
-    # ── Transformation Architecture ──
-    {
-        "key": "Platform",
-        "label": "Platform",
-        "description": "Strategic groupings of applications and technologies.",
-        "icon": "hub",
-        "color": "#e65100",
-        "category": "transformation",
-        "has_hierarchy": False,
-        "sort_order": 10,
-        "subtypes": [
-            {"key": "digital", "label": "Digital"},
-            {"key": "technical", "label": "Technical"},
-        ],
-        "fields_schema": [
-            {
-                "section": "Platform Information",
-                "fields": [
-                    {"key": "alias", "label": "Alias", "type": "text", "weight": 0},
-                ],
-            },
-        ],
-    },
+USAGE_TYPE_OPTIONS = [
+    {"key": "owner", "label": "Owner", "color": "#1976d2"},
+    {"key": "user", "label": "User", "color": "#66bb6a"},
+    {"key": "stakeholder", "label": "Stakeholder", "color": "#ff9800"},
+]
+
+
+# ── 13 Fact Sheet Types (from Meta_Model.xml) ─────────────────────────
+
+TYPES = [
+    # -- Strategy & Transformation layer --
     {
         "key": "Objective",
         "label": "Objective",
-        "description": "Strategic goals driving initiatives and transformation.",
+        "description": "Strategic objectives and goals that drive the enterprise architecture.",
         "icon": "flag",
-        "color": "#ef6c00",
-        "category": "transformation",
+        "color": "#c7527d",
+        "category": "Strategy & Transformation",
         "has_hierarchy": False,
-        "sort_order": 11,
         "subtypes": [],
+        "sort_order": 0,
         "fields_schema": [
             {
                 "section": "Objective Information",
                 "fields": [
-                    {
-                        "key": "category",
-                        "label": "Category",
-                        "type": "single_select",
-                        "weight": 1,
-                        "options": [
-                            {"key": "strategic", "label": "Strategic"},
-                            {"key": "tactical", "label": "Tactical"},
-                            {"key": "operational", "label": "Operational"},
-                        ],
-                    },
-                    {"key": "kpiDescription", "label": "KPI Description", "type": "text", "weight": 1},
+                    {"key": "objectiveType", "label": "Objective Type", "type": "single_select", "options": [
+                        {"key": "strategic", "label": "Strategic"},
+                        {"key": "tactical", "label": "Tactical"},
+                        {"key": "operational", "label": "Operational"},
+                    ], "weight": 1},
+                    {"key": "targetDate", "label": "Target Date", "type": "date", "weight": 1},
+                    {"key": "progress", "label": "Progress (%)", "type": "number", "weight": 1},
+                ],
+            },
+        ],
+    },
+    {
+        "key": "Platform",
+        "label": "Platform",
+        "description": "Technology or business platforms that group applications and components.",
+        "icon": "layers",
+        "color": "#027446",
+        "category": "Strategy & Transformation",
+        "has_hierarchy": False,
+        "subtypes": [
+            {"key": "digital", "label": "Digital"},
+            {"key": "technical", "label": "Technical"},
+        ],
+        "sort_order": 1,
+        "fields_schema": [
+            {
+                "section": "Platform Information",
+                "fields": [
+                    {"key": "platformType", "label": "Platform Type", "type": "single_select", "options": [
+                        {"key": "digital", "label": "Digital", "color": "#1976d2"},
+                        {"key": "technical", "label": "Technical", "color": "#607d8b"},
+                    ], "weight": 1},
                 ],
             },
         ],
@@ -413,286 +140,420 @@ FACT_SHEET_TYPES = [
     {
         "key": "Initiative",
         "label": "Initiative",
-        "description": "Transformation efforts — ideas, projects, programs, epics.",
+        "description": "Projects, programs, and epics that transform the enterprise architecture.",
         "icon": "rocket_launch",
-        "color": "#f57c00",
-        "category": "transformation",
+        "color": "#33cc58",
+        "category": "Strategy & Transformation",
         "has_hierarchy": True,
-        "sort_order": 12,
         "subtypes": [
             {"key": "idea", "label": "Idea"},
             {"key": "program", "label": "Program"},
             {"key": "project", "label": "Project"},
             {"key": "epic", "label": "Epic"},
         ],
+        "sort_order": 2,
         "fields_schema": [
             {
                 "section": "Initiative Information",
                 "fields": [
-                    {
-                        "key": "status",
-                        "label": "Status",
-                        "type": "single_select",
-                        "required": True,
-                        "weight": 2,
-                        "options": INITIATIVE_STATUS_OPTIONS,
-                    },
-                    {"key": "budget", "label": "Budget", "type": "number", "weight": 1},
+                    {"key": "initiativeStatus", "label": "Status", "type": "single_select", "options": INITIATIVE_STATUS_OPTIONS, "weight": 2},
+                    {"key": "businessValue", "label": "Business Value", "type": "single_select", "options": [
+                        {"key": "high", "label": "High", "color": "#2e7d32"},
+                        {"key": "medium", "label": "Medium", "color": "#ff9800"},
+                        {"key": "low", "label": "Low", "color": "#9e9e9e"},
+                    ], "weight": 1},
+                    {"key": "effort", "label": "Effort", "type": "single_select", "options": [
+                        {"key": "high", "label": "High", "color": "#d32f2f"},
+                        {"key": "medium", "label": "Medium", "color": "#ff9800"},
+                        {"key": "low", "label": "Low", "color": "#4caf50"},
+                    ], "weight": 1},
+                ],
+            },
+            {
+                "section": "Cost & Timeline",
+                "fields": [
+                    {"key": "costBudget", "label": "Budget", "type": "number", "weight": 1},
+                    {"key": "costActual", "label": "Actual Cost", "type": "number", "weight": 0},
                     {"key": "startDate", "label": "Start Date", "type": "date", "weight": 1},
                     {"key": "endDate", "label": "End Date", "type": "date", "weight": 1},
                 ],
             },
         ],
     },
-]
-
-# ── Relation Types ─────────────────────────────────────────────────────
-
-RELATION_TYPES = [
-    # Application as hub
+    # -- Business Architecture layer --
     {
-        "key": "relAppToBC",
-        "label": "Application → Business Capability",
-        "source_type_key": "Application",
-        "target_type_key": "BusinessCapability",
-        "attributes_schema": [
+        "key": "Organization",
+        "label": "Organization",
+        "description": "Organizational units, regions, legal entities, teams, and customers.",
+        "icon": "corporate_fare",
+        "color": "#2889ff",
+        "category": "Business Architecture",
+        "has_hierarchy": True,
+        "subtypes": [
+            {"key": "businessUnit", "label": "Business Unit"},
+            {"key": "region", "label": "Region"},
+            {"key": "legalEntity", "label": "Legal Entity"},
+            {"key": "team", "label": "Team"},
+            {"key": "customer", "label": "Customer"},
+        ],
+        "sort_order": 3,
+        "fields_schema": [
             {
-                "key": "functionalSuitability",
-                "label": "Functional Fit",
-                "type": "single_select",
-                "options": FUNCTIONAL_SUITABILITY_OPTIONS,
-            },
-            {
-                "key": "supportType",
-                "label": "Support Type",
-                "type": "single_select",
-                "options": [
-                    {"key": "leading", "label": "Leading"},
-                    {"key": "effective", "label": "Effective"},
+                "section": "Organization Information",
+                "fields": [
+                    {"key": "headCount", "label": "Head Count", "type": "number", "weight": 0},
+                    {"key": "location", "label": "Location", "type": "text", "weight": 0},
                 ],
             },
         ],
     },
     {
-        "key": "relAppToOrg",
-        "label": "Application → Organization",
-        "source_type_key": "Application",
-        "target_type_key": "Organization",
-        "attributes_schema": [
+        "key": "BusinessCapability",
+        "label": "Business Capability",
+        "description": "Stable decomposition of what the business does, independent of how it is done.",
+        "icon": "account_tree",
+        "color": "#003399",
+        "category": "Business Architecture",
+        "has_hierarchy": True,
+        "subtypes": [],
+        "sort_order": 4,
+        "fields_schema": [
             {
-                "key": "usageType",
-                "label": "Usage Type",
-                "type": "single_select",
-                "options": [{"key": "user", "label": "User"}, {"key": "owner", "label": "Owner"}],
+                "section": "Capability Information",
+                "fields": [
+                    {"key": "capabilityLevel", "label": "Capability Level", "type": "single_select", "options": [
+                        {"key": "L1", "label": "Level 1", "color": "#1565c0"},
+                        {"key": "L2", "label": "Level 2", "color": "#42a5f5"},
+                        {"key": "L3", "label": "Level 3", "color": "#90caf9"},
+                    ], "weight": 1},
+                    {"key": "isCoreCapability", "label": "Core Capability", "type": "boolean", "weight": 0},
+                ],
             },
         ],
     },
     {
-        "key": "relAppToITC",
-        "label": "Application → IT Component",
-        "source_type_key": "Application",
-        "target_type_key": "ITComponent",
-        "attributes_schema": [
+        "key": "BusinessContext",
+        "label": "Business Context",
+        "description": "Business processes, value streams, customer journeys, and products.",
+        "icon": "swap_horiz",
+        "color": "#fe6690",
+        "category": "Business Architecture",
+        "has_hierarchy": True,
+        "subtypes": [
+            {"key": "process", "label": "Process"},
+            {"key": "valueStream", "label": "Value Stream"},
+            {"key": "customerJourney", "label": "Customer Journey"},
+            {"key": "businessProduct", "label": "Business Product"},
+            {"key": "esgCapability", "label": "ESG Capability"},
+        ],
+        "sort_order": 5,
+        "fields_schema": [
             {
-                "key": "technicalSuitability",
-                "label": "Technical Fit",
-                "type": "single_select",
-                "options": TECHNICAL_SUITABILITY_OPTIONS,
+                "section": "Business Context Information",
+                "fields": [
+                    {"key": "maturity", "label": "Maturity", "type": "single_select", "options": [
+                        {"key": "initial", "label": "Initial", "color": "#d32f2f"},
+                        {"key": "defined", "label": "Defined", "color": "#ff9800"},
+                        {"key": "managed", "label": "Managed", "color": "#fbc02d"},
+                        {"key": "optimized", "label": "Optimized", "color": "#4caf50"},
+                    ], "weight": 1},
+                ],
             },
-            {"key": "costTotalAnnual", "label": "Annual Cost", "type": "number"},
         ],
     },
+    # -- Application & Data Architecture layer --
     {
-        "key": "relProviderAppToInterface",
-        "label": "Application → Interface (Provider)",
-        "source_type_key": "Application",
-        "target_type_key": "Interface",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relConsumerAppToInterface",
-        "label": "Application → Interface (Consumer)",
-        "source_type_key": "Application",
-        "target_type_key": "Interface",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relAppToDataObj",
-        "label": "Application → Data Object",
-        "source_type_key": "Application",
-        "target_type_key": "DataObject",
-        "attributes_schema": [
-            {"key": "crudFlags", "label": "CRUD", "type": "text"},
+        "key": "Application",
+        "label": "Application",
+        "description": "Software applications, microservices, and deployments in the IT landscape.",
+        "icon": "apps",
+        "color": "#0f7eb5",
+        "category": "Application & Data",
+        "has_hierarchy": True,
+        "subtypes": [
+            {"key": "businessApplication", "label": "Business Application"},
+            {"key": "microservice", "label": "Microservice"},
+            {"key": "aiAgent", "label": "AI Agent"},
+            {"key": "deployment", "label": "Deployment"},
         ],
-    },
-    {
-        "key": "relAppToProvider",
-        "label": "Application → Provider",
-        "source_type_key": "Application",
-        "target_type_key": "Provider",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relAppToPlatform",
-        "label": "Application → Platform",
-        "source_type_key": "Application",
-        "target_type_key": "Platform",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relAppToBCx",
-        "label": "Application → Business Context",
-        "source_type_key": "Application",
-        "target_type_key": "BusinessContext",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relAppToInitiative",
-        "label": "Application → Initiative",
-        "source_type_key": "Application",
-        "target_type_key": "Initiative",
-        "attributes_schema": [],
-    },
-    # Interface relations
-    {
-        "key": "relInterfaceToDataObj",
-        "label": "Interface → Data Object",
-        "source_type_key": "Interface",
-        "target_type_key": "DataObject",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relInterfaceToITC",
-        "label": "Interface → IT Component",
-        "source_type_key": "Interface",
-        "target_type_key": "ITComponent",
-        "attributes_schema": [],
-    },
-    # IT Component relations
-    {
-        "key": "relITCToTechCat",
-        "label": "IT Component → Tech Category",
-        "source_type_key": "ITComponent",
-        "target_type_key": "TechCategory",
-        "attributes_schema": [
+        "sort_order": 6,
+        "fields_schema": [
             {
-                "key": "resourceClassification",
-                "label": "Resource Classification",
-                "type": "single_select",
-                "options": RESOURCE_CLASSIFICATION_OPTIONS,
+                "section": "Application Information",
+                "fields": [
+                    {"key": "businessCriticality", "label": "Business Criticality", "type": "single_select", "required": True, "options": BUSINESS_CRITICALITY_OPTIONS, "weight": 2},
+                    {"key": "functionalSuitability", "label": "Functional Suitability", "type": "single_select", "options": FUNCTIONAL_SUITABILITY_OPTIONS, "weight": 2},
+                    {"key": "technicalSuitability", "label": "Technical Suitability", "type": "single_select", "options": TECHNICAL_SUITABILITY_OPTIONS, "weight": 2},
+                    {"key": "hostingType", "label": "Hosting Type", "type": "single_select", "options": HOSTING_TYPE_OPTIONS, "weight": 1},
+                ],
+            },
+            {
+                "section": "Cost & Ownership",
+                "fields": [
+                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "number", "weight": 1},
+                    {"key": "numberOfUsers", "label": "Number of Users", "type": "number", "weight": 0},
+                    {"key": "vendor", "label": "Vendor", "type": "text", "weight": 0},
+                    {"key": "productName", "label": "Product Name", "type": "text", "weight": 0},
+                ],
             },
         ],
     },
     {
-        "key": "relITCToProvider",
-        "label": "IT Component → Provider",
-        "source_type_key": "ITComponent",
-        "target_type_key": "Provider",
-        "attributes_schema": [],
-    },
-    # Objective relations
-    {
-        "key": "relObjToBC",
-        "label": "Objective → Business Capability",
-        "source_type_key": "Objective",
-        "target_type_key": "BusinessCapability",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relObjToInitiative",
-        "label": "Objective → Initiative",
-        "source_type_key": "Objective",
-        "target_type_key": "Initiative",
-        "attributes_schema": [],
-    },
-    # Initiative relations
-    {
-        "key": "relInitToApp",
-        "label": "Initiative → Application",
-        "source_type_key": "Initiative",
-        "target_type_key": "Application",
-        "attributes_schema": [],
+        "key": "Interface",
+        "label": "Interface",
+        "description": "Data flows and integrations between applications.",
+        "icon": "sync_alt",
+        "color": "#02afa4",
+        "category": "Application & Data",
+        "has_hierarchy": False,
+        "subtypes": [
+            {"key": "logicalInterface", "label": "Logical Interface"},
+            {"key": "api", "label": "API"},
+            {"key": "mcpServer", "label": "MCP Server"},
+        ],
+        "sort_order": 7,
+        "fields_schema": [
+            {
+                "section": "Interface Information",
+                "fields": [
+                    {"key": "frequency", "label": "Frequency", "type": "single_select", "options": FREQUENCY_OPTIONS, "weight": 1},
+                    {"key": "dataFormat", "label": "Data Format", "type": "text", "weight": 0},
+                    {"key": "protocol", "label": "Protocol", "type": "text", "weight": 0},
+                ],
+            },
+        ],
     },
     {
-        "key": "relInitToITC",
-        "label": "Initiative → IT Component",
-        "source_type_key": "Initiative",
-        "target_type_key": "ITComponent",
-        "attributes_schema": [],
+        "key": "DataObject",
+        "label": "Data Object",
+        "description": "Business data objects and their classifications.",
+        "icon": "database",
+        "color": "#774fcc",
+        "category": "Application & Data",
+        "has_hierarchy": True,
+        "subtypes": [],
+        "sort_order": 8,
+        "fields_schema": [
+            {
+                "section": "Data Information",
+                "fields": [
+                    {"key": "dataSensitivity", "label": "Data Sensitivity", "type": "single_select", "options": DATA_SENSITIVITY_OPTIONS, "weight": 1},
+                    {"key": "dataOwner", "label": "Data Owner", "type": "text", "weight": 0},
+                    {"key": "isPersonalData", "label": "Contains Personal Data", "type": "boolean", "weight": 1},
+                ],
+            },
+        ],
+    },
+    # -- Technical Architecture layer --
+    {
+        "key": "ITComponent",
+        "label": "IT Component",
+        "description": "Technology components: software, hardware, SaaS, PaaS, IaaS, services.",
+        "icon": "memory",
+        "color": "#d29270",
+        "category": "Technical Architecture",
+        "has_hierarchy": True,
+        "subtypes": [
+            {"key": "software", "label": "Software"},
+            {"key": "hardware", "label": "Hardware"},
+            {"key": "saas", "label": "SaaS"},
+            {"key": "paas", "label": "PaaS"},
+            {"key": "iaas", "label": "IaaS"},
+            {"key": "service", "label": "Service"},
+            {"key": "aiModel", "label": "AI Model"},
+        ],
+        "sort_order": 9,
+        "fields_schema": [
+            {
+                "section": "Component Information",
+                "fields": [
+                    {"key": "technicalSuitability", "label": "Technical Suitability", "type": "single_select", "options": TECHNICAL_SUITABILITY_OPTIONS, "weight": 2},
+                    {"key": "resourceClassification", "label": "Resource Classification", "type": "single_select", "options": RESOURCE_CLASSIFICATION_OPTIONS, "weight": 2},
+                    {"key": "vendor", "label": "Vendor", "type": "text", "weight": 0},
+                    {"key": "version", "label": "Version", "type": "text", "weight": 0},
+                ],
+            },
+            {
+                "section": "Cost",
+                "fields": [
+                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "number", "weight": 1},
+                    {"key": "licenseType", "label": "License Type", "type": "text", "weight": 0},
+                ],
+            },
+        ],
     },
     {
-        "key": "relInitToBC",
-        "label": "Initiative → Business Capability",
-        "source_type_key": "Initiative",
-        "target_type_key": "BusinessCapability",
-        "attributes_schema": [],
-    },
-    # Platform relations
-    {
-        "key": "relPlatformToApp",
-        "label": "Platform → Application",
-        "source_type_key": "Platform",
-        "target_type_key": "Application",
-        "attributes_schema": [],
+        "key": "TechCategory",
+        "label": "Tech Category",
+        "description": "Technology categories for classifying IT components (e.g., Databases, Middleware).",
+        "icon": "category",
+        "color": "#a6566d",
+        "category": "Technical Architecture",
+        "has_hierarchy": True,
+        "subtypes": [],
+        "sort_order": 10,
+        "fields_schema": [],
     },
     {
-        "key": "relPlatformToITC",
-        "label": "Platform → IT Component",
-        "source_type_key": "Platform",
-        "target_type_key": "ITComponent",
-        "attributes_schema": [],
+        "key": "Provider",
+        "label": "Provider",
+        "description": "External technology providers and vendors.",
+        "icon": "storefront",
+        "color": "#ffa31f",
+        "category": "Technical Architecture",
+        "has_hierarchy": False,
+        "subtypes": [],
+        "sort_order": 11,
+        "fields_schema": [
+            {
+                "section": "Provider Information",
+                "fields": [
+                    {"key": "providerType", "label": "Provider Type", "type": "single_select", "options": [
+                        {"key": "vendor", "label": "Vendor"},
+                        {"key": "partner", "label": "Partner"},
+                        {"key": "internalProvider", "label": "Internal Provider"},
+                    ], "weight": 1},
+                    {"key": "website", "label": "Website", "type": "text", "weight": 0},
+                    {"key": "contractEnd", "label": "Contract End Date", "type": "date", "weight": 0},
+                ],
+            },
+        ],
     },
     {
-        "key": "relPlatformToBC",
-        "label": "Platform → Business Capability",
-        "source_type_key": "Platform",
-        "target_type_key": "BusinessCapability",
-        "attributes_schema": [],
-    },
-    # Organization relations
-    {
-        "key": "relOrgToApp",
-        "label": "Organization → Application",
-        "source_type_key": "Organization",
-        "target_type_key": "Application",
-        "attributes_schema": [],
-    },
-    # Business Context relations
-    {
-        "key": "relBCxToBC",
-        "label": "Business Context → Business Capability",
-        "source_type_key": "BusinessContext",
-        "target_type_key": "BusinessCapability",
-        "attributes_schema": [],
-    },
-    {
-        "key": "relBCxToApp",
-        "label": "Business Context → Application",
-        "source_type_key": "BusinessContext",
-        "target_type_key": "Application",
-        "attributes_schema": [],
-    },
-    # Business Capability relations
-    {
-        "key": "relBCToOrg",
-        "label": "Business Capability → Organization",
-        "source_type_key": "BusinessCapability",
-        "target_type_key": "Organization",
-        "attributes_schema": [],
+        "key": "System",
+        "label": "System",
+        "description": "Technical systems and runtime environments.",
+        "icon": "dns",
+        "color": "#5B738B",
+        "category": "Technical Architecture",
+        "has_hierarchy": False,
+        "subtypes": [],
+        "sort_order": 12,
+        "is_hidden": False,
+        "fields_schema": [
+            {
+                "section": "System Information",
+                "fields": [
+                    {"key": "systemType", "label": "System Type", "type": "single_select", "options": [
+                        {"key": "cluster", "label": "Cluster"},
+                        {"key": "server", "label": "Server"},
+                        {"key": "virtualMachine", "label": "Virtual Machine"},
+                        {"key": "container", "label": "Container"},
+                    ], "weight": 1},
+                    {"key": "environment", "label": "Environment", "type": "single_select", "options": [
+                        {"key": "production", "label": "Production", "color": "#d32f2f"},
+                        {"key": "staging", "label": "Staging", "color": "#ff9800"},
+                        {"key": "development", "label": "Development", "color": "#4caf50"},
+                        {"key": "test", "label": "Test", "color": "#2196f3"},
+                    ], "weight": 1},
+                ],
+            },
+        ],
     },
 ]
 
 
+# ── Relations (from Meta_Model.xml — verbs are the edge labels) ────────
+
+RELATIONS = [
+    # Strategy & Transformation connections
+    {"key": "relObjectiveToBC", "label": "improves", "reverse_label": "is improved by", "source_type_key": "Objective", "target_type_key": "BusinessCapability", "cardinality": "n:m", "sort_order": 0},
+    {"key": "relPlatformToObjective", "label": "supports", "reverse_label": "is supported by", "source_type_key": "Platform", "target_type_key": "Objective", "cardinality": "n:m", "sort_order": 1},
+    {"key": "relPlatformToApp", "label": "runs", "reverse_label": "runs on", "source_type_key": "Platform", "target_type_key": "Application", "cardinality": "n:m", "sort_order": 2},
+    {"key": "relPlatformToITC", "label": "implements", "reverse_label": "is implemented by", "source_type_key": "Platform", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 3},
+    {"key": "relInitiativeToObjective", "label": "supports", "reverse_label": "is supported by", "source_type_key": "Initiative", "target_type_key": "Objective", "cardinality": "n:m", "sort_order": 4},
+    {"key": "relInitiativeToPlatform", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "Platform", "cardinality": "n:m", "sort_order": 5},
+    {"key": "relInitiativeToBC", "label": "improves", "reverse_label": "is improved by", "source_type_key": "Initiative", "target_type_key": "BusinessCapability", "cardinality": "n:m", "sort_order": 6},
+    {"key": "relInitiativeToApp", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "Application", "cardinality": "n:m", "sort_order": 7},
+    {"key": "relInitiativeToInterface", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "Interface", "cardinality": "n:m", "sort_order": 8},
+    {"key": "relInitiativeToDataObj", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "DataObject", "cardinality": "n:m", "sort_order": 9},
+    {"key": "relInitiativeToITC", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 10},
+    {"key": "relInitiativeToSystem", "label": "affects", "reverse_label": "is affected by", "source_type_key": "Initiative", "target_type_key": "System", "cardinality": "n:m", "sort_order": 11},
+
+    # Organization connections
+    {"key": "relOrgToObjective", "label": "owns", "reverse_label": "is owned by", "source_type_key": "Organization", "target_type_key": "Objective", "cardinality": "n:m", "sort_order": 12},
+    {"key": "relOrgToInitiative", "label": "owns", "reverse_label": "is owned by", "source_type_key": "Organization", "target_type_key": "Initiative", "cardinality": "n:m", "sort_order": 13},
+    {"key": "relOrgToBizCtx", "label": "owns", "reverse_label": "is owned by", "source_type_key": "Organization", "target_type_key": "BusinessContext", "cardinality": "n:m", "sort_order": 14},
+    {"key": "relOrgToApp", "label": "uses", "reverse_label": "is used by", "source_type_key": "Organization", "target_type_key": "Application", "cardinality": "n:m", "sort_order": 15, "attributes_schema": [
+        {"key": "usageType", "label": "Usage Type", "type": "single_select", "options": USAGE_TYPE_OPTIONS},
+    ]},
+    {"key": "relOrgToITC", "label": "owns", "reverse_label": "is owned by", "source_type_key": "Organization", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 16},
+
+    # Application connections
+    {"key": "relAppToBC", "label": "supports", "reverse_label": "is supported by", "source_type_key": "Application", "target_type_key": "BusinessCapability", "cardinality": "n:m", "sort_order": 17, "attributes_schema": [
+        {"key": "functionalSuitability", "label": "Functional Suitability", "type": "single_select", "options": FUNCTIONAL_SUITABILITY_OPTIONS},
+        {"key": "supportType", "label": "Support Type", "type": "single_select", "options": SUPPORT_TYPE_OPTIONS},
+    ]},
+    {"key": "relAppToBizCtx", "label": "supports", "reverse_label": "is supported by", "source_type_key": "Application", "target_type_key": "BusinessContext", "cardinality": "n:m", "sort_order": 18},
+    {"key": "relAppToInterface", "label": "provides / consumes", "reverse_label": "is provided / consumed by", "source_type_key": "Application", "target_type_key": "Interface", "cardinality": "n:m", "sort_order": 19},
+    {"key": "relAppToDataObj", "label": "CRUD", "reverse_label": "is used by", "source_type_key": "Application", "target_type_key": "DataObject", "cardinality": "n:m", "sort_order": 20, "attributes_schema": [
+        {"key": "crudCreate", "label": "Create", "type": "boolean"},
+        {"key": "crudRead", "label": "Read", "type": "boolean"},
+        {"key": "crudUpdate", "label": "Update", "type": "boolean"},
+        {"key": "crudDelete", "label": "Delete", "type": "boolean"},
+    ]},
+    {"key": "relAppToITC", "label": "uses", "reverse_label": "is used by", "source_type_key": "Application", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 21, "attributes_schema": [
+        {"key": "technicalSuitability", "label": "Technical Suitability", "type": "single_select", "options": TECHNICAL_SUITABILITY_OPTIONS},
+        {"key": "costTotalAnnual", "label": "Annual Cost", "type": "number"},
+    ]},
+    {"key": "relAppToSystem", "label": "runs on", "reverse_label": "runs", "source_type_key": "Application", "target_type_key": "System", "cardinality": "n:m", "sort_order": 22},
+
+    # IT Component connections
+    {"key": "relITCToTechCat", "label": "belongs to", "reverse_label": "includes", "source_type_key": "ITComponent", "target_type_key": "TechCategory", "cardinality": "n:m", "sort_order": 23, "attributes_schema": [
+        {"key": "resourceClassification", "label": "Resource Classification", "type": "single_select", "options": RESOURCE_CLASSIFICATION_OPTIONS},
+    ]},
+    {"key": "relITCToPlatform", "label": "implements", "reverse_label": "is implemented by", "source_type_key": "ITComponent", "target_type_key": "Platform", "cardinality": "n:m", "sort_order": 24},
+
+    # Interface connections
+    {"key": "relInterfaceToDataObj", "label": "transfers", "reverse_label": "is transferred by", "source_type_key": "Interface", "target_type_key": "DataObject", "cardinality": "n:m", "sort_order": 25},
+    {"key": "relInterfaceToITC", "label": "uses", "reverse_label": "is used by", "source_type_key": "Interface", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 26},
+
+    # Provider connections
+    {"key": "relProviderToInitiative", "label": "supports", "reverse_label": "is supported by", "source_type_key": "Provider", "target_type_key": "Initiative", "cardinality": "n:m", "sort_order": 27},
+    {"key": "relProviderToITC", "label": "offers", "reverse_label": "is offered by", "source_type_key": "Provider", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 28},
+
+    # Business Context connections
+    {"key": "relBizCtxToBC", "label": "is associated with", "reverse_label": "is associated with", "source_type_key": "BusinessContext", "target_type_key": "BusinessCapability", "cardinality": "n:m", "sort_order": 29},
+]
+
+
 async def seed_metamodel(db: AsyncSession) -> None:
-    """Insert default fact sheet types and relation types if they don't exist."""
-    result = await db.execute(select(FactSheetType).limit(1))
+    """Seed the default metamodel if no types exist yet."""
+    result = await db.execute(select(FactSheetType.id).limit(1))
     if result.scalar_one_or_none() is not None:
-        return  # already seeded
+        return  # Already seeded
 
-    for data in FACT_SHEET_TYPES:
-        db.add(FactSheetType(**data))
+    for i, t in enumerate(TYPES):
+        fst = FactSheetType(
+            key=t["key"],
+            label=t["label"],
+            description=t.get("description"),
+            icon=t.get("icon", "category"),
+            color=t.get("color", "#1976d2"),
+            category=t.get("category"),
+            has_hierarchy=t.get("has_hierarchy", False),
+            subtypes=t.get("subtypes", []),
+            fields_schema=t.get("fields_schema", []),
+            built_in=True,
+            is_hidden=t.get("is_hidden", False),
+            sort_order=t.get("sort_order", i),
+        )
+        db.add(fst)
 
-    for data in RELATION_TYPES:
-        db.add(RelationType(**data))
+    for i, r in enumerate(RELATIONS):
+        rt = RelationType(
+            key=r["key"],
+            label=r["label"],
+            reverse_label=r.get("reverse_label"),
+            description=r.get("description"),
+            source_type_key=r["source_type_key"],
+            target_type_key=r["target_type_key"],
+            cardinality=r.get("cardinality", "n:m"),
+            attributes_schema=r.get("attributes_schema", []),
+            built_in=True,
+            is_hidden=False,
+            sort_order=r.get("sort_order", i),
+        )
+        db.add(rt)
 
     await db.commit()

--- a/frontend/src/features/admin/MetamodelAdmin.tsx
+++ b/frontend/src/features/admin/MetamodelAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
@@ -21,181 +21,2008 @@ import Chip from "@mui/material/Chip";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
-import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
+import Tooltip from "@mui/material/Tooltip";
+import Alert from "@mui/material/Alert";
+import Divider from "@mui/material/Divider";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
+import type {
+  FactSheetType as FSType,
+  RelationType as RType,
+  FieldDef,
+  FieldOption,
+  SectionDef,
+} from "@/types";
 
-function FactSheetTypesTab() {
-  const { types, invalidateCache } = useMetamodel();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [newType, setNewType] = useState({ key: "", label: "", icon: "category", color: "#1976d2", category: "application", has_hierarchy: false, description: "" });
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
 
-  const handleCreate = async () => {
+const FIELD_TYPE_OPTIONS: { value: FieldDef["type"]; label: string }[] = [
+  { value: "text", label: "Text" },
+  { value: "number", label: "Number" },
+  { value: "boolean", label: "Boolean" },
+  { value: "date", label: "Date" },
+  { value: "single_select", label: "Single Select" },
+  { value: "multiple_select", label: "Multiple Select" },
+];
+
+const CATEGORIES = [
+  "Strategy & Transformation",
+  "Business Architecture",
+  "Application & Data",
+  "Technical Architecture",
+];
+
+const LAYER_ORDER = [...CATEGORIES, "Other"];
+
+const CARDINALITY_OPTIONS: ("1:1" | "1:n" | "n:m")[] = ["1:1", "1:n", "n:m"];
+
+/* ------------------------------------------------------------------ */
+/*  Graph layout constants                                             */
+/* ------------------------------------------------------------------ */
+
+const NODE_W = 160;
+const NODE_H = 56;
+const NODE_RX = 12;
+const NODE_GAP_X = 48;
+const LAYER_GAP_Y = 120;
+const PAD_X = 80;
+const PAD_Y = 60;
+const LAYER_LABEL_W = 180;
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function fieldTypeColor(type: FieldDef["type"]): string {
+  const map: Record<string, string> = {
+    text: "#1976d2",
+    number: "#ed6c02",
+    boolean: "#9c27b0",
+    date: "#2e7d32",
+    single_select: "#0288d1",
+    multiple_select: "#7b1fa2",
+  };
+  return map[type] || "#757575";
+}
+
+function emptyField(): FieldDef {
+  return { key: "", label: "", type: "text", required: false, weight: 0 };
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max - 1) + "\u2026" : text;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Field Editor Dialog                                                */
+/* ------------------------------------------------------------------ */
+
+interface FieldEditorProps {
+  open: boolean;
+  field: FieldDef;
+  onClose: () => void;
+  onSave: (field: FieldDef) => void;
+}
+
+function FieldEditorDialog({ open, field: initial, onClose, onSave }: FieldEditorProps) {
+  const [field, setField] = useState<FieldDef>(initial);
+
+  useEffect(() => {
+    if (open) setField({ ...initial });
+  }, [open, initial]);
+
+  const isSelect = field.type === "single_select" || field.type === "multiple_select";
+
+  const updateOption = (idx: number, patch: Partial<FieldOption>) => {
+    const opts = [...(field.options || [])];
+    opts[idx] = { ...opts[idx], ...patch };
+    setField({ ...field, options: opts });
+  };
+
+  const addOption = () => {
+    setField({
+      ...field,
+      options: [...(field.options || []), { key: "", label: "" }],
+    });
+  };
+
+  const removeOption = (idx: number) => {
+    const opts = [...(field.options || [])];
+    opts.splice(idx, 1);
+    setField({ ...field, options: opts });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{initial.key ? "Edit Field" : "Add Field"}</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="Key"
+          value={field.key}
+          onChange={(e) => setField({ ...field, key: e.target.value })}
+          sx={{ mt: 1, mb: 2 }}
+          disabled={!!initial.key}
+        />
+        <TextField
+          fullWidth
+          label="Label"
+          value={field.label}
+          onChange={(e) => setField({ ...field, label: e.target.value })}
+          sx={{ mb: 2 }}
+        />
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Type</InputLabel>
+          <Select
+            value={field.type}
+            label="Type"
+            onChange={(e) =>
+              setField({ ...field, type: e.target.value as FieldDef["type"] })
+            }
+          >
+            {FIELD_TYPE_OPTIONS.map((o) => (
+              <MenuItem key={o.value} value={o.value}>
+                {o.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Box sx={{ display: "flex", gap: 2, mb: 2, alignItems: "center" }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!field.required}
+                onChange={(e) =>
+                  setField({ ...field, required: e.target.checked })
+                }
+              />
+            }
+            label="Required"
+          />
+          <TextField
+            label="Weight"
+            type="number"
+            value={field.weight ?? 0}
+            onChange={(e) =>
+              setField({ ...field, weight: Number(e.target.value) })
+            }
+            sx={{ width: 120 }}
+            size="small"
+          />
+        </Box>
+        {isSelect && (
+          <>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Options
+            </Typography>
+            {(field.options || []).map((opt, idx) => (
+              <Box
+                key={idx}
+                sx={{ display: "flex", gap: 1, mb: 1, alignItems: "center" }}
+              >
+                <TextField
+                  size="small"
+                  label="Key"
+                  value={opt.key}
+                  onChange={(e) => updateOption(idx, { key: e.target.value })}
+                  sx={{ flex: 1 }}
+                />
+                <TextField
+                  size="small"
+                  label="Label"
+                  value={opt.label}
+                  onChange={(e) => updateOption(idx, { label: e.target.value })}
+                  sx={{ flex: 1 }}
+                />
+                <TextField
+                  size="small"
+                  type="color"
+                  value={opt.color || "#1976d2"}
+                  onChange={(e) => updateOption(idx, { color: e.target.value })}
+                  sx={{ width: 56, p: 0 }}
+                />
+                <IconButton size="small" onClick={() => removeOption(idx)}>
+                  <MaterialSymbol icon="close" size={18} />
+                </IconButton>
+              </Box>
+            ))}
+            <Button
+              size="small"
+              startIcon={<MaterialSymbol icon="add" size={16} />}
+              onClick={addOption}
+            >
+              Add Option
+            </Button>
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={() => onSave(field)}
+          disabled={!field.key || !field.label}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Type Detail Drawer                                                 */
+/* ------------------------------------------------------------------ */
+
+interface TypeDrawerProps {
+  open: boolean;
+  typeKey: string | null;
+  types: FSType[];
+  relationTypes: RType[];
+  onClose: () => void;
+  onRefresh: () => void;
+  onCreateRelation: (preselectedTypeKey: string) => void;
+}
+
+function TypeDetailDrawer({
+  open,
+  typeKey,
+  types,
+  relationTypes,
+  onClose,
+  onRefresh,
+  onCreateRelation,
+}: TypeDrawerProps) {
+  const fsType = types.find((t) => t.key === typeKey) || null;
+
+  /* --- Editable header state --- */
+  const [label, setLabel] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("");
+  const [color, setColor] = useState("#1976d2");
+  const [icon, setIcon] = useState("category");
+  const [hasHierarchy, setHasHierarchy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  /* --- Subtype inline add --- */
+  const [addSubOpen, setAddSubOpen] = useState(false);
+  const [newSubKey, setNewSubKey] = useState("");
+  const [newSubLabel, setNewSubLabel] = useState("");
+
+  /* --- Field editor --- */
+  const [fieldDialogOpen, setFieldDialogOpen] = useState(false);
+  const [editingSectionIdx, setEditingSectionIdx] = useState(0);
+  const [editingFieldIdx, setEditingFieldIdx] = useState<number | null>(null);
+  const [editingField, setEditingField] = useState<FieldDef>(emptyField());
+
+  /* --- Add section --- */
+  const [addSectionOpen, setAddSectionOpen] = useState(false);
+  const [newSectionName, setNewSectionName] = useState("");
+
+  /* Initialise local state from the type whenever the drawer opens or the type changes */
+  useEffect(() => {
+    if (fsType) {
+      setLabel(fsType.label);
+      setDescription(fsType.description || "");
+      setCategory(fsType.category || "");
+      setColor(fsType.color);
+      setIcon(fsType.icon);
+      setHasHierarchy(fsType.has_hierarchy);
+      setError(null);
+      setAddSubOpen(false);
+      setAddSectionOpen(false);
+    }
+  }, [fsType]);
+
+  if (!fsType) return null;
+
+  const connectedRelations = relationTypes.filter(
+    (r) => r.source_type_key === fsType.key || r.target_type_key === fsType.key,
+  );
+
+  /* --- Save header --- */
+  const handleSaveHeader = async () => {
+    setSaving(true);
+    try {
+      await api.patch(`/metamodel/types/${fsType.key}`, {
+        label,
+        description: description || undefined,
+        category,
+        color,
+        icon,
+        has_hierarchy: hasHierarchy,
+      });
+      onRefresh();
+      setError(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /* --- Subtypes --- */
+  const handleAddSubtype = async () => {
+    if (!newSubKey || !newSubLabel) return;
+    try {
+      const updated = [
+        ...(fsType.subtypes || []),
+        { key: newSubKey, label: newSubLabel },
+      ];
+      await api.patch(`/metamodel/types/${fsType.key}`, { subtypes: updated });
+      onRefresh();
+      setNewSubKey("");
+      setNewSubLabel("");
+      setAddSubOpen(false);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to add subtype");
+    }
+  };
+
+  const handleRemoveSubtype = async (subKey: string) => {
+    try {
+      const updated = (fsType.subtypes || []).filter((s) => s.key !== subKey);
+      await api.patch(`/metamodel/types/${fsType.key}`, { subtypes: updated });
+      onRefresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to remove subtype");
+    }
+  };
+
+  /* --- Fields --- */
+  const openAddField = (sectionIdx: number) => {
+    setEditingSectionIdx(sectionIdx);
+    setEditingFieldIdx(null);
+    setEditingField(emptyField());
+    setFieldDialogOpen(true);
+  };
+
+  const openEditField = (sectionIdx: number, fieldIdx: number) => {
+    setEditingSectionIdx(sectionIdx);
+    setEditingFieldIdx(fieldIdx);
+    setEditingField({ ...fsType.fields_schema[sectionIdx].fields[fieldIdx] });
+    setFieldDialogOpen(true);
+  };
+
+  const handleSaveField = async (field: FieldDef) => {
+    try {
+      const schema: SectionDef[] = fsType.fields_schema.map((s) => ({
+        ...s,
+        fields: [...s.fields],
+      }));
+      if (editingFieldIdx !== null) {
+        schema[editingSectionIdx].fields[editingFieldIdx] = field;
+      } else {
+        schema[editingSectionIdx].fields.push(field);
+      }
+      await api.patch(`/metamodel/types/${fsType.key}`, {
+        fields_schema: schema,
+      });
+      onRefresh();
+      setFieldDialogOpen(false);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to save field");
+    }
+  };
+
+  const handleDeleteField = async (sectionIdx: number, fieldIdx: number) => {
+    try {
+      const schema: SectionDef[] = fsType.fields_schema.map((s) => ({
+        ...s,
+        fields: [...s.fields],
+      }));
+      schema[sectionIdx].fields.splice(fieldIdx, 1);
+      await api.patch(`/metamodel/types/${fsType.key}`, {
+        fields_schema: schema,
+      });
+      onRefresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to delete field");
+    }
+  };
+
+  const handleAddSection = async () => {
+    if (!newSectionName) return;
+    try {
+      const schema: SectionDef[] = [
+        ...fsType.fields_schema,
+        { section: newSectionName, fields: [] },
+      ];
+      await api.patch(`/metamodel/types/${fsType.key}`, {
+        fields_schema: schema,
+      });
+      onRefresh();
+      setNewSectionName("");
+      setAddSectionOpen(false);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to add section");
+    }
+  };
+
+  /* --- Render --- */
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { width: 600 } }}
+    >
+      <Box sx={{ p: 3, height: "100%", overflow: "auto" }}>
+        {/* ---------- Header ---------- */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            mb: 2,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: "50%",
+                bgcolor: color,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <MaterialSymbol icon={icon} size={24} color="#fff" />
+            </Box>
+            <Box>
+              <Typography variant="h6" fontWeight={700} lineHeight={1.2}>
+                {label || fsType.label}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {fsType.key}
+              </Typography>
+            </Box>
+          </Box>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button
+              variant="contained"
+              size="small"
+              onClick={handleSaveHeader}
+              disabled={saving}
+            >
+              {saving ? "Saving..." : "Save"}
+            </Button>
+            <IconButton onClick={onClose}>
+              <MaterialSymbol icon="close" size={22} />
+            </IconButton>
+          </Box>
+        </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {/* ---------- Editable fields ---------- */}
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mb: 3 }}>
+          <TextField
+            size="small"
+            label="Label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+          />
+          <TextField
+            size="small"
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            multiline
+            rows={2}
+          />
+          <TextField
+            size="small"
+            label="Category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            helperText="Free text. Common values: Strategy & Transformation, Business Architecture, Application & Data, Technical Architecture"
+          />
+          <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+            <TextField
+              size="small"
+              label="Icon name"
+              value={icon}
+              onChange={(e) => setIcon(e.target.value)}
+              sx={{ flex: 1 }}
+              helperText="Material Symbols Outlined name"
+            />
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                borderRadius: 1,
+                bgcolor: "action.hover",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <MaterialSymbol icon={icon} size={24} color={color} />
+            </Box>
+          </Box>
+          <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+            <TextField
+              size="small"
+              label="Color"
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              sx={{ width: 120 }}
+            />
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                bgcolor: color,
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            />
+            <Typography variant="body2" color="text.secondary">
+              {color}
+            </Typography>
+          </Box>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={hasHierarchy}
+                onChange={(e) => setHasHierarchy(e.target.checked)}
+              />
+            }
+            label="Supports Hierarchy (Parent / Child)"
+          />
+        </Box>
+
+        <Divider sx={{ mb: 2 }} />
+
+        {/* ---------- Subtypes ---------- */}
+        <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+          Subtypes
+        </Typography>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 1 }}>
+          {(fsType.subtypes || []).map((s) => (
+            <Chip
+              key={s.key}
+              label={`${s.label} (${s.key})`}
+              onDelete={() => handleRemoveSubtype(s.key)}
+              variant="outlined"
+              size="small"
+            />
+          ))}
+          {(!fsType.subtypes || fsType.subtypes.length === 0) && (
+            <Typography variant="body2" color="text.secondary">
+              No subtypes defined
+            </Typography>
+          )}
+        </Box>
+        {addSubOpen ? (
+          <Box
+            sx={{ display: "flex", gap: 1, alignItems: "center", mt: 1, mb: 2 }}
+          >
+            <TextField
+              size="small"
+              label="Key"
+              value={newSubKey}
+              onChange={(e) => setNewSubKey(e.target.value)}
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              size="small"
+              label="Label"
+              value={newSubLabel}
+              onChange={(e) => setNewSubLabel(e.target.value)}
+              sx={{ flex: 1 }}
+            />
+            <Button
+              size="small"
+              variant="contained"
+              onClick={handleAddSubtype}
+              disabled={!newSubKey || !newSubLabel}
+            >
+              Add
+            </Button>
+            <IconButton
+              size="small"
+              onClick={() => {
+                setAddSubOpen(false);
+                setNewSubKey("");
+                setNewSubLabel("");
+              }}
+            >
+              <MaterialSymbol icon="close" size={18} />
+            </IconButton>
+          </Box>
+        ) : (
+          <Button
+            size="small"
+            startIcon={<MaterialSymbol icon="add" size={16} />}
+            onClick={() => setAddSubOpen(true)}
+            sx={{ mb: 2 }}
+          >
+            Add Subtype
+          </Button>
+        )}
+
+        <Divider sx={{ mb: 2 }} />
+
+        {/* ---------- Fields ---------- */}
+        <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+          Fields
+        </Typography>
+        {fsType.fields_schema.map((section, si) => (
+          <Accordion
+            key={si}
+            defaultExpanded
+            variant="outlined"
+            disableGutters
+            sx={{ mb: 1, "&:before": { display: "none" } }}
+          >
+            <AccordionSummary
+              expandIcon={<MaterialSymbol icon="expand_more" size={20} />}
+            >
+              <Typography fontWeight={600} sx={{ mr: 1 }}>
+                {section.section}
+              </Typography>
+              <Chip
+                size="small"
+                label={section.fields.length}
+                sx={{ height: 20, fontSize: 11 }}
+              />
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0 }}>
+              <List dense disablePadding>
+                {section.fields.map((f, fi) => (
+                  <ListItem
+                    key={f.key}
+                    secondaryAction={
+                      <Box sx={{ display: "flex", gap: 0.25 }}>
+                        <IconButton
+                          size="small"
+                          onClick={() => openEditField(si, fi)}
+                        >
+                          <MaterialSymbol icon="edit" size={18} />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={() => handleDeleteField(si, fi)}
+                        >
+                          <MaterialSymbol icon="delete" size={18} />
+                        </IconButton>
+                      </Box>
+                    }
+                  >
+                    <ListItemText
+                      primary={
+                        <Box
+                          sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                        >
+                          <Typography variant="body2" fontWeight={500}>
+                            {f.label}
+                          </Typography>
+                          <Chip
+                            size="small"
+                            label={f.type}
+                            sx={{
+                              bgcolor: fieldTypeColor(f.type),
+                              color: "#fff",
+                              height: 20,
+                              fontSize: 11,
+                            }}
+                          />
+                          {f.required && (
+                            <Chip
+                              size="small"
+                              label="Required"
+                              color="error"
+                              variant="outlined"
+                              sx={{ height: 20, fontSize: 11 }}
+                            />
+                          )}
+                        </Box>
+                      }
+                      secondary={`Weight: ${f.weight ?? 0}`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <Button
+                size="small"
+                startIcon={<MaterialSymbol icon="add" size={16} />}
+                onClick={() => openAddField(si)}
+                sx={{ mt: 0.5 }}
+              >
+                Add Field
+              </Button>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+        {fsType.fields_schema.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            No field sections yet.
+          </Typography>
+        )}
+        {addSectionOpen ? (
+          <Box
+            sx={{ display: "flex", gap: 1, alignItems: "center", mt: 1, mb: 2 }}
+          >
+            <TextField
+              size="small"
+              label="Section Name"
+              value={newSectionName}
+              onChange={(e) => setNewSectionName(e.target.value)}
+              sx={{ flex: 1 }}
+            />
+            <Button
+              size="small"
+              variant="contained"
+              onClick={handleAddSection}
+              disabled={!newSectionName}
+            >
+              Add
+            </Button>
+            <IconButton
+              size="small"
+              onClick={() => {
+                setAddSectionOpen(false);
+                setNewSectionName("");
+              }}
+            >
+              <MaterialSymbol icon="close" size={18} />
+            </IconButton>
+          </Box>
+        ) : (
+          <Button
+            size="small"
+            startIcon={<MaterialSymbol icon="add" size={16} />}
+            onClick={() => setAddSectionOpen(true)}
+            sx={{ mb: 2 }}
+          >
+            Add Section
+          </Button>
+        )}
+
+        <Divider sx={{ mb: 2 }} />
+
+        {/* ---------- Relations ---------- */}
+        <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+          Relations
+        </Typography>
+        <List dense disablePadding>
+          {connectedRelations.map((r) => {
+            const isSource = r.source_type_key === fsType.key;
+            const otherKey = isSource
+              ? r.target_type_key
+              : r.source_type_key;
+            const otherType = types.find((t) => t.key === otherKey);
+            return (
+              <ListItem key={r.key} sx={{ pl: 0 }}>
+                <ListItemText
+                  primary={
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight={500}>
+                        {isSource
+                          ? r.label
+                          : r.reverse_label || r.label}
+                      </Typography>
+                      <MaterialSymbol
+                        icon={isSource ? "arrow_forward" : "arrow_back"}
+                        size={16}
+                        color="#999"
+                      />
+                      {otherType && (
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              width: 14,
+                              height: 14,
+                              borderRadius: "50%",
+                              bgcolor: otherType.color,
+                              flexShrink: 0,
+                            }}
+                          />
+                          <MaterialSymbol
+                            icon={otherType.icon}
+                            size={16}
+                            color={otherType.color}
+                          />
+                          <Typography variant="body2">
+                            {otherType.label}
+                          </Typography>
+                        </Box>
+                      )}
+                      <Chip
+                        size="small"
+                        label={r.cardinality}
+                        variant="outlined"
+                        sx={{ height: 20, fontSize: 11 }}
+                      />
+                    </Box>
+                  }
+                />
+              </ListItem>
+            );
+          })}
+        </List>
+        {connectedRelations.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            No relations connected to this type.
+          </Typography>
+        )}
+        <Button
+          size="small"
+          startIcon={<MaterialSymbol icon="add" size={16} />}
+          onClick={() => onCreateRelation(fsType.key)}
+        >
+          Add Relation
+        </Button>
+      </Box>
+
+      {/* --- Field editor dialog (rendered inside the drawer portal) --- */}
+      <FieldEditorDialog
+        open={fieldDialogOpen}
+        field={editingField}
+        onClose={() => setFieldDialogOpen(false)}
+        onSave={handleSaveField}
+      />
+    </Drawer>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Metamodel Graph  (SVG)                                             */
+/* ------------------------------------------------------------------ */
+
+interface GraphProps {
+  types: FSType[];
+  relationTypes: RType[];
+  onNodeClick: (key: string) => void;
+}
+
+function MetamodelGraph({ types, relationTypes, onNodeClick }: GraphProps) {
+  const visibleTypes = types.filter((t) => !t.is_hidden);
+
+  /* --- Build layers --- */
+  const layers = useMemo(() => {
+    const byCategory: Record<string, FSType[]> = {};
+    for (const t of visibleTypes) {
+      const cat = CATEGORIES.includes(t.category || "")
+        ? t.category!
+        : "Other";
+      (byCategory[cat] ??= []).push(t);
+    }
+    return LAYER_ORDER.map((cat) => ({
+      category: cat,
+      nodes: byCategory[cat] || [],
+    })).filter((l) => l.nodes.length > 0);
+  }, [visibleTypes]);
+
+  /* --- Compute positions --- */
+  const layout = useMemo(() => {
+    const map: Record<string, { x: number; y: number }> = {};
+    const maxNodes = Math.max(...layers.map((l) => l.nodes.length), 1);
+    const contentW =
+      maxNodes * NODE_W + (maxNodes - 1) * NODE_GAP_X;
+    const svgW = contentW + PAD_X * 2 + LAYER_LABEL_W;
+
+    layers.forEach((layer, li) => {
+      const n = layer.nodes.length;
+      const layerW = n * NODE_W + (n - 1) * NODE_GAP_X;
+      const startX = LAYER_LABEL_W + PAD_X + (contentW - layerW) / 2;
+      const y = PAD_Y + li * (NODE_H + LAYER_GAP_Y);
+      layer.nodes.forEach((node, ni) => {
+        map[node.key] = {
+          x: startX + ni * (NODE_W + NODE_GAP_X),
+          y,
+        };
+      });
+    });
+
+    const svgH =
+      layers.length * NODE_H +
+      (layers.length - 1) * LAYER_GAP_Y +
+      PAD_Y * 2;
+
+    return { map, svgW, svgH, contentW };
+  }, [layers]);
+
+  /* --- Build edges --- */
+  const edges = useMemo(() => {
+    return relationTypes
+      .filter(
+        (r) =>
+          layout.map[r.source_type_key] && layout.map[r.target_type_key],
+      )
+      .map((r) => {
+        const src = layout.map[r.source_type_key];
+        const tgt = layout.map[r.target_type_key];
+        const srcCx = src.x + NODE_W / 2;
+        const tgtCx = tgt.x + NODE_W / 2;
+
+        let d: string;
+        let labelX: number;
+        let labelY: number;
+
+        if (src.y < tgt.y) {
+          /* Source layer is above target layer */
+          const srcBotY = src.y + NODE_H;
+          const tgtTopY = tgt.y;
+          const midY = (srcBotY + tgtTopY) / 2;
+          d = `M${srcCx},${srcBotY} C${srcCx},${midY} ${tgtCx},${midY} ${tgtCx},${tgtTopY}`;
+          labelX = (srcCx + tgtCx) / 2;
+          labelY = midY;
+        } else if (src.y > tgt.y) {
+          /* Source layer is below target layer */
+          const srcTopY = src.y;
+          const tgtBotY = tgt.y + NODE_H;
+          const midY = (srcTopY + tgtBotY) / 2;
+          d = `M${srcCx},${srcTopY} C${srcCx},${midY} ${tgtCx},${midY} ${tgtCx},${tgtBotY}`;
+          labelX = (srcCx + tgtCx) / 2;
+          labelY = midY;
+        } else {
+          /* Same layer -- arc below the nodes */
+          const botY = src.y + NODE_H;
+          const arcDrop = 50 + Math.abs(srcCx - tgtCx) * 0.15;
+          const cpY = botY + arcDrop;
+          d = `M${srcCx},${botY} C${srcCx},${cpY} ${tgtCx},${cpY} ${tgtCx},${botY}`;
+          labelX = (srcCx + tgtCx) / 2;
+          labelY = cpY - 6;
+        }
+
+        return { key: r.key, d, label: r.label, labelX, labelY };
+      });
+  }, [relationTypes, layout]);
+
+  /* --- Category label y positions --- */
+  const layerLabels = useMemo(() => {
+    return layers.map((layer, li) => ({
+      label: layer.category,
+      y: PAD_Y + li * (NODE_H + LAYER_GAP_Y),
+    }));
+  }, [layers]);
+
+  if (visibleTypes.length === 0) {
+    return (
+      <Box sx={{ p: 4, textAlign: "center" }}>
+        <Typography color="text.secondary">
+          No visible types to display. Create some fact sheet types first.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        overflow: "auto",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 2,
+        bgcolor: "#fafbfc",
+      }}
+    >
+      <svg
+        width={layout.svgW}
+        height={layout.svgH}
+        style={{ display: "block", minWidth: layout.svgW }}
+      >
+        <defs>
+          <marker
+            id="mm-arrow"
+            markerWidth="10"
+            markerHeight="7"
+            refX="10"
+            refY="3.5"
+            orient="auto"
+          >
+            <path d="M0,0 L10,3.5 L0,7 Z" fill="#b0b0b0" />
+          </marker>
+          <filter
+            id="mm-shadow"
+            x="-8%"
+            y="-8%"
+            width="120%"
+            height="140%"
+          >
+            <feDropShadow
+              dx="0"
+              dy="2"
+              stdDeviation="4"
+              floodColor="#000"
+              floodOpacity="0.12"
+            />
+          </filter>
+        </defs>
+
+        {/* ---- Layer backgrounds + labels ---- */}
+        {layerLabels.map((ll) => (
+          <g key={ll.label}>
+            <rect
+              x={LAYER_LABEL_W - 4}
+              y={ll.y - 16}
+              width={layout.svgW - LAYER_LABEL_W + 4 - PAD_X + 20}
+              height={NODE_H + 32}
+              rx={10}
+              fill="#f0f1f3"
+              stroke="#e2e4e8"
+              strokeWidth={1}
+              strokeDasharray="6 3"
+            />
+            <text
+              x={16}
+              y={ll.y + NODE_H / 2 + 5}
+              fontSize={12}
+              fontWeight={600}
+              fill="#8a8f98"
+              fontFamily="Inter, Roboto, system-ui, sans-serif"
+            >
+              {ll.label}
+            </text>
+          </g>
+        ))}
+
+        {/* ---- Edges ---- */}
+        {edges.map((e) => (
+          <g key={e.key}>
+            <path
+              d={e.d}
+              fill="none"
+              stroke="#c0c4cc"
+              strokeWidth={1.5}
+              markerEnd="url(#mm-arrow)"
+            />
+            <rect
+              x={e.labelX - 36}
+              y={e.labelY - 9}
+              width={72}
+              height={18}
+              rx={4}
+              fill="#fff"
+              fillOpacity={0.9}
+              stroke="#e0e0e0"
+              strokeWidth={0.5}
+            />
+            <text
+              x={e.labelX}
+              y={e.labelY + 4}
+              textAnchor="middle"
+              fontSize={10}
+              fill="#777"
+              fontFamily="Inter, Roboto, system-ui, sans-serif"
+            >
+              {truncate(e.label, 14)}
+            </text>
+          </g>
+        ))}
+
+        {/* ---- Nodes ---- */}
+        {visibleTypes.map((t) => {
+          const pos = layout.map[t.key];
+          if (!pos) return null;
+          return (
+            <g
+              key={t.key}
+              style={{ cursor: "pointer" }}
+              onClick={() => onNodeClick(t.key)}
+            >
+              <rect
+                x={pos.x}
+                y={pos.y}
+                width={NODE_W}
+                height={NODE_H}
+                rx={NODE_RX}
+                fill={t.color}
+                filter="url(#mm-shadow)"
+              />
+              {/* Icon via Material Symbols font */}
+              <text
+                x={pos.x + 14}
+                y={pos.y + NODE_H / 2 + 7}
+                fontFamily="Material Symbols Outlined"
+                fontSize={22}
+                fill="rgba(255,255,255,0.92)"
+              >
+                {t.icon}
+              </text>
+              {/* Label */}
+              <text
+                x={pos.x + 42}
+                y={pos.y + NODE_H / 2 + 5}
+                fontSize={12}
+                fontWeight={600}
+                fill="#fff"
+                fontFamily="Inter, Roboto, system-ui, sans-serif"
+              >
+                {truncate(t.label, 14)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </Box>
+  );
+}
+
+/* ================================================================== */
+/*  Main Component                                                     */
+/* ================================================================== */
+
+export default function MetamodelAdmin() {
+  const { invalidateCache } = useMetamodel();
+
+  const [tab, setTab] = useState(0);
+  const [types, setTypes] = useState<FSType[]>([]);
+  const [relationTypes, setRelationTypes] = useState<RType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showHidden, setShowHidden] = useState(false);
+
+  /* --- Drawer state --- */
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedTypeKey, setSelectedTypeKey] = useState<string | null>(null);
+
+  /* --- Create type dialog --- */
+  const [createTypeOpen, setCreateTypeOpen] = useState(false);
+  const [newType, setNewType] = useState({
+    key: "",
+    label: "",
+    icon: "category",
+    color: "#1976d2",
+    category: "Application & Data",
+    has_hierarchy: false,
+    description: "",
+  });
+
+  /* --- Create relation dialog --- */
+  const [createRelOpen, setCreateRelOpen] = useState(false);
+  const [newRel, setNewRel] = useState({
+    key: "",
+    label: "",
+    reverse_label: "",
+    source_type_key: "",
+    target_type_key: "",
+    cardinality: "1:n" as "1:1" | "1:n" | "n:m",
+  });
+
+  /* --- Edit relation dialog --- */
+  const [editRelOpen, setEditRelOpen] = useState(false);
+  const [editRel, setEditRel] = useState<RType | null>(null);
+
+  /* ---- Data fetching ---- */
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [t, r] = await Promise.all([
+        api.get<FSType[]>("/metamodel/types?include_hidden=true"),
+        api.get<RType[]>("/metamodel/relation-types"),
+      ]);
+      setTypes(t);
+      setRelationTypes(r);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(() => {
+    invalidateCache();
+    fetchData();
+  }, [invalidateCache, fetchData]);
+
+  /* ---- Derived ---- */
+  const displayTypes = showHidden
+    ? types
+    : types.filter((t) => !t.is_hidden);
+
+  const autoRelKey =
+    newRel.source_type_key && newRel.target_type_key
+      ? `${newRel.source_type_key}_to_${newRel.target_type_key}`
+      : "";
+
+  /* ---- Handlers ---- */
+  const handleCreateType = async () => {
     await api.post("/metamodel/types", {
       ...newType,
       fields_schema: [],
       built_in: false,
     });
-    invalidateCache();
-    setCreateOpen(false);
-    window.location.reload();
+    refresh();
+    setCreateTypeOpen(false);
+    setNewType({
+      key: "",
+      label: "",
+      icon: "category",
+      color: "#1976d2",
+      category: "Application & Data",
+      has_hierarchy: false,
+      description: "",
+    });
   };
 
-  return (
-    <Box>
-      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
-        <Button variant="contained" startIcon={<MaterialSymbol icon="add" size={18} />} onClick={() => setCreateOpen(true)}>
-          New Fact Sheet Type
-        </Button>
-      </Box>
-
-      {types.map((t) => (
-        <Accordion key={t.key}>
-          <AccordionSummary expandIcon={<MaterialSymbol icon="expand_more" size={20} />}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-              <MaterialSymbol icon={t.icon} size={20} color={t.color} />
-              <Typography fontWeight={600}>{t.label}</Typography>
-              <Chip size="small" label={t.category} />
-              {t.has_hierarchy && <Chip size="small" label="Hierarchy" variant="outlined" />}
-              {t.built_in && <Chip size="small" label="Built-in" color="info" />}
-            </Box>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              Key: <code>{t.key}</code> | {t.description || "No description"}
-            </Typography>
-            <Divider sx={{ my: 1 }} />
-            <Typography variant="subtitle2" gutterBottom>Fields</Typography>
-            {t.fields_schema.map((section, si) => (
-              <Box key={si} sx={{ ml: 2, mb: 1 }}>
-                <Typography variant="body2" fontWeight={600}>{section.section}</Typography>
-                <List dense>
-                  {section.fields.map((f) => (
-                    <ListItem key={f.key} sx={{ py: 0 }}>
-                      <ListItemText
-                        primary={`${f.label} (${f.key})`}
-                        secondary={`Type: ${f.type}${f.options ? ` | Options: ${f.options.map((o) => o.label).join(", ")}` : ""}`}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              </Box>
-            ))}
-            {t.fields_schema.length === 0 && (
-              <Typography variant="body2" color="text.secondary">No custom fields</Typography>
-            )}
-          </AccordionDetails>
-        </Accordion>
-      ))}
-
-      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>Create Fact Sheet Type</DialogTitle>
-        <DialogContent>
-          <TextField fullWidth label="Key (e.g., MyCustomType)" value={newType.key} onChange={(e) => setNewType({ ...newType, key: e.target.value })} sx={{ mt: 1, mb: 2 }} />
-          <TextField fullWidth label="Label" value={newType.label} onChange={(e) => setNewType({ ...newType, label: e.target.value })} sx={{ mb: 2 }} />
-          <TextField fullWidth label="Description" value={newType.description} onChange={(e) => setNewType({ ...newType, description: e.target.value })} sx={{ mb: 2 }} />
-          <TextField fullWidth label="Icon (Material Symbol)" value={newType.icon} onChange={(e) => setNewType({ ...newType, icon: e.target.value })} sx={{ mb: 2 }} />
-          <TextField fullWidth label="Color" type="color" value={newType.color} onChange={(e) => setNewType({ ...newType, color: e.target.value })} sx={{ mb: 2 }} />
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <InputLabel>Category</InputLabel>
-            <Select value={newType.category} label="Category" onChange={(e) => setNewType({ ...newType, category: e.target.value })}>
-              <MenuItem value="business">Business</MenuItem>
-              <MenuItem value="application">Application</MenuItem>
-              <MenuItem value="technology">Technology</MenuItem>
-              <MenuItem value="transformation">Transformation</MenuItem>
-            </Select>
-          </FormControl>
-          <FormControlLabel control={<Switch checked={newType.has_hierarchy} onChange={(e) => setNewType({ ...newType, has_hierarchy: e.target.checked })} />} label="Supports Hierarchy (Parent/Child)" />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleCreate} disabled={!newType.key || !newType.label}>Create</Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
-  );
-}
-
-function RelationTypesTab() {
-  const { types, relationTypes, invalidateCache } = useMetamodel();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [newRel, setNewRel] = useState({ key: "", label: "", source_type_key: "", target_type_key: "" });
-
-  const handleCreate = async () => {
-    await api.post("/metamodel/relation-types", { ...newRel, attributes_schema: [], built_in: false });
-    invalidateCache();
-    setCreateOpen(false);
-    window.location.reload();
+  const handleCreateRelation = async () => {
+    const finalKey = newRel.key || autoRelKey;
+    await api.post("/metamodel/relation-types", {
+      ...newRel,
+      key: finalKey,
+      attributes_schema: [],
+      built_in: false,
+    });
+    refresh();
+    setCreateRelOpen(false);
+    setNewRel({
+      key: "",
+      label: "",
+      reverse_label: "",
+      source_type_key: "",
+      target_type_key: "",
+      cardinality: "1:n",
+    });
   };
 
-  return (
-    <Box>
-      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
-        <Button variant="contained" startIcon={<MaterialSymbol icon="add" size={18} />} onClick={() => setCreateOpen(true)}>
-          New Relation Type
-        </Button>
-      </Box>
+  const handleUpdateRelation = async () => {
+    if (!editRel) return;
+    await api.patch(`/metamodel/relation-types/${editRel.key}`, {
+      label: editRel.label,
+      reverse_label: editRel.reverse_label,
+      cardinality: editRel.cardinality,
+    });
+    refresh();
+    setEditRelOpen(false);
+    setEditRel(null);
+  };
 
-      {relationTypes.map((rt) => (
-        <Card key={rt.key} sx={{ mb: 1 }}>
-          <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Typography fontWeight={600}>{rt.label}</Typography>
-              <Typography variant="body2" color="text.secondary">({rt.key})</Typography>
-              <Box sx={{ flex: 1 }} />
-              <Chip size="small" label={rt.source_type_key} />
-              <MaterialSymbol icon="arrow_forward" size={16} />
-              <Chip size="small" label={rt.target_type_key} />
-              {rt.built_in && <Chip size="small" label="Built-in" color="info" />}
-            </Box>
-          </CardContent>
-        </Card>
-      ))}
+  const handleDeleteRelation = async (key: string) => {
+    await api.delete(`/metamodel/relation-types/${key}`);
+    refresh();
+  };
 
-      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>Create Relation Type</DialogTitle>
-        <DialogContent>
-          <TextField fullWidth label="Key" value={newRel.key} onChange={(e) => setNewRel({ ...newRel, key: e.target.value })} sx={{ mt: 1, mb: 2 }} />
-          <TextField fullWidth label="Label" value={newRel.label} onChange={(e) => setNewRel({ ...newRel, label: e.target.value })} sx={{ mb: 2 }} />
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <InputLabel>Source Type</InputLabel>
-            <Select value={newRel.source_type_key} label="Source Type" onChange={(e) => setNewRel({ ...newRel, source_type_key: e.target.value })}>
-              {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
-            </Select>
-          </FormControl>
-          <FormControl fullWidth>
-            <InputLabel>Target Type</InputLabel>
-            <Select value={newRel.target_type_key} label="Target Type" onChange={(e) => setNewRel({ ...newRel, target_type_key: e.target.value })}>
-              {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
-            </Select>
-          </FormControl>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleCreate} disabled={!newRel.key || !newRel.source_type_key || !newRel.target_type_key}>Create</Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
-  );
-}
+  const openCreateRelation = (preselectedTypeKey?: string) => {
+    setNewRel({
+      key: "",
+      label: "",
+      reverse_label: "",
+      source_type_key: preselectedTypeKey || "",
+      target_type_key: "",
+      cardinality: "1:n",
+    });
+    setCreateRelOpen(true);
+  };
 
-export default function MetamodelAdmin() {
-  const [tab, setTab] = useState(0);
+  const handleNodeClick = (key: string) => {
+    setSelectedTypeKey(key);
+    setDrawerOpen(true);
+  };
+
+  const resolveType = (key: string) => types.find((t) => t.key === key);
+
+  /* ================================================================ */
+  /*  Render                                                           */
+  /* ================================================================ */
 
   return (
     <Box>
-      <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>Metamodel Configuration</Typography>
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+      <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
+        Metamodel Configuration
+      </Typography>
+
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3 }}>
         <Tab label="Fact Sheet Types" />
         <Tab label="Relation Types" />
+        <Tab label="Metamodel Graph" />
       </Tabs>
 
-      {tab === 0 && <FactSheetTypesTab />}
-      {tab === 1 && <RelationTypesTab />}
+      {/* ============================================================ */}
+      {/*  TAB 0 -- Fact Sheet Types                                   */}
+      {/* ============================================================ */}
+      {tab === 0 && (
+        <Box>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              mb: 2,
+            }}
+          >
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showHidden}
+                  onChange={(e) => setShowHidden(e.target.checked)}
+                />
+              }
+              label="Show hidden types"
+            />
+            <Button
+              variant="contained"
+              startIcon={<MaterialSymbol icon="add" size={18} />}
+              onClick={() => setCreateTypeOpen(true)}
+            >
+              New Type
+            </Button>
+          </Box>
+
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, 1fr)",
+              gap: 2,
+            }}
+          >
+            {displayTypes.map((t) => {
+              const fieldCount = t.fields_schema.reduce(
+                (sum, s) => sum + s.fields.length,
+                0,
+              );
+              const subtypeCount = (t.subtypes || []).length;
+              const relCount = relationTypes.filter(
+                (r) =>
+                  r.source_type_key === t.key ||
+                  r.target_type_key === t.key,
+              ).length;
+
+              return (
+                <Card
+                  key={t.key}
+                  sx={{
+                    cursor: "pointer",
+                    transition: "box-shadow 0.2s, transform 0.15s",
+                    "&:hover": { boxShadow: 6, transform: "translateY(-2px)" },
+                    opacity: t.is_hidden ? 0.55 : 1,
+                  }}
+                  onClick={() => {
+                    setSelectedTypeKey(t.key);
+                    setDrawerOpen(true);
+                  }}
+                >
+                  <CardContent>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                        mb: 1,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          width: 40,
+                          height: 40,
+                          borderRadius: "50%",
+                          bgcolor: t.color,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          flexShrink: 0,
+                        }}
+                      >
+                        <MaterialSymbol
+                          icon={t.icon}
+                          size={22}
+                          color="#fff"
+                        />
+                      </Box>
+                      <Box sx={{ minWidth: 0 }}>
+                        <Typography fontWeight={600} noWrap>
+                          {t.label}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                        >
+                          {t.category || "Uncategorized"}
+                        </Typography>
+                      </Box>
+                    </Box>
+
+                    <Box
+                      sx={{
+                        display: "flex",
+                        gap: 0.5,
+                        flexWrap: "wrap",
+                        mb: 1,
+                      }}
+                    >
+                      {t.has_hierarchy && (
+                        <Chip
+                          size="small"
+                          label="Hierarchy"
+                          variant="outlined"
+                          sx={{ height: 22, fontSize: 11 }}
+                        />
+                      )}
+                      {t.built_in && (
+                        <Chip
+                          size="small"
+                          label="Built-in"
+                          color="info"
+                          sx={{ height: 22, fontSize: 11 }}
+                        />
+                      )}
+                      {t.is_hidden && (
+                        <Chip
+                          size="small"
+                          label="Hidden"
+                          sx={{ height: 22, fontSize: 11 }}
+                        />
+                      )}
+                    </Box>
+
+                    <Box sx={{ display: "flex", gap: 2 }}>
+                      <Typography variant="caption" color="text.secondary">
+                        {fieldCount} field{fieldCount !== 1 ? "s" : ""}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {subtypeCount} subtype{subtypeCount !== 1 ? "s" : ""}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {relCount} relation{relCount !== 1 ? "s" : ""}
+                      </Typography>
+                    </Box>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </Box>
+
+          {displayTypes.length === 0 && !loading && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 2, textAlign: "center" }}
+            >
+              No fact sheet types found.
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {/* ============================================================ */}
+      {/*  TAB 1 -- Relation Types                                     */}
+      {/* ============================================================ */}
+      {tab === 1 && (
+        <Box>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+            <Button
+              variant="contained"
+              startIcon={<MaterialSymbol icon="add" size={18} />}
+              onClick={() => openCreateRelation()}
+            >
+              New Relation
+            </Button>
+          </Box>
+
+          {relationTypes.map((rt) => {
+            const srcType = resolveType(rt.source_type_key);
+            const tgtType = resolveType(rt.target_type_key);
+            return (
+              <Card key={rt.key} sx={{ mb: 1 }}>
+                <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1.5,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {/* Source type */}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                      }}
+                    >
+                      {srcType && (
+                        <>
+                          <Box
+                            sx={{
+                              width: 12,
+                              height: 12,
+                              borderRadius: "50%",
+                              bgcolor: srcType.color,
+                              flexShrink: 0,
+                            }}
+                          />
+                          <MaterialSymbol
+                            icon={srcType.icon}
+                            size={16}
+                            color={srcType.color}
+                          />
+                        </>
+                      )}
+                      <Typography variant="body2" fontWeight={500}>
+                        {srcType?.label || rt.source_type_key}
+                      </Typography>
+                    </Box>
+
+                    <MaterialSymbol
+                      icon="arrow_forward"
+                      size={16}
+                      color="#bbb"
+                    />
+
+                    {/* Verb */}
+                    <Typography
+                      variant="body2"
+                      fontWeight={600}
+                      color="primary.main"
+                    >
+                      {rt.label}
+                    </Typography>
+
+                    <MaterialSymbol
+                      icon="arrow_forward"
+                      size={16}
+                      color="#bbb"
+                    />
+
+                    {/* Target type */}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                      }}
+                    >
+                      {tgtType && (
+                        <>
+                          <Box
+                            sx={{
+                              width: 12,
+                              height: 12,
+                              borderRadius: "50%",
+                              bgcolor: tgtType.color,
+                              flexShrink: 0,
+                            }}
+                          />
+                          <MaterialSymbol
+                            icon={tgtType.icon}
+                            size={16}
+                            color={tgtType.color}
+                          />
+                        </>
+                      )}
+                      <Typography variant="body2" fontWeight={500}>
+                        {tgtType?.label || rt.target_type_key}
+                      </Typography>
+                    </Box>
+
+                    <Box sx={{ flex: 1 }} />
+
+                    <Chip
+                      size="small"
+                      label={rt.cardinality}
+                      variant="outlined"
+                      sx={{ height: 22, fontSize: 11 }}
+                    />
+                    {rt.built_in && (
+                      <Chip
+                        size="small"
+                        label="Built-in"
+                        color="info"
+                        sx={{ height: 22, fontSize: 11 }}
+                      />
+                    )}
+
+                    <Tooltip title="Edit">
+                      <IconButton
+                        size="small"
+                        onClick={() => {
+                          setEditRel({ ...rt });
+                          setEditRelOpen(true);
+                        }}
+                      >
+                        <MaterialSymbol icon="edit" size={18} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="small"
+                        onClick={() => handleDeleteRelation(rt.key)}
+                      >
+                        <MaterialSymbol icon="delete" size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          {relationTypes.length === 0 && !loading && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ textAlign: "center", mt: 2 }}
+            >
+              No relation types defined yet.
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {/* ============================================================ */}
+      {/*  TAB 2 -- Metamodel Graph                                    */}
+      {/* ============================================================ */}
+      {tab === 2 && (
+        <MetamodelGraph
+          types={types}
+          relationTypes={relationTypes}
+          onNodeClick={handleNodeClick}
+        />
+      )}
+
+      {/* ============================================================ */}
+      {/*  Type Detail Drawer                                          */}
+      {/* ============================================================ */}
+      <TypeDetailDrawer
+        open={drawerOpen}
+        typeKey={selectedTypeKey}
+        types={types}
+        relationTypes={relationTypes}
+        onClose={() => setDrawerOpen(false)}
+        onRefresh={refresh}
+        onCreateRelation={(preKey) => openCreateRelation(preKey)}
+      />
+
+      {/* ============================================================ */}
+      {/*  Create Type Dialog                                          */}
+      {/* ============================================================ */}
+      <Dialog
+        open={createTypeOpen}
+        onClose={() => setCreateTypeOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Create Fact Sheet Type</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="Key (e.g., MyCustomType)"
+            value={newType.key}
+            onChange={(e) => setNewType({ ...newType, key: e.target.value })}
+            sx={{ mt: 1, mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            label="Label"
+            value={newType.label}
+            onChange={(e) => setNewType({ ...newType, label: e.target.value })}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            label="Description"
+            value={newType.description}
+            onChange={(e) =>
+              setNewType({ ...newType, description: e.target.value })
+            }
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            label="Icon (Material Symbol name)"
+            value={newType.icon}
+            onChange={(e) => setNewType({ ...newType, icon: e.target.value })}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            label="Color"
+            type="color"
+            value={newType.color}
+            onChange={(e) => setNewType({ ...newType, color: e.target.value })}
+            sx={{ mb: 2 }}
+          />
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel>Category</InputLabel>
+            <Select
+              value={newType.category}
+              label="Category"
+              onChange={(e) =>
+                setNewType({ ...newType, category: e.target.value })
+              }
+            >
+              {CATEGORIES.map((c) => (
+                <MenuItem key={c} value={c}>
+                  {c}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={newType.has_hierarchy}
+                onChange={(e) =>
+                  setNewType({ ...newType, has_hierarchy: e.target.checked })
+                }
+              />
+            }
+            label="Supports Hierarchy (Parent / Child)"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateTypeOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreateType}
+            disabled={!newType.key || !newType.label}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ============================================================ */}
+      {/*  Create Relation Dialog                                      */}
+      {/* ============================================================ */}
+      <Dialog
+        open={createRelOpen}
+        onClose={() => setCreateRelOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Create Relation Type</DialogTitle>
+        <DialogContent>
+          <FormControl fullWidth sx={{ mt: 1, mb: 2 }}>
+            <InputLabel>Source Type</InputLabel>
+            <Select
+              value={newRel.source_type_key}
+              label="Source Type"
+              onChange={(e) => {
+                const src = e.target.value;
+                setNewRel({
+                  ...newRel,
+                  source_type_key: src,
+                  key:
+                    src && newRel.target_type_key
+                      ? `${src}_to_${newRel.target_type_key}`
+                      : newRel.key,
+                });
+              }}
+            >
+              {types.map((t) => (
+                <MenuItem key={t.key} value={t.key}>
+                  <Box
+                    sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                  >
+                    <Box
+                      sx={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: "50%",
+                        bgcolor: t.color,
+                      }}
+                    />
+                    <MaterialSymbol icon={t.icon} size={16} color={t.color} />
+                    {t.label}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel>Target Type</InputLabel>
+            <Select
+              value={newRel.target_type_key}
+              label="Target Type"
+              onChange={(e) => {
+                const tgt = e.target.value;
+                setNewRel({
+                  ...newRel,
+                  target_type_key: tgt,
+                  key:
+                    newRel.source_type_key && tgt
+                      ? `${newRel.source_type_key}_to_${tgt}`
+                      : newRel.key,
+                });
+              }}
+            >
+              {types.map((t) => (
+                <MenuItem key={t.key} value={t.key}>
+                  <Box
+                    sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                  >
+                    <Box
+                      sx={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: "50%",
+                        bgcolor: t.color,
+                      }}
+                    />
+                    <MaterialSymbol icon={t.icon} size={16} color={t.color} />
+                    {t.label}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <TextField
+            fullWidth
+            label="Key"
+            value={newRel.key || autoRelKey}
+            onChange={(e) => setNewRel({ ...newRel, key: e.target.value })}
+            sx={{ mb: 2 }}
+            helperText="Auto-generated from source + target"
+          />
+          <TextField
+            fullWidth
+            label='Label (verb, e.g., "uses")'
+            value={newRel.label}
+            onChange={(e) => setNewRel({ ...newRel, label: e.target.value })}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            label='Reverse Label (e.g., "is used by")'
+            value={newRel.reverse_label}
+            onChange={(e) =>
+              setNewRel({ ...newRel, reverse_label: e.target.value })
+            }
+            sx={{ mb: 2 }}
+          />
+          <FormControl fullWidth>
+            <InputLabel>Cardinality</InputLabel>
+            <Select
+              value={newRel.cardinality}
+              label="Cardinality"
+              onChange={(e) =>
+                setNewRel({
+                  ...newRel,
+                  cardinality: e.target.value as "1:1" | "1:n" | "n:m",
+                })
+              }
+            >
+              {CARDINALITY_OPTIONS.map((c) => (
+                <MenuItem key={c} value={c}>
+                  {c}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateRelOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreateRelation}
+            disabled={
+              !newRel.source_type_key ||
+              !newRel.target_type_key ||
+              !(newRel.key || autoRelKey) ||
+              !newRel.label
+            }
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ============================================================ */}
+      {/*  Edit Relation Dialog                                        */}
+      {/* ============================================================ */}
+      <Dialog
+        open={editRelOpen}
+        onClose={() => setEditRelOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Edit Relation Type</DialogTitle>
+        {editRel && (
+          <>
+            <DialogContent>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  mb: 2,
+                  mt: 1,
+                }}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  {resolveType(editRel.source_type_key)?.label ||
+                    editRel.source_type_key}
+                </Typography>
+                <MaterialSymbol
+                  icon="arrow_forward"
+                  size={16}
+                  color="#bbb"
+                />
+                <Typography variant="body2" color="text.secondary">
+                  {resolveType(editRel.target_type_key)?.label ||
+                    editRel.target_type_key}
+                </Typography>
+              </Box>
+              <TextField
+                fullWidth
+                label="Label"
+                value={editRel.label}
+                onChange={(e) =>
+                  setEditRel({ ...editRel, label: e.target.value })
+                }
+                sx={{ mb: 2 }}
+              />
+              <TextField
+                fullWidth
+                label="Reverse Label"
+                value={editRel.reverse_label || ""}
+                onChange={(e) =>
+                  setEditRel({
+                    ...editRel,
+                    reverse_label: e.target.value,
+                  })
+                }
+                sx={{ mb: 2 }}
+              />
+              <FormControl fullWidth>
+                <InputLabel>Cardinality</InputLabel>
+                <Select
+                  value={editRel.cardinality}
+                  label="Cardinality"
+                  onChange={(e) =>
+                    setEditRel({
+                      ...editRel,
+                      cardinality: e.target.value as "1:1" | "1:n" | "n:m",
+                    })
+                  }
+                >
+                  {CARDINALITY_OPTIONS.map((c) => (
+                    <MenuItem key={c} value={c}>
+                      {c}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setEditRelOpen(false)}>Cancel</Button>
+              <Button variant="contained" onClick={handleUpdateRelation}>
+                Save
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
     </Box>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,7 +15,7 @@ export interface FieldOption {
 export interface FieldDef {
   key: string;
   label: string;
-  type: "text" | "number" | "boolean" | "date" | "single_select";
+  type: "text" | "number" | "boolean" | "date" | "single_select" | "multiple_select";
   options?: FieldOption[];
   required?: boolean;
   weight?: number;
@@ -37,20 +37,27 @@ export interface FactSheetType {
   description?: string;
   icon: string;
   color: string;
-  category: string;
+  category?: string;
   has_hierarchy: boolean;
   subtypes?: SubtypeDef[];
   fields_schema: SectionDef[];
   built_in: boolean;
+  is_hidden: boolean;
+  sort_order: number;
 }
 
 export interface RelationType {
   key: string;
   label: string;
+  reverse_label?: string;
+  description?: string;
   source_type_key: string;
   target_type_key: string;
+  cardinality: "1:1" | "1:n" | "n:m";
   attributes_schema: FieldDef[];
   built_in: boolean;
+  is_hidden: boolean;
+  sort_order: number;
 }
 
 export interface TagRef {


### PR DESCRIPTION
…nIX XML parity

- Backend: full CRUD API for fact sheet types and relation types with soft-delete for built-in types, instance count validation, and cascade cleanup
- Models: add cardinality, reverse_label, is_hidden, sort_order to RelationType; make category optional free-text on FactSheetType
- Seed: 13 fact sheet types from LeanIX Meta_Model.xml with exact colors, 30 relations with directional verb labels and cardinality
- Frontend MetamodelAdmin: 3-tab layout (type cards, relation list, SVG graph), type detail drawer with inline field/subtype/relation editing, field editor dialog with options management, create/edit/delete dialogs
- FactSheetDetail: relations section shows directional verb labels and cardinality
- Types: add multiple_select field type, is_hidden/sort_order on both type interfaces

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF