### PR TITLE
Add diagram rename, delete, description, and card/list view toggle

### DIFF
--- a/backend/alembic/versions/003_add_diagram_description.py
+++ b/backend/alembic/versions/003_add_diagram_description.py
@@ -1,0 +1,23 @@
+"""add description column to diagrams table
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-02-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("diagrams", sa.Column("description", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("diagrams", "description")

--- a/backend/app/models/diagram.py
+++ b/backend/app/models/diagram.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,6 +13,7 @@ class Diagram(Base, UUIDMixin, TimestampMixin):
     __tablename__ = "diagrams"
 
     name: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
     type: Mapped[str] = mapped_column(String(50), default="free_draw")
     data: Mapped[dict | None] = mapped_column(JSONB, default=dict)
     created_by: Mapped[uuid.UUID | None] = mapped_column(

--- a/frontend/src/features/diagrams/DiagramsPage.tsx
+++ b/frontend/src/features/diagrams/DiagramsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -6,6 +6,7 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardActionArea from "@mui/material/CardActionArea";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -17,12 +18,25 @@ import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import Grid from "@mui/material/Grid";
 import Chip from "@mui/material/Chip";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import Menu from "@mui/material/Menu";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 
 interface DiagramSummary {
   id: string;
   name: string;
+  description?: string;
   type: string;
   thumbnail?: string;
   fact_sheet_count?: number;
@@ -30,129 +44,447 @@ interface DiagramSummary {
   updated_at?: string;
 }
 
+type ViewMode = "card" | "list";
+
 export default function DiagramsPage() {
   const navigate = useNavigate();
   const [diagrams, setDiagrams] = useState<DiagramSummary[]>([]);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [type, setType] = useState("free_draw");
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    () => (localStorage.getItem("diagrams_view") as ViewMode) || "card"
+  );
 
-  useEffect(() => {
+  // Create dialog
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createDesc, setCreateDesc] = useState("");
+  const [createType, setCreateType] = useState("free_draw");
+
+  // Edit dialog (rename + description)
+  const [editOpen, setEditOpen] = useState(false);
+  const [editDiagram, setEditDiagram] = useState<DiagramSummary | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDesc, setEditDesc] = useState("");
+
+  // Delete confirmation
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteDiagram, setDeleteDiagram] = useState<DiagramSummary | null>(null);
+
+  // Context menu
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuDiagram, setMenuDiagram] = useState<DiagramSummary | null>(null);
+
+  const loadDiagrams = useCallback(() => {
     api.get<DiagramSummary[]>("/diagrams").then(setDiagrams);
   }, []);
 
+  useEffect(() => {
+    loadDiagrams();
+  }, [loadDiagrams]);
+
+  const handleViewChange = (_: unknown, mode: ViewMode | null) => {
+    if (mode) {
+      setViewMode(mode);
+      localStorage.setItem("diagrams_view", mode);
+    }
+  };
+
   const handleCreate = async () => {
-    if (!name.trim()) return;
-    const d = await api.post<{ id: string }>("/diagrams", { name, type });
+    if (!createName.trim()) return;
+    const d = await api.post<{ id: string }>("/diagrams", {
+      name: createName,
+      description: createDesc.trim() || undefined,
+      type: createType,
+    });
     setCreateOpen(false);
-    setName("");
+    setCreateName("");
+    setCreateDesc("");
+    setCreateType("free_draw");
     navigate(`/diagrams/${d.id}`);
   };
 
+  const openEdit = (d: DiagramSummary) => {
+    setEditDiagram(d);
+    setEditName(d.name);
+    setEditDesc(d.description || "");
+    setEditOpen(true);
+    setMenuAnchor(null);
+  };
+
+  const handleEdit = async () => {
+    if (!editDiagram || !editName.trim()) return;
+    await api.patch(`/diagrams/${editDiagram.id}`, {
+      name: editName.trim(),
+      description: editDesc.trim() || null,
+    });
+    setEditOpen(false);
+    setEditDiagram(null);
+    loadDiagrams();
+  };
+
+  const openDelete = (d: DiagramSummary) => {
+    setDeleteDiagram(d);
+    setDeleteOpen(true);
+    setMenuAnchor(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteDiagram) return;
+    await api.delete(`/diagrams/${deleteDiagram.id}`);
+    setDeleteOpen(false);
+    setDeleteDiagram(null);
+    loadDiagrams();
+  };
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>, d: DiagramSummary) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+    setMenuDiagram(d);
+  };
+
+  const typeLabel = (t: string) => (t === "data_flow" ? "Data Flow" : "Free Draw");
+  const typeIcon = (t: string) => (t === "data_flow" ? "device_hub" : "draw");
+  const fmtDate = (iso?: string) =>
+    iso ? new Date(iso).toLocaleDateString() : "";
+
   return (
     <Box>
+      {/* Header */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 3 }}>
-        <Typography variant="h5" fontWeight={600}>Diagrams</Typography>
+        <Typography variant="h5" fontWeight={600}>
+          Diagrams
+        </Typography>
+        <Chip label={`${diagrams.length}`} size="small" />
         <Box sx={{ flex: 1 }} />
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={handleViewChange}
+          size="small"
+        >
+          <ToggleButton value="card">
+            <MaterialSymbol icon="grid_view" size={18} />
+          </ToggleButton>
+          <ToggleButton value="list">
+            <MaterialSymbol icon="view_list" size={18} />
+          </ToggleButton>
+        </ToggleButtonGroup>
         <Button
           variant="contained"
           startIcon={<MaterialSymbol icon="add" size={18} />}
           onClick={() => setCreateOpen(true)}
+          sx={{ textTransform: "none" }}
         >
           New Diagram
         </Button>
       </Box>
 
-      <Grid container spacing={2}>
-        {diagrams.map((d) => (
-          <Grid item xs={12} sm={6} md={4} key={d.id}>
-            <Card>
-              <CardActionArea onClick={() => navigate(`/diagrams/${d.id}`)}>
-                {/* Thumbnail preview */}
-                {d.thumbnail ? (
-                  <Box
-                    sx={{
-                      height: 160,
-                      overflow: "hidden",
-                      bgcolor: "#fafafa",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      borderBottom: "1px solid #eee",
-                    }}
-                  >
-                    <img
-                      src={
-                        d.thumbnail.startsWith("data:")
-                          ? d.thumbnail
-                          : `data:image/svg+xml;base64,${btoa(d.thumbnail)}`
-                      }
-                      alt={d.name}
-                      style={{
-                        maxWidth: "100%",
-                        maxHeight: "100%",
-                        objectFit: "contain",
+      {/* Card View */}
+      {viewMode === "card" && (
+        <Grid container spacing={2}>
+          {diagrams.map((d) => (
+            <Grid item xs={12} sm={6} md={4} key={d.id}>
+              <Card sx={{ position: "relative" }}>
+                <CardActionArea onClick={() => navigate(`/diagrams/${d.id}`)}>
+                  {/* Thumbnail */}
+                  {d.thumbnail ? (
+                    <Box
+                      sx={{
+                        height: 160,
+                        overflow: "hidden",
+                        bgcolor: "#fafafa",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        borderBottom: "1px solid #eee",
                       }}
-                    />
-                  </Box>
-                ) : (
-                  <Box
-                    sx={{
-                      height: 160,
-                      bgcolor: "#fafafa",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      borderBottom: "1px solid #eee",
-                    }}
-                  >
-                    <MaterialSymbol icon="draw" size={48} color="#ccc" />
-                  </Box>
-                )}
-
-                <CardContent>
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
-                    <MaterialSymbol icon={d.type === "data_flow" ? "device_hub" : "draw"} size={24} color="#1976d2" />
-                    <Typography variant="subtitle1" fontWeight={600} noWrap>{d.name}</Typography>
-                  </Box>
-                  <Chip size="small" label={d.type === "data_flow" ? "Data Flow" : "Free Draw"} />
-                  {!!d.fact_sheet_count && (
-                    <Chip
-                      size="small"
-                      label={`${d.fact_sheet_count} fact sheet${d.fact_sheet_count > 1 ? "s" : ""}`}
-                      variant="outlined"
-                      sx={{ ml: 0.5 }}
-                    />
+                    >
+                      <img
+                        src={
+                          d.thumbnail.startsWith("data:")
+                            ? d.thumbnail
+                            : `data:image/svg+xml;base64,${btoa(d.thumbnail)}`
+                        }
+                        alt={d.name}
+                        style={{
+                          maxWidth: "100%",
+                          maxHeight: "100%",
+                          objectFit: "contain",
+                        }}
+                      />
+                    </Box>
+                  ) : (
+                    <Box
+                      sx={{
+                        height: 160,
+                        bgcolor: "#fafafa",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        borderBottom: "1px solid #eee",
+                      }}
+                    >
+                      <MaterialSymbol icon="draw" size={48} color="#ccc" />
+                    </Box>
                   )}
-                  {d.updated_at && (
-                    <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-                      Updated: {new Date(d.updated_at).toLocaleDateString()}
+
+                  <CardContent sx={{ pb: "12px !important" }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        mb: 0.5,
+                      }}
+                    >
+                      <MaterialSymbol
+                        icon={typeIcon(d.type)}
+                        size={24}
+                        color="#1976d2"
+                      />
+                      <Typography
+                        variant="subtitle1"
+                        fontWeight={600}
+                        noWrap
+                        sx={{ flex: 1 }}
+                      >
+                        {d.name}
+                      </Typography>
+                    </Box>
+                    {d.description && (
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{
+                          mb: 0.75,
+                          display: "-webkit-box",
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                          fontSize: 13,
+                        }}
+                      >
+                        {d.description}
+                      </Typography>
+                    )}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Chip size="small" label={typeLabel(d.type)} />
+                      {!!d.fact_sheet_count && (
+                        <Chip
+                          size="small"
+                          label={`${d.fact_sheet_count} fact sheet${d.fact_sheet_count > 1 ? "s" : ""}`}
+                          variant="outlined"
+                        />
+                      )}
+                      {d.updated_at && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ ml: "auto" }}
+                        >
+                          {fmtDate(d.updated_at)}
+                        </Typography>
+                      )}
+                    </Box>
+                  </CardContent>
+                </CardActionArea>
+
+                {/* More menu button */}
+                <IconButton
+                  size="small"
+                  sx={{
+                    position: "absolute",
+                    top: 4,
+                    right: 4,
+                    bgcolor: "rgba(255,255,255,0.85)",
+                    "&:hover": { bgcolor: "rgba(255,255,255,0.95)" },
+                  }}
+                  onClick={(e) => openMenu(e, d)}
+                >
+                  <MaterialSymbol icon="more_vert" size={18} />
+                </IconButton>
+              </Card>
+            </Grid>
+          ))}
+          {diagrams.length === 0 && (
+            <Grid item xs={12}>
+              <Typography
+                color="text.secondary"
+                sx={{ textAlign: "center", py: 4 }}
+              >
+                No diagrams yet. Create one to get started.
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      )}
+
+      {/* List View */}
+      {viewMode === "list" && (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Description</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: 120 }}>Type</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: 100 }} align="center">
+                  Fact Sheets
+                </TableCell>
+                <TableCell sx={{ fontWeight: 600, width: 120 }}>Updated</TableCell>
+                <TableCell sx={{ width: 48 }} />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {diagrams.map((d) => (
+                <TableRow
+                  key={d.id}
+                  hover
+                  sx={{ cursor: "pointer" }}
+                  onClick={() => navigate(`/diagrams/${d.id}`)}
+                >
+                  <TableCell>
+                    <Box
+                      sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                    >
+                      <MaterialSymbol
+                        icon={typeIcon(d.type)}
+                        size={20}
+                        color="#1976d2"
+                      />
+                      <Typography variant="body2" fontWeight={600} noWrap>
+                        {d.name}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ maxWidth: 300 }}
+                      title={d.description}
+                    >
+                      {d.description || "—"}
                     </Typography>
-                  )}
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        ))}
-        {diagrams.length === 0 && (
-          <Grid item xs={12}>
-            <Typography color="text.secondary" sx={{ textAlign: "center", py: 4 }}>
-              No diagrams yet. Create one to get started.
-            </Typography>
-          </Grid>
-        )}
-      </Grid>
+                  </TableCell>
+                  <TableCell>
+                    <Chip size="small" label={typeLabel(d.type)} />
+                  </TableCell>
+                  <TableCell align="center">
+                    {d.fact_sheet_count || 0}
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption" color="text.secondary">
+                      {fmtDate(d.updated_at)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => openMenu(e, d)}
+                    >
+                      <MaterialSymbol icon="more_vert" size={18} />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {diagrams.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                    <Typography color="text.secondary">
+                      No diagrams yet. Create one to get started.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
 
-      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="xs" fullWidth>
+      {/* Context menu */}
+      <Menu
+        anchorEl={menuAnchor}
+        open={!!menuAnchor}
+        onClose={() => setMenuAnchor(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            if (menuDiagram) navigate(`/diagrams/${menuDiagram.id}`);
+            setMenuAnchor(null);
+          }}
+        >
+          <ListItemIcon>
+            <MaterialSymbol icon="open_in_new" size={18} />
+          </ListItemIcon>
+          <ListItemText>Open</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (menuDiagram) openEdit(menuDiagram);
+          }}
+        >
+          <ListItemIcon>
+            <MaterialSymbol icon="edit" size={18} />
+          </ListItemIcon>
+          <ListItemText>Rename / Edit</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (menuDiagram) openDelete(menuDiagram);
+          }}
+          sx={{ color: "error.main" }}
+        >
+          <ListItemIcon>
+            <MaterialSymbol icon="delete" size={18} color="#d32f2f" />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      {/* Create Dialog */}
+      <Dialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>New Diagram</DialogTitle>
         <DialogContent>
           <TextField
-            fullWidth label="Name" value={name} onChange={(e) => setName(e.target.value)}
+            fullWidth
+            label="Name"
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
             sx={{ mt: 1, mb: 2 }}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && createName.trim()) handleCreate();
+            }}
+          />
+          <TextField
+            fullWidth
+            label="Description"
+            value={createDesc}
+            onChange={(e) => setCreateDesc(e.target.value)}
+            multiline
+            rows={2}
+            sx={{ mb: 2 }}
           />
           <FormControl fullWidth>
             <InputLabel>Type</InputLabel>
-            <Select value={type} label="Type" onChange={(e) => setType(e.target.value)}>
+            <Select
+              value={createType}
+              label="Type"
+              onChange={(e) => setCreateType(e.target.value)}
+            >
               <MenuItem value="free_draw">Free Draw</MenuItem>
               <MenuItem value="data_flow">Data Flow</MenuItem>
             </Select>
@@ -160,7 +492,76 @@ export default function DiagramsPage() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>Create</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={!createName.trim()}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Edit Diagram</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="Name"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            sx={{ mt: 1, mb: 2 }}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && editName.trim()) handleEdit();
+            }}
+          />
+          <TextField
+            fullWidth
+            label="Description"
+            value={editDesc}
+            onChange={(e) => setEditDesc(e.target.value)}
+            multiline
+            rows={3}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleEdit}
+            disabled={!editName.trim()}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <Dialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete Diagram</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete{" "}
+            <strong>{deleteDiagram?.name}</strong>? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteOpen(false)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDelete}>
+            Delete
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>


### PR DESCRIPTION
Backend:
- Add description column (Text, nullable) to Diagram model
- Update all API endpoints to support description field
- Add Alembic migration 003

Frontend DiagramsPage:
- Card/list view toggle (persisted to localStorage)
- Three-dot context menu on each diagram: Open, Rename/Edit, Delete
- Create dialog now includes description field
- Edit dialog for renaming and updating description
- Delete confirmation dialog
- Card view shows description (2-line clamp) and more button overlay
- List view shows table with Name, Description, Type, Fact Sheets, Updated

https://claude.ai/code/session_01MvqJzQ58y1N7pVCBP3Gtqg