### PR TITLE
Self-host DrawIO in the same container via multi-stage Docker build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # Deployment — port exposed on the Unraid host
 HOST_PORT=8920
+
+# DrawIO — self-hosted by default (bundled in the Docker image).
+# For local dev without Docker, create frontend/.env.development with:
+#   VITE_DRAWIO_URL=https://embed.diagrams.net

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,24 +6,20 @@ RUN npm install
 COPY . .
 RUN npm run build
 
+# ---------------------------------------------------------------------------
+# DrawIO stage — clone the open-source webapp (static files only, ~50 MB).
+# Pin to a release tag for reproducible builds.
+# ---------------------------------------------------------------------------
+FROM alpine/git:latest AS drawio
+RUN git clone --depth 1 --branch v26.0.9 https://github.com/jgraph/drawio.git /drawio
+
 FROM nginx:alpine AS production
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Self-hosted DrawIO (optional).
-# To enable air-gapped DrawIO (no external requests to embed.diagrams.net):
-#
-# 1. Download a DrawIO release:
-#      git clone --depth 1 --branch v24.7.17 https://github.com/jgraph/drawio.git /tmp/drawio
-#
-# 2. Uncomment the COPY line below to bundle it into the image:
-# COPY /tmp/drawio/src/main/webapp /usr/share/nginx/drawio
-#
-# 3. Set VITE_DRAWIO_URL=/drawio/index.html in your build environment
-#    so the frontend loads DrawIO from your server instead of embed.diagrams.net.
-#
-# Alternatively, mount a volume with DrawIO files at /usr/share/nginx/drawio/
-# in docker-compose.yml.
+# Copy DrawIO static webapp into Nginx.
+# Only the webapp directory is needed — no Java, no Electron, no build tools.
+COPY --from=drawio /drawio/src/main/webapp /usr/share/nginx/drawio
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,22 +21,13 @@ server {
         proxy_read_timeout 86400s;
     }
 
-    # Self-hosted DrawIO (optional).
-    # To enable: download the DrawIO release and extract to /usr/share/nginx/drawio/
-    # See Dockerfile comments for instructions.
+    # Self-hosted DrawIO — static webapp served from the same container.
+    # Loaded inside an iframe by the diagram editor; never accessed directly.
     location /drawio/ {
         alias /usr/share/nginx/drawio/;
-        try_files $uri $uri/ =404;
-
-        # Prevent search engines from indexing self-hosted DrawIO
         add_header X-Robots-Tag "noindex, nofollow" always;
-
-        # DrawIO assets are versioned, cache aggressively
-        location ~* \.(js|css|png|jpg|svg|woff|woff2)$ {
-            alias /usr/share/nginx/drawio/;
-            expires 30d;
-            add_header Cache-Control "public";
-        }
+        expires 30d;
+        add_header Cache-Control "public";
     }
 
     # SPA fallback

--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -10,13 +10,14 @@ import { api } from "@/api/client";
 
 /**
  * DrawIO embed mode URL.
- * In production, replace with self-hosted path: "/drawio/index.html"
- * to avoid loading external scripts. See nginx.conf for setup.
+ * Defaults to self-hosted path (DrawIO static files bundled in the Docker image).
+ * Override with VITE_DRAWIO_URL env var if needed (e.g. "https://embed.diagrams.net"
+ * for local dev without Docker).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _meta = import.meta as any;
 const DRAWIO_BASE_URL: string =
-  _meta.env?.VITE_DRAWIO_URL || "https://embed.diagrams.net";
+  _meta.env?.VITE_DRAWIO_URL || "/drawio/index.html";
 
 const DRAWIO_URL_PARAMS = new URLSearchParams({
   embed: "1",


### PR DESCRIPTION
DrawIO's web editor is pure static files — no runtime needed. The Dockerfile now clones the DrawIO repo (pinned to v26.0.9) in a build stage and copies only src/main/webapp (~50MB) into the Nginx container at /drawio/.

- Dockerfile: add drawio git clone stage, COPY webapp into nginx
- nginx.conf: simplified /drawio/ location block with alias
- DiagramEditor: default to /drawio/index.html (self-hosted)
- .env.example: document VITE_DRAWIO_URL override for local dev

Zero external requests in production — fully air-gapped diagramming.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg