### PR TITLE
Fix Nginx serving DrawIO assets from wrong root

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,7 +23,7 @@ server {
 
     # Self-hosted DrawIO — static webapp served from the same container.
     # Loaded inside an iframe by the diagram editor; never accessed directly.
-    location /drawio/ {
+    location ^~ /drawio/ {
         alias /usr/share/nginx/drawio/;
         add_header X-Robots-Tag "noindex, nofollow" always;
         expires 30d;


### PR DESCRIPTION
The regex location for static asset caching (~* \.(js|css|...)$) had higher priority than the regular prefix /drawio/ location, so DrawIO sub-resources were resolved against /usr/share/nginx/html/ instead of /usr/share/nginx/drawio/.

Fix: add ^~ modifier to the /drawio/ location block so it takes priority over regex matches for any request under /drawio/*.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg