### PR TITLE
Fix fact sheet insertion: use mxGraph API instead of XML merge

### DIFF
--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -10,7 +10,7 @@ import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import FactSheetSidebar from "./FactSheetSidebar";
 import FactSheetPickerDialog from "./FactSheetPickerDialog";
-import { buildFactSheetXml } from "./drawio-shapes";
+import { buildFactSheetCell } from "./drawio-shapes";
 import type { FactSheet, FactSheetType } from "@/types";
 
 /**
@@ -125,7 +125,7 @@ export default function DiagramEditor() {
     [diagram]
   );
 
-  /** Insert a fact sheet shape into DrawIO via the merge action */
+  /** Insert a fact sheet shape into DrawIO via PreConfig.js graph API */
   const handleInsertFactSheet = useCallback(
     (fs: FactSheet, fsType: FactSheetType) => {
       // Use right-click position if available, otherwise fall back to grid layout
@@ -143,7 +143,7 @@ export default function DiagramEditor() {
       }
       insertCountRef.current += 1;
 
-      const xml = buildFactSheetXml({
+      const msg = buildFactSheetCell({
         factSheetId: fs.id,
         factSheetType: fs.type,
         name: fs.name,
@@ -152,7 +152,7 @@ export default function DiagramEditor() {
         y,
       });
 
-      postToDrawIO({ action: "merge", xml });
+      postToDrawIO(msg);
       setSnackMsg(`Inserted "${fs.name}"`);
     },
     [postToDrawIO]


### PR DESCRIPTION
The DrawIO merge action has a fundamental conflict with root cells: including id="0"/id="1" replaces the entire graph (deletes existing shapes), but omitting them causes the codec to drop the cell since parent="1" can't be resolved.

Switch to a direct mxGraph API approach:
- PreConfig.js now listens for a custom "insertFactSheetCell" message and calls graph.insertVertex() directly with an <object> element carrying factSheetId/factSheetType attributes
- buildFactSheetCell() returns a plain message payload instead of XML
- DiagramEditor posts this message instead of the merge action

This fixes both issues: shapes now appear on the current page and inserting multiple fact sheets no longer removes previous ones.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg