### PR TITLE
Add auto-computed hierarchy with CRUD for all fact sheet types

### DIFF
--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -228,11 +228,6 @@ TYPES = [
             {
                 "section": "Capability Information",
                 "fields": [
-                    {"key": "capabilityLevel", "label": "Capability Level", "type": "single_select", "options": [
-                        {"key": "L1", "label": "Level 1", "color": "#1565c0"},
-                        {"key": "L2", "label": "Level 2", "color": "#42a5f5"},
-                        {"key": "L3", "label": "Level 3", "color": "#90caf9"},
-                    ], "weight": 1},
                     {"key": "isCoreCapability", "label": "Core Capability", "type": "boolean", "weight": 0},
                 ],
             },

--- a/frontend/src/features/fact-sheets/FactSheetDetail.tsx
+++ b/frontend/src/features/fact-sheets/FactSheetDetail.tsx
@@ -46,6 +46,7 @@ import type {
   SubscriptionRef,
   SubscriptionRoleDef,
   User,
+  HierarchyData,
 } from "@/types";
 
 // ── Completion Ring ─────────────────────────────────────────────
@@ -568,6 +569,392 @@ function AttributeSection({
                 />
               </Box>
             ))}
+          </Box>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+// ── Section: Hierarchy ───────────────────────────────────────────
+const LEVEL_COLORS = ["#1565c0", "#42a5f5", "#90caf9", "#bbdefb", "#e3f2fd"];
+
+function HierarchySection({
+  fs,
+  onUpdate,
+}: {
+  fs: FactSheet;
+  onUpdate: () => void;
+}) {
+  const navigate = useNavigate();
+  const { getType } = useMetamodel();
+  const typeConfig = getType(fs.type);
+  const [hierarchy, setHierarchy] = useState<HierarchyData | null>(null);
+
+  // Parent picker state
+  const [pickingParent, setPickingParent] = useState(false);
+  const [parentSearch, setParentSearch] = useState("");
+  const [parentOptions, setParentOptions] = useState<{ id: string; name: string }[]>([]);
+  const [selectedParent, setSelectedParent] = useState<{ id: string; name: string } | null>(null);
+
+  // Add child state
+  const [addChildOpen, setAddChildOpen] = useState(false);
+  const [childSearch, setChildSearch] = useState("");
+  const [childOptions, setChildOptions] = useState<{ id: string; name: string }[]>([]);
+  const [selectedChild, setSelectedChild] = useState<{ id: string; name: string } | null>(null);
+
+  // Inline create state
+  const [createMode, setCreateMode] = useState<"parent" | "child" | null>(null);
+  const [createName, setCreateName] = useState("");
+  const [createLoading, setCreateLoading] = useState(false);
+
+  const loadHierarchy = useCallback(() => {
+    api.get<HierarchyData>(`/fact-sheets/${fs.id}/hierarchy`).then(setHierarchy).catch(() => {});
+  }, [fs.id]);
+
+  useEffect(loadHierarchy, [loadHierarchy]);
+
+  // Search parents (same type, exclude self and descendants)
+  useEffect(() => {
+    if (!pickingParent || parentSearch.length < 1) { setParentOptions([]); return; }
+    const timer = setTimeout(() => {
+      api
+        .get<{ items: { id: string; name: string }[] }>(
+          `/fact-sheets?type=${fs.type}&search=${encodeURIComponent(parentSearch)}&page_size=20`
+        )
+        .then((res) => {
+          const childIds = new Set(hierarchy?.children.map((c) => c.id) || []);
+          setParentOptions(res.items.filter((item) => item.id !== fs.id && !childIds.has(item.id)));
+        })
+        .catch(() => {});
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [pickingParent, parentSearch, fs.id, fs.type, hierarchy]);
+
+  // Search children (same type, exclude self)
+  useEffect(() => {
+    if (!addChildOpen || childSearch.length < 1) { setChildOptions([]); return; }
+    const timer = setTimeout(() => {
+      api
+        .get<{ items: { id: string; name: string }[] }>(
+          `/fact-sheets?type=${fs.type}&search=${encodeURIComponent(childSearch)}&page_size=20`
+        )
+        .then((res) => {
+          const ancestorIds = new Set(hierarchy?.ancestors.map((a) => a.id) || []);
+          setChildOptions(res.items.filter((item) => item.id !== fs.id && !ancestorIds.has(item.id)));
+        })
+        .catch(() => {});
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [addChildOpen, childSearch, fs.id, fs.type, hierarchy]);
+
+  const handleSetParent = async () => {
+    if (!selectedParent) return;
+    await api.patch(`/fact-sheets/${fs.id}`, { parent_id: selectedParent.id });
+    setPickingParent(false);
+    setSelectedParent(null);
+    setParentSearch("");
+    loadHierarchy();
+    onUpdate();
+  };
+
+  const handleRemoveParent = async () => {
+    await api.patch(`/fact-sheets/${fs.id}`, { parent_id: null });
+    loadHierarchy();
+    onUpdate();
+  };
+
+  const handleAddChild = async () => {
+    if (!selectedChild) return;
+    await api.patch(`/fact-sheets/${selectedChild.id}`, { parent_id: fs.id });
+    setAddChildOpen(false);
+    setSelectedChild(null);
+    setChildSearch("");
+    loadHierarchy();
+  };
+
+  const handleRemoveChild = async (childId: string) => {
+    await api.patch(`/fact-sheets/${childId}`, { parent_id: null });
+    loadHierarchy();
+  };
+
+  const handleQuickCreate = async () => {
+    if (!createName.trim()) return;
+    setCreateLoading(true);
+    try {
+      const created = await api.post<{ id: string; name: string }>("/fact-sheets", {
+        type: fs.type,
+        name: createName.trim(),
+        ...(createMode === "child" ? { parent_id: fs.id } : {}),
+      });
+      if (createMode === "parent") {
+        // Set the newly created fact sheet as parent
+        await api.patch(`/fact-sheets/${fs.id}`, { parent_id: created.id });
+        onUpdate();
+      }
+      setCreateMode(null);
+      setCreateName("");
+      loadHierarchy();
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  if (!typeConfig?.has_hierarchy) return null;
+
+  const level = hierarchy?.level ?? 1;
+  const levelColor = LEVEL_COLORS[Math.min(level - 1, LEVEL_COLORS.length - 1)];
+
+  return (
+    <Accordion defaultExpanded disableGutters>
+      <AccordionSummary expandIcon={<MaterialSymbol icon="expand_more" size={20} />}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flex: 1 }}>
+          <MaterialSymbol icon="account_tree" size={20} color="#666" />
+          <Typography fontWeight={600}>Hierarchy</Typography>
+          {hierarchy && (
+            <Chip
+              size="small"
+              label={`Level ${level}`}
+              sx={{ ml: 1, height: 20, fontSize: "0.7rem", bgcolor: levelColor, color: "#fff" }}
+            />
+          )}
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        {!hierarchy ? (
+          <LinearProgress />
+        ) : (
+          <Box>
+            {/* Ancestor breadcrumb trail */}
+            {hierarchy.ancestors.length > 0 && (
+              <Box sx={{ mb: 2 }}>
+                <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{ mb: 0.5, display: "block" }}>
+                  Path
+                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
+                  {hierarchy.ancestors.map((ancestor, i) => {
+                    const ancestorLevel = i + 1;
+                    const aColor = LEVEL_COLORS[Math.min(ancestorLevel - 1, LEVEL_COLORS.length - 1)];
+                    return (
+                      <Box key={ancestor.id} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                        <Chip
+                          size="small"
+                          label={ancestor.name}
+                          onClick={() => navigate(`/fact-sheets/${ancestor.id}`)}
+                          sx={{ cursor: "pointer", borderColor: aColor, color: aColor, fontWeight: 500 }}
+                          variant="outlined"
+                        />
+                        <MaterialSymbol icon="chevron_right" size={16} color="#bbb" />
+                      </Box>
+                    );
+                  })}
+                  <Chip
+                    size="small"
+                    label={fs.name}
+                    sx={{ bgcolor: levelColor, color: "#fff", fontWeight: 600 }}
+                  />
+                </Box>
+              </Box>
+            )}
+
+            {/* Parent */}
+            <Box sx={{ mb: 2 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                  Parent
+                </Typography>
+              </Box>
+              {hierarchy.ancestors.length > 0 ? (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Chip
+                    size="small"
+                    label={hierarchy.ancestors[hierarchy.ancestors.length - 1].name}
+                    onClick={() => navigate(`/fact-sheets/${hierarchy.ancestors[hierarchy.ancestors.length - 1].id}`)}
+                    sx={{ cursor: "pointer" }}
+                    icon={<MaterialSymbol icon={typeConfig?.icon || "category"} size={16} />}
+                  />
+                  <IconButton size="small" onClick={() => setPickingParent(true)} title="Change parent">
+                    <MaterialSymbol icon="edit" size={16} />
+                  </IconButton>
+                  <IconButton size="small" onClick={handleRemoveParent} title="Remove parent">
+                    <MaterialSymbol icon="link_off" size={16} color="#f44336" />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Typography variant="body2" color="text.secondary">No parent</Typography>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<MaterialSymbol icon="add" size={16} />}
+                    onClick={() => setPickingParent(true)}
+                  >
+                    Set Parent
+                  </Button>
+                </Box>
+              )}
+            </Box>
+
+            {/* Parent picker dialog */}
+            <Dialog open={pickingParent} onClose={() => { setPickingParent(false); setCreateMode(null); }} maxWidth="sm" fullWidth>
+              <DialogTitle>Set Parent</DialogTitle>
+              <DialogContent>
+                {!createMode ? (
+                  <>
+                    <Autocomplete
+                      options={parentOptions}
+                      getOptionLabel={(opt) => opt.name}
+                      value={selectedParent}
+                      onChange={(_, val) => setSelectedParent(val)}
+                      inputValue={parentSearch}
+                      onInputChange={(_, val) => setParentSearch(val)}
+                      renderInput={(params) => (
+                        <TextField {...params} size="small" label={`Search ${typeConfig?.label || fs.type}`} placeholder="Type to search..." sx={{ mt: 1 }} />
+                      )}
+                      noOptionsText={parentSearch ? "No results found" : "Type to search..."}
+                      filterOptions={(x) => x}
+                    />
+                    <Button
+                      size="small"
+                      sx={{ mt: 1 }}
+                      startIcon={<MaterialSymbol icon="add" size={16} />}
+                      onClick={() => { setCreateMode("parent"); setCreateName(parentSearch); }}
+                    >
+                      Create new {typeConfig?.label || fs.type}
+                    </Button>
+                  </>
+                ) : (
+                  <Box sx={{ mt: 1, p: 2, border: "1px solid", borderColor: "divider", borderRadius: 1, bgcolor: "action.hover" }}>
+                    <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+                      Create new {typeConfig?.label || fs.type} as parent
+                    </Typography>
+                    <TextField
+                      fullWidth size="small" label="Name" value={createName}
+                      onChange={(e) => setCreateName(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && handleQuickCreate()}
+                      autoFocus sx={{ mb: 1 }}
+                    />
+                    <Box sx={{ display: "flex", gap: 1 }}>
+                      <Button size="small" variant="contained" onClick={handleQuickCreate} disabled={!createName.trim() || createLoading}>
+                        Create & Set as Parent
+                      </Button>
+                      <Button size="small" onClick={() => setCreateMode(null)}>Back to search</Button>
+                    </Box>
+                  </Box>
+                )}
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => { setPickingParent(false); setCreateMode(null); }}>Cancel</Button>
+                {!createMode && (
+                  <Button variant="contained" onClick={handleSetParent} disabled={!selectedParent}>
+                    Set Parent
+                  </Button>
+                )}
+              </DialogActions>
+            </Dialog>
+
+            {/* Children */}
+            <Box>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                  Children
+                </Typography>
+                <Chip size="small" label={hierarchy.children.length} sx={{ height: 18, fontSize: "0.65rem" }} />
+              </Box>
+              {hierarchy.children.length > 0 ? (
+                <List dense disablePadding>
+                  {hierarchy.children.map((child) => (
+                    <ListItem
+                      key={child.id}
+                      secondaryAction={
+                        <IconButton size="small" onClick={() => handleRemoveChild(child.id)} title="Remove from hierarchy">
+                          <MaterialSymbol icon="link_off" size={16} color="#999" />
+                        </IconButton>
+                      }
+                    >
+                      <Box
+                        component="div"
+                        onClick={() => navigate(`/fact-sheets/${child.id}`)}
+                        sx={{ cursor: "pointer", display: "flex", alignItems: "center", gap: 1, "&:hover": { textDecoration: "underline" } }}
+                      >
+                        <MaterialSymbol icon={typeConfig?.icon || "category"} size={16} color={typeConfig?.color} />
+                        <ListItemText primary={child.name} />
+                      </Box>
+                    </ListItem>
+                  ))}
+                </List>
+              ) : (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>No children</Typography>
+              )}
+              <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<MaterialSymbol icon="add" size={16} />}
+                  onClick={() => setAddChildOpen(true)}
+                >
+                  Add Child
+                </Button>
+              </Box>
+            </Box>
+
+            {/* Add child dialog */}
+            <Dialog open={addChildOpen} onClose={() => { setAddChildOpen(false); setCreateMode(null); }} maxWidth="sm" fullWidth>
+              <DialogTitle>Add Child</DialogTitle>
+              <DialogContent>
+                {createMode !== "child" ? (
+                  <>
+                    <Autocomplete
+                      options={childOptions}
+                      getOptionLabel={(opt) => opt.name}
+                      value={selectedChild}
+                      onChange={(_, val) => setSelectedChild(val)}
+                      inputValue={childSearch}
+                      onInputChange={(_, val) => setChildSearch(val)}
+                      renderInput={(params) => (
+                        <TextField {...params} size="small" label={`Search ${typeConfig?.label || fs.type}`} placeholder="Type to search..." sx={{ mt: 1 }} />
+                      )}
+                      noOptionsText={childSearch ? "No results found" : "Type to search..."}
+                      filterOptions={(x) => x}
+                    />
+                    <Button
+                      size="small"
+                      sx={{ mt: 1 }}
+                      startIcon={<MaterialSymbol icon="add" size={16} />}
+                      onClick={() => { setCreateMode("child"); setCreateName(childSearch); }}
+                    >
+                      Create new {typeConfig?.label || fs.type}
+                    </Button>
+                  </>
+                ) : (
+                  <Box sx={{ mt: 1, p: 2, border: "1px solid", borderColor: "divider", borderRadius: 1, bgcolor: "action.hover" }}>
+                    <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+                      Create new {typeConfig?.label || fs.type} as child
+                    </Typography>
+                    <TextField
+                      fullWidth size="small" label="Name" value={createName}
+                      onChange={(e) => setCreateName(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && handleQuickCreate()}
+                      autoFocus sx={{ mb: 1 }}
+                    />
+                    <Box sx={{ display: "flex", gap: 1 }}>
+                      <Button size="small" variant="contained" onClick={handleQuickCreate} disabled={!createName.trim() || createLoading}>
+                        Create & Add as Child
+                      </Button>
+                      <Button size="small" onClick={() => setCreateMode(null)}>Back to search</Button>
+                    </Box>
+                  </Box>
+                )}
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => { setAddChildOpen(false); setCreateMode(null); }}>Cancel</Button>
+                {createMode !== "child" && (
+                  <Button variant="contained" onClick={handleAddChild} disabled={!selectedChild}>
+                    Add Child
+                  </Button>
+                )}
+              </DialogActions>
+            </Dialog>
           </Box>
         )}
       </AccordionDetails>
@@ -1318,6 +1705,7 @@ export default function FactSheetDetail() {
             onSave={handleUpdate}
           />
         ))}
+        <HierarchySection fs={fs} onUpdate={() => api.get<FactSheet>(`/fact-sheets/${fs.id}`).then(setFs)} />
         <RelationsSection fsId={fs.id} fsType={fs.type} />
       </Box>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,6 +105,18 @@ export interface FactSheet {
   subscriptions: SubscriptionRef[];
 }
 
+export interface HierarchyNode {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface HierarchyData {
+  ancestors: HierarchyNode[];
+  children: HierarchyNode[];
+  level: number;
+}
+
 export interface FactSheetListResponse {
   items: FactSheet[];
   total: number;


### PR DESCRIPTION
Backend:
- Add GET /fact-sheets/{id}/hierarchy endpoint returning ancestors (root→parent), children, and computed level
- Remove manual capabilityLevel field from BusinessCapability seed; level is now auto-computed from parent depth (L1=root, L2=child, etc.)

Frontend:
- Add HierarchySection to FactSheetDetail (shown for types with has_hierarchy=true): ancestor breadcrumb trail, parent display with set/change/remove, children list with remove
- Set Parent dialog: autocomplete search same type + inline create
- Add Child dialog: autocomplete search same type + inline create (prefilled with parent_id)
- Add HierarchyData/HierarchyNode types

https://claude.ai/code/session_01MrooiuWT3UfwCSheFktbzF