### PR TITLE
Fix inventory scrolling, create dialog, and add relationship columns/…

### DIFF
--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -324,7 +324,7 @@ export default function DiagramEditor() {
   const iframeSrc = `${DRAWIO_BASE_URL}?${DRAWIO_URL_PARAMS}`;
 
   return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+    <Box sx={{ height: "calc(100vh - 64px)", m: -3, display: "flex", flexDirection: "column" }}>
       {/* Toolbar */}
       <Box
         sx={{


### PR DESCRIPTION
…filters

- Fix vertical scrolling: use calc(100vh - 64px) with negative margins for full-bleed pages (Inventory, Diagrams) so other pages scroll normally
- Fix Create dialog not opening when clicking top nav Create button while already on inventory page (useEffect watches searchParams changes)
- Fetch relations per type and display as grid columns with semicolon-separated names when multiple relations exist to the same fact sheet type
- Add Relationships filter section in sidebar with dropdowns per relation type showing unique related fact sheet names for filtering

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg