### PR TITLE
Fix fact sheet insertion position: account for container scroll offset

### DIFF
--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -98,14 +98,15 @@ function bootstrapDrawIO(iframe: HTMLIFrameElement) {
           menu.addSeparator();
 
           const mxEvent = win.mxEvent;
-          const offset = graph.container.getBoundingClientRect();
+          const container = graph.container;
+          const offset = container.getBoundingClientRect();
           const s = graph.view.scale;
           const tr = graph.view.translate;
           const gx = Math.round(
-            (mxEvent.getClientX(evt) - offset.left) / s - tr.x
+            (mxEvent.getClientX(evt) - offset.left + container.scrollLeft) / s - tr.x
           );
           const gy = Math.round(
-            (mxEvent.getClientY(evt) - offset.top) / s - tr.y
+            (mxEvent.getClientY(evt) - offset.top + container.scrollTop) / s - tr.y
           );
 
           menu.addItem("Insert Fact Sheet\u2026", null, () => {


### PR DESCRIPTION
The right-click context menu coordinate calculation was missing the graph container's scrollLeft/scrollTop, causing shapes to be inserted at wrong positions when the canvas was panned/scrolled.

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg