### PR TITLE
feat: user CRUD, subscription roles, TIME assessment, relation CRUD, …

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.config import settings
+from app.models import Base  # noqa: F401 – ensures all models are registered
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = settings.database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection):
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in 'online' mode with async engine."""
+    connectable = create_async_engine(settings.database_url, poolclass=pool.NullPool)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/001_baseline.py
+++ b/backend/alembic/versions/001_baseline.py
@@ -1,0 +1,30 @@
+"""baseline – stamp existing schema
+
+Revision ID: 001
+Revises: None
+Create Date: 2026-02-11
+
+This is a baseline migration representing the schema already created by
+create_all.  When running against an existing database, stamp this revision
+without executing:  alembic stamp 001
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Baseline: tables already exist via create_all.
+    # This migration is intentionally empty – stamp it on existing DBs.
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/002_expand_subscription_role.py
+++ b/backend/alembic/versions/002_expand_subscription_role.py
@@ -1,0 +1,38 @@
+"""expand subscription role column to 50 chars
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-02-11
+
+Subscription role was VARCHAR(20) which is too short for roles like
+'technical_application_owner' and 'business_application_owner'.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "subscriptions",
+        "role",
+        existing_type=sa.String(20),
+        type_=sa.String(50),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "subscriptions",
+        "role",
+        existing_type=sa.String(50),
+        type_=sa.String(20),
+        existing_nullable=False,
+    )

--- a/backend/app/api/v1/subscriptions.py
+++ b/backend/app/api/v1/subscriptions.py
@@ -8,11 +8,41 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.database import get_db
+from app.models.fact_sheet import FactSheet
 from app.models.subscription import Subscription
 from app.models.user import User
 from app.schemas.common import SubscriptionCreate
 
 router = APIRouter(tags=["subscriptions"])
+
+# Roles available for all fact sheet types
+UNIVERSAL_ROLES = {"responsible", "observer"}
+# Roles restricted to specific fact sheet types
+TYPE_SPECIFIC_ROLES = {
+    "technical_application_owner": {"Application"},
+    "business_application_owner": {"Application"},
+}
+ALL_ROLES = UNIVERSAL_ROLES | TYPE_SPECIFIC_ROLES.keys()
+
+ROLE_LABELS = {
+    "responsible": "Responsible",
+    "observer": "Observer",
+    "technical_application_owner": "Technical Application Owner",
+    "business_application_owner": "Business Application Owner",
+}
+
+
+@router.get("/subscription-roles")
+async def list_roles():
+    """Return role definitions for the UI."""
+    return [
+        {
+            "key": k,
+            "label": v,
+            "allowed_types": list(TYPE_SPECIFIC_ROLES[k]) if k in TYPE_SPECIFIC_ROLES else None,
+        }
+        for k, v in ROLE_LABELS.items()
+    ]
 
 
 @router.get("/fact-sheets/{fs_id}/subscriptions")
@@ -28,6 +58,7 @@ async def list_subscriptions(fs_id: str, db: AsyncSession = Depends(get_db)):
             "user_display_name": s.user.display_name if s.user else None,
             "user_email": s.user.email if s.user else None,
             "role": s.role,
+            "role_label": ROLE_LABELS.get(s.role, s.role),
             "created_at": s.created_at.isoformat() if s.created_at else None,
         }
         for s in subs
@@ -41,6 +72,36 @@ async def create_subscription(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    if body.role not in ALL_ROLES:
+        raise HTTPException(400, f"Invalid role '{body.role}'. Valid: {sorted(ALL_ROLES)}")
+
+    # Check type-specific role constraints
+    if body.role in TYPE_SPECIFIC_ROLES:
+        fs_result = await db.execute(
+            select(FactSheet.type).where(FactSheet.id == uuid.UUID(fs_id))
+        )
+        fs_type = fs_result.scalar_one_or_none()
+        if not fs_type:
+            raise HTTPException(404, "Fact sheet not found")
+        allowed = TYPE_SPECIFIC_ROLES[body.role]
+        if fs_type not in allowed:
+            raise HTTPException(
+                400,
+                f"Role '{body.role}' is only allowed for types: {sorted(allowed)}. "
+                f"This fact sheet is type '{fs_type}'.",
+            )
+
+    # Prevent duplicate role for same user on same fact sheet
+    existing = await db.execute(
+        select(Subscription).where(
+            Subscription.fact_sheet_id == uuid.UUID(fs_id),
+            Subscription.user_id == uuid.UUID(body.user_id),
+            Subscription.role == body.role,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(409, "User already has this role on this fact sheet")
+
     sub = Subscription(
         fact_sheet_id=uuid.UUID(fs_id),
         user_id=uuid.UUID(body.user_id),
@@ -49,7 +110,49 @@ async def create_subscription(
     db.add(sub)
     await db.commit()
     await db.refresh(sub)
-    return {"id": str(sub.id), "user_id": str(sub.user_id), "role": sub.role}
+    return {
+        "id": str(sub.id),
+        "user_id": str(sub.user_id),
+        "user_display_name": sub.user.display_name if sub.user else None,
+        "role": sub.role,
+        "role_label": ROLE_LABELS.get(sub.role, sub.role),
+    }
+
+
+@router.patch("/subscriptions/{sub_id}")
+async def update_subscription(
+    sub_id: str,
+    body: SubscriptionCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    result = await db.execute(select(Subscription).where(Subscription.id == uuid.UUID(sub_id)))
+    sub = result.scalar_one_or_none()
+    if not sub:
+        raise HTTPException(404, "Subscription not found")
+
+    if body.role not in ALL_ROLES:
+        raise HTTPException(400, f"Invalid role '{body.role}'. Valid: {sorted(ALL_ROLES)}")
+
+    if body.role in TYPE_SPECIFIC_ROLES:
+        fs_result = await db.execute(
+            select(FactSheet.type).where(FactSheet.id == sub.fact_sheet_id)
+        )
+        fs_type = fs_result.scalar_one_or_none()
+        allowed = TYPE_SPECIFIC_ROLES[body.role]
+        if fs_type and fs_type not in allowed:
+            raise HTTPException(
+                400, f"Role '{body.role}' is only allowed for types: {sorted(allowed)}"
+            )
+
+    sub.role = body.role
+    await db.commit()
+    return {
+        "id": str(sub.id),
+        "user_id": str(sub.user_id),
+        "role": sub.role,
+        "role_label": ROLE_LABELS.get(sub.role, sub.role),
+    }
 
 
 @router.delete("/subscriptions/{sub_id}", status_code=204)

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -3,36 +3,89 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
+from app.core.security import hash_password
 from app.database import get_db
 from app.models.user import User
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 
+class UserCreate(BaseModel):
+    email: EmailStr
+    display_name: str
+    password: str
+    role: str = "member"
+
+
 class UserUpdate(BaseModel):
     display_name: str | None = None
+    email: EmailStr | None = None
     role: str | None = None
     is_active: bool | None = None
+    password: str | None = None
+
+
+def _user_response(u: User) -> dict:
+    return {
+        "id": str(u.id),
+        "email": u.email,
+        "display_name": u.display_name,
+        "role": u.role,
+        "is_active": u.is_active,
+        "created_at": u.created_at.isoformat() if u.created_at else None,
+    }
 
 
 @router.get("")
 async def list_users(db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)):
     result = await db.execute(select(User).order_by(User.display_name))
-    return [
-        {
-            "id": str(u.id),
-            "email": u.email,
-            "display_name": u.display_name,
-            "role": u.role,
-            "is_active": u.is_active,
-        }
-        for u in result.scalars().all()
-    ]
+    return [_user_response(u) for u in result.scalars().all()]
+
+
+@router.get("/{user_id}")
+async def get_user(
+    user_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
+    u = result.scalar_one_or_none()
+    if not u:
+        raise HTTPException(404, "User not found")
+    return _user_response(u)
+
+
+@router.post("", status_code=201)
+async def create_user(
+    body: UserCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(403, "Admin only")
+
+    if body.role not in ("admin", "member", "viewer"):
+        raise HTTPException(400, "Role must be admin, member, or viewer")
+
+    existing = await db.execute(select(User).where(User.email == body.email))
+    if existing.scalar_one_or_none():
+        raise HTTPException(409, "A user with this email already exists")
+
+    u = User(
+        email=body.email,
+        display_name=body.display_name,
+        password_hash=hash_password(body.password),
+        role=body.role,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return _user_response(u)
 
 
 @router.patch("/{user_id}")
@@ -42,13 +95,59 @@ async def update_user(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if current_user.role != "admin":
-        raise HTTPException(403, "Admin only")
+    if current_user.role != "admin" and str(current_user.id) != user_id:
+        raise HTTPException(403, "Admin only or own profile")
+
     result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
     u = result.scalar_one_or_none()
     if not u:
         raise HTTPException(404, "User not found")
-    for field, value in body.model_dump(exclude_unset=True).items():
+
+    data = body.model_dump(exclude_unset=True)
+
+    # Non-admin can only update own display_name and password
+    if current_user.role != "admin":
+        allowed = {"display_name", "password"}
+        if not set(data.keys()).issubset(allowed):
+            raise HTTPException(403, "Non-admin can only update display_name and password")
+
+    if "role" in data and data["role"] not in ("admin", "member", "viewer"):
+        raise HTTPException(400, "Role must be admin, member, or viewer")
+
+    if "email" in data:
+        existing = await db.execute(
+            select(User).where(User.email == data["email"], User.id != u.id)
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(409, "A user with this email already exists")
+
+    if "password" in data:
+        u.password_hash = hash_password(data.pop("password"))
+
+    for field, value in data.items():
         setattr(u, field, value)
+
     await db.commit()
-    return {"id": str(u.id), "role": u.role, "is_active": u.is_active}
+    return _user_response(u)
+
+
+@router.delete("/{user_id}", status_code=204)
+async def delete_user(
+    user_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(403, "Admin only")
+
+    if str(current_user.id) == user_id:
+        raise HTTPException(400, "Cannot delete your own account")
+
+    result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
+    u = result.scalar_one_or_none()
+    if not u:
+        raise HTTPException(404, "User not found")
+
+    # Soft-delete: deactivate rather than hard-delete to preserve audit trail
+    u.is_active = False
+    await db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,11 +13,18 @@ from app.api.v1.router import api_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Drop and recreate tables if RESET_DB is set (handles old schema migration)
-    async with engine.begin() as conn:
-        if settings.RESET_DB:
+    if settings.RESET_DB:
+        # Full reset: drop everything and recreate
+        async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
-        await conn.run_sync(Base.metadata.create_all)
+            await conn.run_sync(Base.metadata.create_all)
+    else:
+        # Run Alembic migrations to bring schema up to date
+        from alembic.config import Config
+        from alembic import command
+
+        alembic_cfg = Config("alembic.ini")
+        command.upgrade(alembic_cfg, "head")
 
     # Seed default metamodel
     from app.database import async_session

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -19,7 +19,7 @@ class Subscription(Base, UUIDMixin):
     user_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
-    role: Mapped[str] = mapped_column(String(20), nullable=False)  # responsible/accountable/observer
+    role: Mapped[str] = mapped_column(String(50), nullable=False)  # responsible/observer/technical_application_owner/business_application_owner
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     fact_sheet = relationship("FactSheet", back_populates="subscriptions")

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -82,6 +82,13 @@ USAGE_TYPE_OPTIONS = [
     {"key": "stakeholder", "label": "Stakeholder", "color": "#ff9800"},
 ]
 
+TIME_MODEL_OPTIONS = [
+    {"key": "tolerate", "label": "Tolerate", "color": "#ff9800"},
+    {"key": "invest", "label": "Invest", "color": "#4caf50"},
+    {"key": "migrate", "label": "Migrate", "color": "#2196f3"},
+    {"key": "eliminate", "label": "Eliminate", "color": "#d32f2f"},
+]
+
 
 # ── 13 Fact Sheet Types (from Meta_Model.xml) ─────────────────────────
 
@@ -284,6 +291,7 @@ TYPES = [
                     {"key": "businessCriticality", "label": "Business Criticality", "type": "single_select", "required": True, "options": BUSINESS_CRITICALITY_OPTIONS, "weight": 2},
                     {"key": "functionalSuitability", "label": "Functional Suitability", "type": "single_select", "options": FUNCTIONAL_SUITABILITY_OPTIONS, "weight": 2},
                     {"key": "technicalSuitability", "label": "Technical Suitability", "type": "single_select", "options": TECHNICAL_SUITABILITY_OPTIONS, "weight": 2},
+                    {"key": "timeModel", "label": "TIME Model", "type": "single_select", "required": True, "options": TIME_MODEL_OPTIONS, "weight": 3},
                     {"key": "hostingType", "label": "Hosting Type", "type": "single_select", "options": HOSTING_TYPE_OPTIONS, "weight": 1},
                 ],
             },

--- a/frontend/src/features/admin/UsersAdmin.tsx
+++ b/frontend/src/features/admin/UsersAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Table from "@mui/material/Table";
@@ -6,70 +6,410 @@ import TableHead from "@mui/material/TableHead";
 import TableBody from "@mui/material/TableBody";
 import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import Paper from "@mui/material/Paper";
 import Chip from "@mui/material/Chip";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Alert from "@mui/material/Alert";
+import Stack from "@mui/material/Stack";
 import { api } from "@/api/client";
+import type { User } from "@/types";
+import MaterialSymbol from "@/components/MaterialSymbol";
 
-interface UserRow {
-  id: string;
+type Role = "admin" | "member" | "viewer";
+
+interface UserFormState {
   email: string;
   display_name: string;
-  role: string;
-  is_active: boolean;
+  password: string;
+  role: Role;
 }
 
-export default function UsersAdmin() {
-  const [users, setUsers] = useState<UserRow[]>([]);
+const EMPTY_FORM: UserFormState = {
+  email: "",
+  display_name: "",
+  password: "",
+  role: "member",
+};
 
-  useEffect(() => {
-    api.get<UserRow[]>("/users").then(setUsers);
+export default function UsersAdmin() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Dialog state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [form, setForm] = useState<UserFormState>(EMPTY_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await api.get<User[]>("/users");
+      setUsers(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load users");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  // --- Inline role update ---
   const updateRole = async (userId: string, role: string) => {
-    await api.patch(`/users/${userId}`, { role });
-    setUsers(users.map((u) => (u.id === userId ? { ...u, role } : u)));
+    try {
+      await api.patch(`/users/${userId}`, { role });
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, role } : u))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update role");
+    }
   };
+
+  // --- Toggle active/inactive ---
+  const toggleActive = async (user: User) => {
+    try {
+      const updated = await api.patch<User>(`/users/${user.id}`, {
+        is_active: !user.is_active,
+      });
+      setUsers((prev) =>
+        prev.map((u) => (u.id === updated.id ? updated : u))
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to toggle user status"
+      );
+    }
+  };
+
+  // --- Delete (soft-delete) ---
+  const handleDelete = async (user: User) => {
+    const confirmed = window.confirm(
+      `Are you sure you want to delete "${user.display_name || user.email}"? This action cannot be undone.`
+    );
+    if (!confirmed) return;
+    try {
+      await api.delete(`/users/${user.id}`);
+      setUsers((prev) => prev.filter((u) => u.id !== user.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete user");
+    }
+  };
+
+  // --- Create dialog ---
+  const openCreate = () => {
+    setForm(EMPTY_FORM);
+    setFormError(null);
+    setCreateOpen(true);
+  };
+
+  const handleCreate = async () => {
+    if (!form.email.trim() || !form.display_name.trim() || !form.password) {
+      setFormError("Email, display name, and password are required.");
+      return;
+    }
+    try {
+      setSubmitting(true);
+      setFormError(null);
+      const created = await api.post<User>("/users", {
+        email: form.email.trim(),
+        display_name: form.display_name.trim(),
+        password: form.password,
+        role: form.role,
+      });
+      setUsers((prev) => [...prev, created]);
+      setCreateOpen(false);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to create user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // --- Edit dialog ---
+  const openEdit = (user: User) => {
+    setEditingUser(user);
+    setForm({
+      email: user.email,
+      display_name: user.display_name,
+      password: "",
+      role: user.role as Role,
+    });
+    setFormError(null);
+    setEditOpen(true);
+  };
+
+  const handleEdit = async () => {
+    if (!editingUser) return;
+    if (!form.email.trim() || !form.display_name.trim()) {
+      setFormError("Email and display name are required.");
+      return;
+    }
+    const payload: Record<string, string> = {
+      email: form.email.trim(),
+      display_name: form.display_name.trim(),
+      role: form.role,
+    };
+    if (form.password) {
+      payload.password = form.password;
+    }
+    try {
+      setSubmitting(true);
+      setFormError(null);
+      const updated = await api.patch<User>(
+        `/users/${editingUser.id}`,
+        payload
+      );
+      setUsers((prev) =>
+        prev.map((u) => (u.id === updated.id ? updated : u))
+      );
+      setEditOpen(false);
+      setEditingUser(null);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to update user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // --- Form field handler ---
+  const updateField = (field: keyof UserFormState, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  // --- Shared dialog form ---
+  const renderFormFields = (isEdit: boolean) => (
+    <Stack spacing={2.5} sx={{ mt: 1 }}>
+      <TextField
+        label="Display Name"
+        value={form.display_name}
+        onChange={(e) => updateField("display_name", e.target.value)}
+        fullWidth
+        required
+        autoFocus={!isEdit}
+        size="small"
+      />
+      <TextField
+        label="Email"
+        type="email"
+        value={form.email}
+        onChange={(e) => updateField("email", e.target.value)}
+        fullWidth
+        required
+        size="small"
+      />
+      <TextField
+        label={isEdit ? "Password (leave blank to keep current)" : "Password"}
+        type="password"
+        value={form.password}
+        onChange={(e) => updateField("password", e.target.value)}
+        fullWidth
+        required={!isEdit}
+        size="small"
+      />
+      <FormControl fullWidth size="small">
+        <InputLabel>Role</InputLabel>
+        <Select
+          label="Role"
+          value={form.role}
+          onChange={(e) => updateField("role", e.target.value)}
+        >
+          <MenuItem value="admin">Admin</MenuItem>
+          <MenuItem value="member">Member</MenuItem>
+          <MenuItem value="viewer">Viewer</MenuItem>
+        </Select>
+      </FormControl>
+      {formError && <Alert severity="error">{formError}</Alert>}
+    </Stack>
+  );
 
   return (
     <Box>
-      <Typography variant="h5" fontWeight={600} sx={{ mb: 3 }}>User Management</Typography>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Email</TableCell>
-            <TableCell>Role</TableCell>
-            <TableCell>Status</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {users.map((u) => (
-            <TableRow key={u.id}>
-              <TableCell>{u.display_name}</TableCell>
-              <TableCell>{u.email}</TableCell>
-              <TableCell>
-                <Select
-                  size="small"
-                  value={u.role}
-                  onChange={(e) => updateRole(u.id, e.target.value)}
-                >
-                  <MenuItem value="admin">Admin</MenuItem>
-                  <MenuItem value="member">Member</MenuItem>
-                  <MenuItem value="viewer">Viewer</MenuItem>
-                </Select>
-              </TableCell>
-              <TableCell>
-                <Chip
-                  size="small"
-                  label={u.is_active ? "Active" : "Disabled"}
-                  color={u.is_active ? "success" : "default"}
-                />
-              </TableCell>
+      {/* Header */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 3,
+        }}
+      >
+        <Typography variant="h5" fontWeight={600}>
+          User Management
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<MaterialSymbol icon="person_add" size={20} />}
+          onClick={openCreate}
+        >
+          Create User
+        </Button>
+      </Box>
+
+      {/* Error banner */}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Users table */}
+      <TableContainer component={Paper} variant="outlined">
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell align="right">Actions</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {loading && (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    Loading users...
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {!loading && users.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">
+                    No users found.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {!loading &&
+              users.map((u) => (
+                <TableRow key={u.id} hover>
+                  <TableCell>{u.display_name}</TableCell>
+                  <TableCell>{u.email}</TableCell>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      value={u.role}
+                      onChange={(e) => updateRole(u.id, e.target.value)}
+                      sx={{ minWidth: 110 }}
+                    >
+                      <MenuItem value="admin">Admin</MenuItem>
+                      <MenuItem value="member">Member</MenuItem>
+                      <MenuItem value="viewer">Viewer</MenuItem>
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={u.is_active ? "Active" : "Disabled"}
+                      color={u.is_active ? "success" : "default"}
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    <Tooltip title="Edit user">
+                      <IconButton size="small" onClick={() => openEdit(u)}>
+                        <MaterialSymbol icon="edit" size={20} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip
+                      title={u.is_active ? "Deactivate user" : "Activate user"}
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => toggleActive(u)}
+                        color={u.is_active ? "warning" : "success"}
+                      >
+                        <MaterialSymbol
+                          icon={u.is_active ? "person_off" : "person"}
+                          size={20}
+                        />
+                      </IconButton>
+                    </Tooltip>
+                    {!u.is_active && (
+                      <Tooltip title="Delete user">
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => handleDelete(u)}
+                        >
+                          <MaterialSymbol icon="delete" size={20} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Create User Dialog */}
+      <Dialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Create User</DialogTitle>
+        <DialogContent>{renderFormFields(false)}</DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setCreateOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={submitting}
+          >
+            {submitting ? "Creating..." : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Edit User Dialog */}
+      <Dialog
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Edit User</DialogTitle>
+        <DialogContent>{renderFormFields(true)}</DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setEditOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleEdit}
+            disabled={submitting}
+          >
+            {submitting ? "Saving..." : "Save Changes"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,13 @@ export interface User {
   display_name: string;
   role: string;
   is_active: boolean;
+  created_at?: string;
+}
+
+export interface SubscriptionRoleDef {
+  key: string;
+  label: string;
+  allowed_types: string[] | null;
 }
 
 export interface FieldOption {
@@ -73,6 +80,7 @@ export interface SubscriptionRef {
   user_display_name?: string;
   user_email?: string;
   role: string;
+  role_label?: string;
 }
 
 export interface FactSheet {


### PR DESCRIPTION
…Alembic

Backend:
- Users API: full CRUD (create with password, get, update with email/password reset, soft-delete), admin-only guards, self-profile editing
- Subscriptions: type-aware roles (Responsible, Observer, Technical Application Owner, Business Application Owner), duplicate prevention, role validation endpoint, update subscription role
- Seed: TIME Model field (Tolerate/Invest/Migrate/Eliminate) on Application type
- Alembic: directory structure, async env.py, baseline migration, migration to expand subscription.role column to VARCHAR(50)
- Main: run Alembic upgrade on startup (RESET_DB=false), create_all on reset

Frontend:
- UsersAdmin: full CRUD table with create/edit dialogs, inline role selector, activate/deactivate toggle, soft-delete with confirmation
- SubscriptionsTab: fetches roles from API, filters by fact sheet type, add/remove subscriptions with user picker
- RelationsSection: add relation dialog (pick type then autocomplete search target fact sheets), delete relation button, respects metamodel constraints
- Types: SubscriptionRoleDef, User.created_at, SubscriptionRef.role_label

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF