### PR TITLE
Integrate DrawIO editor with DB-backed diagram storage

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,5 +9,21 @@ RUN npm run build
 FROM nginx:alpine AS production
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Self-hosted DrawIO (optional).
+# To enable air-gapped DrawIO (no external requests to embed.diagrams.net):
+#
+# 1. Download a DrawIO release:
+#      git clone --depth 1 --branch v24.7.17 https://github.com/jgraph/drawio.git /tmp/drawio
+#
+# 2. Uncomment the COPY line below to bundle it into the image:
+# COPY /tmp/drawio/src/main/webapp /usr/share/nginx/drawio
+#
+# 3. Set VITE_DRAWIO_URL=/drawio/index.html in your build environment
+#    so the frontend loads DrawIO from your server instead of embed.diagrams.net.
+#
+# Alternatively, mount a volume with DrawIO files at /usr/share/nginx/drawio/
+# in docker-compose.yml.
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,6 +21,24 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Self-hosted DrawIO (optional).
+    # To enable: download the DrawIO release and extract to /usr/share/nginx/drawio/
+    # See Dockerfile comments for instructions.
+    location /drawio/ {
+        alias /usr/share/nginx/drawio/;
+        try_files $uri $uri/ =404;
+
+        # Prevent search engines from indexing self-hosted DrawIO
+        add_header X-Robots-Tag "noindex, nofollow" always;
+
+        # DrawIO assets are versioned, cache aggressively
+        location ~* \.(js|css|png|jpg|svg|woff|woff2)$ {
+            alias /usr/share/nginx/drawio/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -1,63 +1,250 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import Snackbar from "@mui/material/Snackbar";
+import CircularProgress from "@mui/material/CircularProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
+
+/**
+ * DrawIO embed mode URL.
+ * In production, replace with self-hosted path: "/drawio/index.html"
+ * to avoid loading external scripts. See nginx.conf for setup.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const _meta = import.meta as any;
+const DRAWIO_BASE_URL: string =
+  _meta.env?.VITE_DRAWIO_URL || "https://embed.diagrams.net";
+
+const DRAWIO_URL_PARAMS = new URLSearchParams({
+  embed: "1",
+  proto: "json",
+  spin: "1",
+  modified: "unsavedChanges",
+  saveAndExit: "1",
+  noSaveBtn: "0",
+  noExitBtn: "0",
+}).toString();
+
+/** Default empty diagram XML */
+const EMPTY_DIAGRAM =
+  '<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>';
 
 interface DiagramData {
   id: string;
   name: string;
   type: string;
-  data: Record<string, unknown>;
+  data: {
+    xml?: string;
+    thumbnail?: string;
+  };
+}
+
+/** Messages FROM DrawIO iframe → host */
+interface DrawIOMessage {
+  event: "init" | "save" | "exit" | "export" | "configure";
+  xml?: string;
+  data?: string;
+  modified?: boolean;
 }
 
 export default function DiagramEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const [diagram, setDiagram] = useState<DiagramData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [snackMsg, setSnackMsg] = useState("");
+  // Track whether we're waiting for a thumbnail export after save
+  const pendingSaveXmlRef = useRef<string | null>(null);
 
+  // Load diagram from API
   useEffect(() => {
-    if (id) api.get<DiagramData>(`/diagrams/${id}`).then(setDiagram);
+    if (!id) return;
+    api
+      .get<DiagramData>(`/diagrams/${id}`)
+      .then(setDiagram)
+      .catch(() => setSnackMsg("Failed to load diagram"))
+      .finally(() => setLoading(false));
   }, [id]);
 
-  if (!diagram) return <Typography>Loading...</Typography>;
+  /** Send a message to the DrawIO iframe */
+  const postToDrawIO = useCallback((msg: Record<string, unknown>) => {
+    const frame = iframeRef.current;
+    if (frame?.contentWindow) {
+      frame.contentWindow.postMessage(JSON.stringify(msg), "*");
+    }
+  }, []);
+
+  /** Persist XML + thumbnail to the backend */
+  const saveDiagram = useCallback(
+    async (xml: string, thumbnail?: string) => {
+      if (!diagram) return;
+      setSaving(true);
+      try {
+        const payload: Record<string, unknown> = {
+          data: {
+            ...diagram.data,
+            xml,
+            ...(thumbnail ? { thumbnail } : {}),
+          },
+        };
+        await api.patch(`/diagrams/${diagram.id}`, payload);
+        setDiagram((prev) =>
+          prev
+            ? {
+                ...prev,
+                data: { ...prev.data, xml, ...(thumbnail ? { thumbnail } : {}) },
+              }
+            : prev
+        );
+        setSnackMsg("Diagram saved");
+      } catch {
+        setSnackMsg("Save failed");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [diagram]
+  );
+
+  /** Handle postMessage events from DrawIO */
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      // Only accept messages that look like DrawIO JSON protocol
+      if (typeof e.data !== "string") return;
+      let msg: DrawIOMessage;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+
+      switch (msg.event) {
+        case "init":
+          // Editor is ready — load the diagram XML
+          postToDrawIO({
+            action: "load",
+            xml: diagram?.data?.xml || EMPTY_DIAGRAM,
+            autosave: 0,
+          });
+          break;
+
+        case "save":
+          if (msg.xml) {
+            // Store XML for when thumbnail export completes
+            pendingSaveXmlRef.current = msg.xml;
+            // Request SVG export for thumbnail
+            postToDrawIO({
+              action: "export",
+              format: "svg",
+              spinKey: "saving",
+            });
+            // Acknowledge the save to DrawIO (clears modified state)
+            postToDrawIO({
+              action: "status",
+              messageKey: "allChangesSaved",
+              modified: false,
+            });
+          }
+          break;
+
+        case "export":
+          // Thumbnail SVG arrived after a save
+          if (pendingSaveXmlRef.current) {
+            const xml = pendingSaveXmlRef.current;
+            pendingSaveXmlRef.current = null;
+            saveDiagram(xml, msg.data);
+          }
+          break;
+
+        case "exit":
+          // If modified, save first then navigate
+          if (msg.modified && msg.xml) {
+            saveDiagram(msg.xml).then(() => navigate("/diagrams"));
+          } else {
+            navigate("/diagrams");
+          }
+          break;
+
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [diagram, postToDrawIO, saveDiagram, navigate]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!diagram) {
+    return <Typography color="error">Diagram not found</Typography>;
+  }
+
+  const iframeSrc = `${DRAWIO_BASE_URL}?${DRAWIO_URL_PARAMS}`;
 
   return (
-    <Box>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
-        <IconButton onClick={() => navigate("/diagrams")}>
-          <MaterialSymbol icon="arrow_back" size={24} />
-        </IconButton>
-        <Typography variant="h5" fontWeight={600}>{diagram.name}</Typography>
-        <Box sx={{ flex: 1 }} />
-        <Button variant="outlined">Save</Button>
-      </Box>
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      {/* Toolbar */}
       <Box
         sx={{
-          height: "calc(100vh - 200px)",
-          border: "2px dashed #e0e0e0",
-          borderRadius: 2,
           display: "flex",
           alignItems: "center",
-          justifyContent: "center",
-          bgcolor: "#fafafa",
+          gap: 1,
+          px: 1,
+          py: 0.5,
+          borderBottom: "1px solid #e0e0e0",
+          minHeight: 48,
         }}
       >
-        <Box sx={{ textAlign: "center" }}>
-          <MaterialSymbol icon="draw" size={64} color="#ccc" />
-          <Typography variant="h6" color="text.secondary" sx={{ mt: 2 }}>
-            Diagram Canvas
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Drag and drop fact sheets here to build your diagram.
-            <br />
-            Full diagram editor coming soon.
-          </Typography>
-        </Box>
+        <IconButton size="small" onClick={() => navigate("/diagrams")}>
+          <MaterialSymbol icon="arrow_back" size={20} />
+        </IconButton>
+        <Typography variant="subtitle1" fontWeight={600} noWrap>
+          {diagram.name}
+        </Typography>
+        {saving && (
+          <CircularProgress size={16} sx={{ ml: 1 }} />
+        )}
+        <Box sx={{ flex: 1 }} />
+        <Typography variant="caption" color="text.secondary">
+          DrawIO Editor
+        </Typography>
       </Box>
+
+      {/* DrawIO iframe */}
+      <Box sx={{ flex: 1, position: "relative" }}>
+        <iframe
+          ref={iframeRef}
+          src={iframeSrc}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            border: "none",
+          }}
+          title="Diagram Editor"
+        />
+      </Box>
+
+      <Snackbar
+        open={!!snackMsg}
+        autoHideDuration={3000}
+        onClose={() => setSnackMsg("")}
+        message={snackMsg}
+      />
     </Box>
   );
 }

--- a/frontend/src/features/diagrams/DiagramsPage.tsx
+++ b/frontend/src/features/diagrams/DiagramsPage.tsx
@@ -24,6 +24,7 @@ interface DiagramSummary {
   id: string;
   name: string;
   type: string;
+  thumbnail?: string;
   created_at?: string;
   updated_at?: string;
 }
@@ -66,10 +67,52 @@ export default function DiagramsPage() {
           <Grid item xs={12} sm={6} md={4} key={d.id}>
             <Card>
               <CardActionArea onClick={() => navigate(`/diagrams/${d.id}`)}>
+                {/* Thumbnail preview */}
+                {d.thumbnail ? (
+                  <Box
+                    sx={{
+                      height: 160,
+                      overflow: "hidden",
+                      bgcolor: "#fafafa",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      borderBottom: "1px solid #eee",
+                    }}
+                  >
+                    <img
+                      src={
+                        d.thumbnail.startsWith("data:")
+                          ? d.thumbnail
+                          : `data:image/svg+xml;base64,${btoa(d.thumbnail)}`
+                      }
+                      alt={d.name}
+                      style={{
+                        maxWidth: "100%",
+                        maxHeight: "100%",
+                        objectFit: "contain",
+                      }}
+                    />
+                  </Box>
+                ) : (
+                  <Box
+                    sx={{
+                      height: 160,
+                      bgcolor: "#fafafa",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      borderBottom: "1px solid #eee",
+                    }}
+                  >
+                    <MaterialSymbol icon="draw" size={48} color="#ccc" />
+                  </Box>
+                )}
+
                 <CardContent>
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
                     <MaterialSymbol icon={d.type === "data_flow" ? "device_hub" : "draw"} size={24} color="#1976d2" />
-                    <Typography variant="subtitle1" fontWeight={600}>{d.name}</Typography>
+                    <Typography variant="subtitle1" fontWeight={600} noWrap>{d.name}</Typography>
                   </Box>
                   <Chip size="small" label={d.type === "data_flow" ? "Data Flow" : "Free Draw"} />
                   {d.updated_at && (


### PR DESCRIPTION
Embed DrawIO via iframe postMessage protocol (embed=1&proto=json) so diagram XML is stored in PostgreSQL JSONB and never exposed publicly.

- DiagramEditor: full DrawIO iframe integration with load/save/exit/export
- Save captures SVG thumbnail on each save for list view previews
- DiagramsPage: show SVG thumbnail cards instead of plain text
- Backend: return thumbnail in list endpoint, auth-gate GET endpoint
- Nginx: add /drawio/ location for optional self-hosted DrawIO
- Dockerfile: document steps to bundle DrawIO for air-gapped deploys
- Configurable VITE_DRAWIO_URL to switch between hosted and self-hosted

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg