### PR TITLE
Move sidebar nav to top bar, fix DrawIO integration, add right-click …

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,5 +21,13 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Only the webapp directory is needed — no Java, no Electron, no build tools.
 COPY --from=drawio /drawio/src/main/webapp /usr/share/nginx/drawio
 
+# Add custom DrawIO configuration files:
+#   PreConfig.js    — right-click "Insert Fact Sheet" context menu item
+#   grapheditor.css — custom style overrides (placeholder to suppress 404)
+#   high-contrast.css — accessibility overrides (placeholder to suppress 404)
+COPY drawio-config/PreConfig.js      /usr/share/nginx/drawio/js/PreConfig.js
+COPY drawio-config/grapheditor.css   /usr/share/nginx/drawio/styles/grapheditor.css
+COPY drawio-config/high-contrast.css /usr/share/nginx/drawio/styles/high-contrast.css
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/drawio-config/PreConfig.js
+++ b/frontend/drawio-config/PreConfig.js
@@ -1,0 +1,50 @@
+/**
+ * DrawIO PreConfig.js — loaded automatically by the self-hosted DrawIO editor.
+ *
+ * Adds an "Insert Fact Sheet" item to the right-click context menu.
+ * When clicked it posts a message to the parent window (our React app)
+ * which opens a picker dialog and merges the selected shape back.
+ */
+
+/* global Draw, mxResources, mxEvent, mxPopupMenu */
+
+Draw.loadPlugin(function (ui) {
+  // Wait until the editor is fully initialised
+  var graph = ui.editor.graph;
+
+  // Patch the popup-menu factory so we can append our custom item
+  var origFactory = ui.menus.createPopupMenu;
+  ui.menus.createPopupMenu = function (menu, cell, evt) {
+    // Call the original factory first so all default items are added
+    origFactory.apply(this, arguments);
+
+    menu.addSeparator();
+
+    // Compute the graph-space coordinates of the click so we can position
+    // the inserted shape exactly where the user right-clicked.
+    var pt = mxEvent.getClientXY
+      ? new (graph.container.ownerDocument.defaultView || window).DOMPoint(
+          mxEvent.getClientX(evt),
+          mxEvent.getClientY(evt)
+        )
+      : { x: mxEvent.getClientX(evt), y: mxEvent.getClientY(evt) };
+
+    var offset = graph.container.getBoundingClientRect();
+    var s = graph.view.scale;
+    var tr = graph.view.translate;
+
+    var graphX = Math.round((pt.x - offset.left) / s - tr.x);
+    var graphY = Math.round((pt.y - offset.top) / s - tr.y);
+
+    menu.addItem("Insert Fact Sheet\u2026", null, function () {
+      window.parent.postMessage(
+        JSON.stringify({
+          event: "insertFactSheet",
+          x: graphX,
+          y: graphY,
+        }),
+        "*"
+      );
+    });
+  };
+});

--- a/frontend/drawio-config/grapheditor.css
+++ b/frontend/drawio-config/grapheditor.css
@@ -1,0 +1,1 @@
+/* Custom grapheditor overrides — intentionally empty */

--- a/frontend/drawio-config/high-contrast.css
+++ b/frontend/drawio-config/high-contrast.css
@@ -1,0 +1,1 @@
+/* High-contrast theme overrides — intentionally empty */

