### PR TITLE
Add fact sheet sidebar with click-to-insert into DrawIO diagrams

### DIFF
--- a/frontend/src/features/diagrams/DiagramsPage.tsx
+++ b/frontend/src/features/diagrams/DiagramsPage.tsx
@@ -25,6 +25,7 @@ interface DiagramSummary {
   name: string;
   type: string;
   thumbnail?: string;
+  fact_sheet_count?: number;
   created_at?: string;
   updated_at?: string;
 }
@@ -115,6 +116,14 @@ export default function DiagramsPage() {
                     <Typography variant="subtitle1" fontWeight={600} noWrap>{d.name}</Typography>
                   </Box>
                   <Chip size="small" label={d.type === "data_flow" ? "Data Flow" : "Free Draw"} />
+                  {!!d.fact_sheet_count && (
+                    <Chip
+                      size="small"
+                      label={`${d.fact_sheet_count} fact sheet${d.fact_sheet_count > 1 ? "s" : ""}`}
+                      variant="outlined"
+                      sx={{ ml: 0.5 }}
+                    />
+                  )}
                   {d.updated_at && (
                     <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
                       Updated: {new Date(d.updated_at).toLocaleDateString()}

--- a/frontend/src/features/diagrams/FactSheetSidebar.tsx
+++ b/frontend/src/features/diagrams/FactSheetSidebar.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect, useMemo } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Collapse from "@mui/material/Collapse";
+import Chip from "@mui/material/Chip";
+import InputAdornment from "@mui/material/InputAdornment";
+import Tooltip from "@mui/material/Tooltip";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { FactSheetType, FactSheet, FactSheetListResponse } from "@/types";
+
+interface Props {
+  onInsert: (fs: FactSheet, fsType: FactSheetType) => void;
+}
+
+export default function FactSheetSidebar({ onInsert }: Props) {
+  const [types, setTypes] = useState<FactSheetType[]>([]);
+  const [factSheets, setFactSheets] = useState<FactSheet[]>([]);
+  const [search, setSearch] = useState("");
+  const [expandedType, setExpandedType] = useState<string | null>(null);
+  const [loadingType, setLoadingType] = useState<string | null>(null);
+
+  // Load fact sheet types on mount
+  useEffect(() => {
+    api
+      .get<FactSheetType[]>("/metamodel/types")
+      .then((t) => setTypes(t.filter((x) => !x.is_hidden)));
+  }, []);
+
+  // Load fact sheets when a type group is expanded or search changes
+  useEffect(() => {
+    const params = new URLSearchParams({ page_size: "200" });
+    if (expandedType) params.set("type", expandedType);
+    if (search.trim()) params.set("search", search.trim());
+
+    // Only fetch when there's an expanded type or a search query
+    if (!expandedType && !search.trim()) {
+      setFactSheets([]);
+      return;
+    }
+
+    setLoadingType(expandedType);
+    api
+      .get<FactSheetListResponse>(`/fact-sheets?${params}`)
+      .then((r) => setFactSheets(r.items))
+      .finally(() => setLoadingType(null));
+  }, [expandedType, search]);
+
+  // Group fact sheets by type (when searching across all types)
+  const grouped = useMemo(() => {
+    const map = new Map<string, FactSheet[]>();
+    for (const fs of factSheets) {
+      const arr = map.get(fs.type) || [];
+      arr.push(fs);
+      map.set(fs.type, arr);
+    }
+    return map;
+  }, [factSheets]);
+
+  const toggleType = (key: string) => {
+    setExpandedType((prev) => (prev === key ? null : key));
+  };
+
+  const isSearchMode = search.trim().length > 0;
+
+  // In search mode, show all matching types that have results
+  // In browse mode, show all types but only expand the selected one
+  const visibleTypes = isSearchMode
+    ? types.filter((t) => grouped.has(t.key))
+    : types;
+
+  return (
+    <Box
+      sx={{
+        width: 280,
+        borderRight: "1px solid #e0e0e0",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        bgcolor: "#fafafa",
+      }}
+    >
+      {/* Header */}
+      <Box sx={{ px: 1.5, py: 1, borderBottom: "1px solid #eee" }}>
+        <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+          Fact Sheets
+        </Typography>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <MaterialSymbol icon="search" size={18} color="#999" />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* Type groups */}
+      <Box sx={{ flex: 1, overflow: "auto" }}>
+        <List dense disablePadding>
+          {visibleTypes.map((t) => {
+            const isExpanded = isSearchMode
+              ? grouped.has(t.key)
+              : expandedType === t.key;
+            const items = grouped.get(t.key) || [];
+
+            return (
+              <Box key={t.key}>
+                {/* Type header */}
+                <ListItemButton
+                  onClick={() => toggleType(t.key)}
+                  sx={{ py: 0.5, gap: 1 }}
+                >
+                  <MaterialSymbol icon={t.icon} size={18} color={t.color} />
+                  <ListItemText
+                    primary={t.label}
+                    primaryTypographyProps={{
+                      variant: "body2",
+                      fontWeight: 600,
+                      noWrap: true,
+                    }}
+                  />
+                  {isExpanded && items.length > 0 && (
+                    <Chip label={items.length} size="small" sx={{ height: 20, fontSize: 11 }} />
+                  )}
+                  <MaterialSymbol
+                    icon={isExpanded ? "expand_less" : "expand_more"}
+                    size={18}
+                    color="#999"
+                  />
+                </ListItemButton>
+
+                {/* Fact sheet items */}
+                <Collapse in={isExpanded} unmountOnExit>
+                  {loadingType === t.key && items.length === 0 ? (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ pl: 5, py: 0.5, display: "block" }}
+                    >
+                      Loading...
+                    </Typography>
+                  ) : items.length === 0 && isExpanded ? (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ pl: 5, py: 0.5, display: "block" }}
+                    >
+                      No fact sheets found
+                    </Typography>
+                  ) : (
+                    <List dense disablePadding>
+                      {items.map((fs) => (
+                        <Tooltip
+                          key={fs.id}
+                          title={`Click to insert "${fs.name}" into diagram`}
+                          placement="right"
+                          arrow
+                        >
+                          <ListItemButton
+                            sx={{ pl: 5, py: 0.25 }}
+                            onClick={() => onInsert(fs, t)}
+                          >
+                            <ListItemText
+                              primary={fs.name}
+                              primaryTypographyProps={{
+                                variant: "body2",
+                                noWrap: true,
+                              }}
+                            />
+                          </ListItemButton>
+                        </Tooltip>
+                      ))}
+                    </List>
+                  )}
+                </Collapse>
+              </Box>
+            );
+          })}
+        </List>
+
+        {visibleTypes.length === 0 && search.trim() && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ textAlign: "center", py: 3 }}
+          >
+            No results
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/features/diagrams/drawio-shapes.ts
+++ b/frontend/src/features/diagrams/drawio-shapes.ts
@@ -1,0 +1,85 @@
+/**
+ * Generates DrawIO mxGraphModel XML for inserting fact sheet shapes.
+ *
+ * Uses <object> elements with custom attributes (factSheetId, factSheetType)
+ * so we can extract references when parsing the saved diagram XML.
+ * This is the standard DrawIO pattern for metadata on cells.
+ */
+
+/** Darken a hex color by a factor (0-1) for stroke color */
+function darken(hex: string, factor = 0.25): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const d = (v: number) =>
+    Math.round(v * (1 - factor))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${d(r)}${d(g)}${d(b)}`;
+}
+
+/** Escape XML special characters */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface InsertFactSheetOpts {
+  factSheetId: string;
+  factSheetType: string;
+  name: string;
+  color: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * Build the mxGraphModel XML to merge a single fact sheet shape into DrawIO.
+ * The shape is a rounded rectangle colored by the type, with metadata stored
+ * as attributes on the <object> element.
+ */
+export function buildFactSheetXml(opts: InsertFactSheetOpts): string {
+  const { factSheetId, factSheetType, name, color, x, y } = opts;
+  const stroke = darken(color);
+  const cellId = `fs-${factSheetId.slice(0, 8)}-${Date.now()}`;
+
+  const style = [
+    "rounded=1",
+    "whiteSpace=wrap",
+    "html=1",
+    `fillColor=${color}`,
+    "fontColor=#ffffff",
+    `strokeColor=${stroke}`,
+    "fontSize=12",
+    "fontStyle=1",
+    "arcSize=12",
+    "shadow=1",
+  ].join(";");
+
+  return [
+    '<mxGraphModel><root>',
+    `<object label="${esc(name)}" factSheetId="${esc(factSheetId)}" factSheetType="${esc(factSheetType)}" id="${cellId}">`,
+    `<mxCell style="${style}" vertex="1" parent="1">`,
+    `<mxGeometry x="${x}" y="${y}" width="180" height="60" as="geometry"/>`,
+    "</mxCell>",
+    "</object>",
+    "</root></mxGraphModel>",
+  ].join("");
+}
+
+/**
+ * Parse diagram XML and return the set of factSheetId values found.
+ * Used client-side for display; the backend does its own authoritative parse.
+ */
+export function extractFactSheetIds(xml: string): string[] {
+  const ids: string[] = [];
+  const re = /factSheetId="([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) {
+    if (!ids.includes(m[1])) ids.push(m[1]);
+  }
+  return ids;
+}


### PR DESCRIPTION
Fact sheets can now be browsed by type and inserted as styled shapes in the DrawIO editor. Each shape carries factSheetId/factSheetType metadata via DrawIO's <object> element pattern.

Frontend:
- FactSheetSidebar: searchable, type-grouped panel with click-to-insert
- drawio-shapes.ts: generates mxGraphModel XML with type-colored shapes
- DiagramEditor: sidebar layout + merge postMessage to inject shapes
- DiagramsPage: shows fact sheet count badge on diagram cards

Backend:
- Regex-based extraction of factSheetId UUIDs from diagram XML on save
- fact_sheet_refs stored in JSONB data alongside xml/thumbnail
- List endpoint returns fact_sheet_count per diagram

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg