### PR TITLE
Fix migration 004 to handle create_all race condition

### DIFF
--- a/backend/alembic/versions/004_add_ea_delivery.py
+++ b/backend/alembic/versions/004_add_ea_delivery.py
@@ -17,49 +17,57 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Add initiative_id to diagrams
-    op.add_column(
-        "diagrams",
-        sa.Column(
-            "initiative_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("fact_sheets.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-    )
+    from sqlalchemy import inspect as sa_inspect
 
-    # Create statement_of_architecture_works table
-    op.create_table(
-        "statement_of_architecture_works",
-        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
-        sa.Column("name", sa.String(500), nullable=False),
-        sa.Column(
-            "initiative_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("fact_sheets.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("status", sa.String(50), server_default="draft"),
-        sa.Column("document_info", postgresql.JSONB(), server_default="{}"),
-        sa.Column("version_history", postgresql.JSONB(), server_default="[]"),
-        sa.Column("sections", postgresql.JSONB(), server_default="{}"),
-        sa.Column(
-            "created_by",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("users.id"),
-            nullable=True,
-        ),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-        ),
-    )
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+
+    # Add initiative_id to diagrams (skip if create_all already added it)
+    existing_columns = [c["name"] for c in inspector.get_columns("diagrams")]
+    if "initiative_id" not in existing_columns:
+        op.add_column(
+            "diagrams",
+            sa.Column(
+                "initiative_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("fact_sheets.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+
+    # Create statement_of_architecture_works table (skip if create_all already made it)
+    if not inspector.has_table("statement_of_architecture_works"):
+        op.create_table(
+            "statement_of_architecture_works",
+            sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+            sa.Column("name", sa.String(500), nullable=False),
+            sa.Column(
+                "initiative_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("fact_sheets.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("status", sa.String(50), server_default="draft"),
+            sa.Column("document_info", postgresql.JSONB(), server_default="{}"),
+            sa.Column("version_history", postgresql.JSONB(), server_default="[]"),
+            sa.Column("sections", postgresql.JSONB(), server_default="{}"),
+            sa.Column(
+                "created_by",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("users.id"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Base.metadata.create_all runs before Alembic migrations in the lifespan, which already creates the soaw table and adds initiative_id to diagrams. The migration now checks if objects exist before creating them.

https://claude.ai/code/session_013DhADSWjMTvquVUnEEn7ch