--- a/frontend/src/features/diagrams/FactSheetPickerDialog.tsx
+++ b/frontend/src/features/diagrams/FactSheetPickerDialog.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import Chip from "@mui/material/Chip";
+import Box from "@mui/material/Box";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { FactSheetType, FactSheet, FactSheetListResponse } from "@/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onInsert: (fs: FactSheet, fsType: FactSheetType) => void;
+}
+
+export default function FactSheetPickerDialog({
+  open,
+  onClose,
+  onInsert,
+}: Props) {
+  const [types, setTypes] = useState<FactSheetType[]>([]);
+  const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [factSheets, setFactSheets] = useState<FactSheet[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Load types once
+  useEffect(() => {
+    if (!open) return;
+    api
+      .get<FactSheetType[]>("/metamodel/types")
+      .then((t) => setTypes(t.filter((x) => !x.is_hidden)));
+  }, [open]);
+
+  // Search fact sheets when type or search changes
+  useEffect(() => {
+    if (!open) return;
+    const params = new URLSearchParams({ page_size: "100" });
+    if (selectedType) params.set("type", selectedType);
+    if (search.trim()) params.set("search", search.trim());
+
+    if (!selectedType && !search.trim()) {
+      setFactSheets([]);
+      return;
+    }
+
+    setLoading(true);
+    api
+      .get<FactSheetListResponse>(`/fact-sheets?${params}`)
+      .then((r) => setFactSheets(r.items))
+      .finally(() => setLoading(false));
+  }, [open, selectedType, search]);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setSelectedType(null);
+      setSearch("");
+      setFactSheets([]);
+    }
+  }, [open]);
+
+  const typeMap = useMemo(
+    () => new Map(types.map((t) => [t.key, t])),
+    [types]
+  );
+
+  const handleSelect = useCallback(
+    (fs: FactSheet) => {
+      const fsType = typeMap.get(fs.type);
+      if (fsType) {
+        onInsert(fs, fsType);
+        onClose();
+      }
+    },
+    [typeMap, onInsert, onClose]
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>Insert Fact Sheet</DialogTitle>
+      <DialogContent>
+        {/* Search */}
+        <TextField
+          autoFocus
+          size="small"
+          fullWidth
+          placeholder="Search fact sheets..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ mb: 2 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <MaterialSymbol icon="search" size={18} color="#999" />
+              </InputAdornment>
+            ),
+          }}
+        />
+
+        {/* Type filter chips */}
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mb: 2 }}>
+          {types.map((t) => (
+            <Chip
+              key={t.key}
+              label={t.label}
+              size="small"
+              icon={
+                <MaterialSymbol
+                  icon={t.icon}
+                  size={16}
+                  color={selectedType === t.key ? "#fff" : t.color}
+                />
+              }
+              variant={selectedType === t.key ? "filled" : "outlined"}
+              sx={
+                selectedType === t.key
+                  ? { bgcolor: t.color, color: "#fff" }
+                  : {}
+              }
+              onClick={() =>
+                setSelectedType((prev) => (prev === t.key ? null : t.key))
+              }
+            />
+          ))}
+        </Box>
+
+        {/* Results */}
+        <Box
+          sx={{
+            maxHeight: 360,
+            overflow: "auto",
+            border: "1px solid #e0e0e0",
+            borderRadius: 1,
+          }}
+        >
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : factSheets.length === 0 ? (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ textAlign: "center", py: 4 }}
+            >
+              {selectedType || search.trim()
+                ? "No fact sheets found"
+                : "Select a type or search to browse"}
+            </Typography>
+          ) : (
+            <List dense disablePadding>
+              {factSheets.map((fs) => {
+                const t = typeMap.get(fs.type);
+                return (
+                  <ListItemButton key={fs.id} onClick={() => handleSelect(fs)}>
+                    {t && (
+                      <MaterialSymbol
+                        icon={t.icon}
+                        size={18}
+                        color={t.color}
+                      />
+                    )}
+                    <ListItemText
+                      primary={fs.name}
+                      secondary={t?.label}
+                      primaryTypographyProps={{ noWrap: true, ml: 1 }}
+                      secondaryTypographyProps={{
+                        noWrap: true,
+                        ml: 1,
+                        fontSize: 11,
+                      }}
+                    />
+                  </ListItemButton>
+                );
+              })}
+            </List>
+          )}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/diagrams/drawio-shapes.ts
+++ b/frontend/src/features/diagrams/drawio-shapes.ts
@@ -61,6 +61,8 @@ export function buildFactSheetXml(opts: InsertFactSheetOpts): string {
 
   return [
     '<mxGraphModel><root>',
+    '<mxCell id="0"/>',
+    '<mxCell id="1" parent="0"/>',
     `<object label="${esc(name)}" factSheetId="${esc(factSheetId)}" factSheetType="${esc(factSheetType)}" id="${cellId}">`,
     `<mxCell style="${style}" vertex="1" parent="1">`,
     `<mxGeometry x="${x}" y="${y}" width="180" height="60" as="geometry"/>`,


### PR DESCRIPTION
…Insert Fact Sheet

- Replace the left sidebar Drawer with horizontal navigation buttons in the AppBar toolbar.  Reports and Admin use dropdown menus.  This gives the full viewport width to page content and the diagram editor.

- Fix mxCellCodec "parent 1 not found" warnings by including the mandatory root cells (id="0", id="1") in the merge XML sent to DrawIO.

- Add a custom PreConfig.js loaded by the self-hosted DrawIO editor that injects an "Insert Fact Sheet…" item into the right-click context menu. Clicking it posts a message with the graph-space (x,y) coordinates back to the parent window, which opens a FactSheetPickerDialog with type filter chips and search.  The selected fact sheet is merged at the exact click position.

- Create placeholder grapheditor.css and high-contrast.css to suppress the 404 errors DrawIO logs on startup.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg