### PR TITLE
Fix TOGAF phases to free text and link diagrams to initiatives

### DIFF
--- a/backend/app/models/diagram.py
+++ b/backend/app/models/diagram.py
@@ -16,6 +16,10 @@ class Diagram(Base, UUIDMixin, TimestampMixin):
     description: Mapped[str | None] = mapped_column(Text)
     type: Mapped[str] = mapped_column(String(50), default="free_draw")
     data: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    initiative_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("fact_sheets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id")
     )

--- a/frontend/src/features/ea-delivery/SoAWEditor.tsx
+++ b/frontend/src/features/ea-delivery/SoAWEditor.tsx
@@ -737,9 +737,9 @@ export default function SoAWEditor() {
                 <Table size="small">
                   <TableHead>
                     <TableRow sx={{ bgcolor: "grey.50" }}>
-                      <TableCell sx={{ fontWeight: 600 }}>Phase</TableCell>
-                      <TableCell sx={{ fontWeight: 600, width: 120, textAlign: "center" }}>
-                        In / Out
+                      <TableCell sx={{ fontWeight: 600, width: 280 }}>Phase</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>
+                        Relevant Artefacts
                       </TableCell>
                     </TableRow>
                   </TableHead>
@@ -749,9 +749,10 @@ export default function SoAWEditor() {
                         <TableCell>{phase.label}</TableCell>
                         <TableCell sx={{ p: 0.5 }}>
                           <TextField
-                            select
                             size="small"
                             fullWidth
+                            multiline
+                            placeholder="e.g. documents, diagrams, architecture decisions..."
                             value={data.togaf_data?.[phase.key] ?? ""}
                             onChange={(e) => {
                               const next = {
@@ -763,11 +764,7 @@ export default function SoAWEditor() {
                             variant="standard"
                             InputProps={{ disableUnderline: true }}
                             sx={{ px: 1 }}
-                          >
-                            <MenuItem value="">—</MenuItem>
-                            <MenuItem value="In">In</MenuItem>
-                            <MenuItem value="Out">Out</MenuItem>
-                          </TextField>
+                          />
                         </TableCell>
                       </TableRow>
                     ))}

--- a/frontend/src/features/ea-delivery/soawExport.ts
+++ b/frontend/src/features/ea-delivery/soawExport.ts
@@ -279,7 +279,7 @@ export async function exportToDocx(
     if (def.type === "togaf_phases" && data.togaf_data) {
       tables.push(
         buildDocxTable(
-          ["Phase", "In / Out"],
+          ["Phase", "Relevant Artefacts"],
           TOGAF_PHASES.map((p) => [p.label, data.togaf_data?.[p.key] ?? ""]),
         ),
       );
@@ -436,9 +436,9 @@ export function exportToPdf(
     }
 
     if (def.type === "togaf_phases" && data.togaf_data) {
-      html += `<table><tr><th>Phase</th><th>In / Out</th></tr>`;
+      html += `<table><tr><th>Phase</th><th>Relevant Artefacts</th></tr>`;
       for (const p of TOGAF_PHASES) {
-        html += `<tr><td>${p.label}</td><td style="text-align:center">${data.togaf_data[p.key] || "—"}</td></tr>`;
+        html += `<tr><td>${p.label}</td><td>${data.togaf_data[p.key] || "—"}</td></tr>`;
       }
       html += `</table>`;
     }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -258,6 +258,7 @@ export interface DiagramSummary {
   name: string;
   description?: string;
   type: string;
+  initiative_id?: string | null;
   thumbnail?: string;
   fact_sheet_count: number;
   created_at?: string;


### PR DESCRIPTION
Two improvements based on feedback:

1. Architecture Process (section 3.1): Changed from In/Out dropdown to free text input so users can describe relevant artefacts per phase (documents, diagrams, architecture decisions, etc.)

2. Diagram-Initiative linking: Added initiative_id to the Diagram model and API. Diagrams can now be linked to initiatives from:
   - Diagram create dialog
   - Diagram edit dialog (metadata level)
   - EA Delivery page now shows both diagrams and SoAWs grouped by initiative, with an "unlinked" section for artefacts not yet associated with any initiative.

https://claude.ai/code/session_013DhADSWjMTvquVUnEEn7ch