### PR TITLE
Remove sidebar, insert fact sheets at right-click position or visible…

### DIFF
--- a/frontend/src/features/diagrams/drawio-shapes.ts
+++ b/frontend/src/features/diagrams/drawio-shapes.ts
@@ -128,6 +128,31 @@ export function insertFactSheetIntoGraph(
 }
 
 /**
+ * Return the graph-space coordinates of the center of the currently visible
+ * portion of the DrawIO canvas.  Useful as a fallback insertion position.
+ */
+export function getVisibleCenter(iframe: HTMLIFrameElement): { x: number; y: number } | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = iframe.contentWindow as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const graph: any = win?.__turboGraph;
+    if (!graph) return null;
+
+    const container = graph.container as HTMLElement;
+    const s = graph.view.scale as number;
+    const tr = graph.view.translate as { x: number; y: number };
+
+    const cx = (container.scrollLeft + container.clientWidth / 2) / s - tr.x;
+    const cy = (container.scrollTop + container.clientHeight / 2) / s - tr.y;
+
+    return { x: Math.round(cx), y: Math.round(cy) };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Parse diagram XML and return the set of factSheetId values found.
  * Used client-side for display; the backend does its own authoritative parse.
  */


### PR DESCRIPTION
… center

- Remove FactSheetSidebar and its toggle button from the diagram editor. Insertion is now exclusively via right-click > "Insert Fact Sheet…".

- When inserting from the picker dialog, use the right-click graph-space coordinates.  If unavailable (shouldn't happen), fall back to the center of the currently visible canvas area via getVisibleCenter().

- Add getVisibleCenter() helper that reads the graph container's scroll position and viewport size to compute graph-space center coordinates.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg