### PR TITLE
Fix double checkbox: remove explicit column, use rowSelection built-in

### DIFF
--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -178,15 +178,6 @@ export default function InventoryPage() {
   const columnDefs = useMemo<ColDef[]>(() => {
     const cols: ColDef[] = [
       {
-        checkboxSelection: true,
-        width: 50,
-        maxWidth: 50,
-        suppressHeaderMenuButton: true,
-        sortable: false,
-        filter: false,
-        resizable: false,
-      },
-      {
         field: "type",
         headerName: "Type",
         width: 140,
@@ -602,7 +593,7 @@ export default function InventoryPage() {
           rowData={filteredData}
           columnDefs={columnDefs}
           loading={loading}
-          rowSelection={{ mode: "multiRow", enableClickSelection: false }}
+          rowSelection={{ mode: "multiRow", enableClickSelection: false, headerCheckbox: false }}
           onSelectionChanged={handleSelectionChanged}
           onCellValueChanged={handleCellEdit}
           onRowClicked={(e) => {


### PR DESCRIPTION
AG Grid v32 multiRow mode auto-renders a checkbox column. Remove the duplicate explicit checkboxSelection column and set headerCheckbox:false to keep only per-row checkboxes without a select-all header.

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF