### PR TITLE
Fix SoAW preview to export PDF and make all toolbars responsive

### DIFF
--- a/frontend/src/features/ea-delivery/SoAWEditor.tsx
+++ b/frontend/src/features/ea-delivery/SoAWEditor.tsx
@@ -26,6 +26,8 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import RichTextEditor from "./RichTextEditor";
 import EditableTable from "./EditableTable";
@@ -52,6 +54,8 @@ const STATUS_OPTIONS: { value: string; label: string }[] = [
 export default function SoAWEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const theme = useTheme();
+  const compact = useMediaQuery(theme.breakpoints.down("sm"));
   const isNew = !id;
 
   // SoAW state
@@ -350,58 +354,74 @@ export default function SoAWEditor() {
   return (
     <Box sx={{ maxWidth: 960, mx: "auto" }}>
       {/* Top bar */}
-      <Box sx={{ display: "flex", alignItems: "center", mb: 3, gap: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", mb: 3, gap: 1 }}>
         <Tooltip title="Back to EA Delivery">
           <IconButton onClick={() => navigate("/ea-delivery")}>
             <MaterialSymbol icon="arrow_back" size={22} />
           </IconButton>
         </Tooltip>
-        <MaterialSymbol icon="description" size={26} color="#e65100" />
-        <Typography variant="h5" sx={{ fontWeight: 700, flex: 1 }}>
+        {!compact && <MaterialSymbol icon="description" size={26} color="#e65100" />}
+        <Typography
+          variant={compact ? "subtitle1" : "h5"}
+          sx={{ fontWeight: 700, flex: 1, minWidth: 0 }}
+          noWrap
+        >
           {isNew ? "New Statement of Architecture Work" : name || "Untitled"}
         </Typography>
         {!isNew && (
+          compact ? (
+            <Tooltip title="Preview">
+              <IconButton onClick={() => navigate(`/ea-delivery/soaw/${soawIdRef.current}/preview`)}>
+                <MaterialSymbol icon="visibility" size={20} />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <Button
+              size="small"
+              startIcon={<MaterialSymbol icon="visibility" size={18} />}
+              sx={{ textTransform: "none" }}
+              onClick={() => navigate(`/ea-delivery/soaw/${soawIdRef.current}/preview`)}
+            >
+              Preview
+            </Button>
+          )
+        )}
+        {compact ? (
+          <Tooltip title="Export PDF">
+            <IconButton
+              onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections)}
+            >
+              <MaterialSymbol icon="picture_as_pdf" size={20} />
+            </IconButton>
+          </Tooltip>
+        ) : (
           <Button
             size="small"
-            startIcon={<MaterialSymbol icon="visibility" size={18} />}
+            startIcon={<MaterialSymbol icon="picture_as_pdf" size={18} />}
             sx={{ textTransform: "none" }}
-            onClick={() => navigate(`/ea-delivery/soaw/${soawIdRef.current}/preview`)}
+            onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections)}
           >
-            Preview
+            PDF
           </Button>
         )}
-        <Button
-          size="small"
-          startIcon={<MaterialSymbol icon="picture_as_pdf" size={18} />}
-          sx={{ textTransform: "none" }}
-          onClick={() =>
-            exportToPdf(
-              name,
-              docInfo,
-              versionHistory,
-              sections,
-              customSections,
-            )
-          }
-        >
-          PDF
-        </Button>
-        <Button
-          size="small"
-          startIcon={<MaterialSymbol icon="article" size={18} />}
-          sx={{ textTransform: "none" }}
-          onClick={() =>
-            exportToDocx(
-              name,
-              docInfo,
-              versionHistory,
-              sections,
-              customSections,
-            )
-          }
-        >
-          Word
-        </Button>
+        {compact ? (
+          <Tooltip title="Export Word">
+            <IconButton
+              onClick={() => exportToDocx(name, docInfo, versionHistory, sections, customSections)}
+            >
+              <MaterialSymbol icon="article" size={20} />
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Button
+            size="small"
+            startIcon={<MaterialSymbol icon="article" size={18} />}
+            sx={{ textTransform: "none" }}
+            onClick={() => exportToDocx(name, docInfo, versionHistory, sections, customSections)}
+          >
+            Word
+          </Button>
+        )}
         <Button
           variant="contained"
           size="small"

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -13,6 +13,13 @@ import MenuItem from "@mui/material/MenuItem";
 import Divider from "@mui/material/Divider";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
+import Drawer from "@mui/material/Drawer";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import Collapse from "@mui/material/Collapse";
+import Tooltip from "@mui/material/Tooltip";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
 import MaterialSymbol from "@/components/MaterialSymbol";
 
 interface NavItem {
@@ -56,14 +63,22 @@ interface Props {
 export default function AppLayout({ children, user, onLogout }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const isCompact = useMediaQuery(theme.breakpoints.down("lg"));
+
   const [userMenu, setUserMenu] = useState<HTMLElement | null>(null);
   const [reportsMenu, setReportsMenu] = useState<HTMLElement | null>(null);
   const [adminMenu, setAdminMenu] = useState<HTMLElement | null>(null);
   const [search, setSearch] = useState("");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerReportsOpen, setDrawerReportsOpen] = useState(false);
+  const [drawerAdminOpen, setDrawerAdminOpen] = useState(false);
 
   const handleSearch = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && search.trim()) {
       navigate(`/inventory?search=${encodeURIComponent(search.trim())}`);
+      setDrawerOpen(false);
     }
   };
 
@@ -78,11 +93,192 @@ export default function AppLayout({ children, user, onLogout }: Props) {
     fontWeight: active ? 700 : 500,
     fontSize: "0.85rem",
     minWidth: 0,
-    px: 1.5,
+    px: isCompact && !isMobile ? 1 : 1.5,
     borderRadius: 1,
     bgcolor: active ? "rgba(255,255,255,0.12)" : "transparent",
     "&:hover": { bgcolor: "rgba(255,255,255,0.1)" },
   });
+
+  const drawerNav = (path: string) => {
+    navigate(path);
+    setDrawerOpen(false);
+  };
+
+  // ── Mobile drawer ───────────────────────────────────────────────────────
+
+  const renderDrawer = () => (
+    <Drawer
+      anchor="left"
+      open={drawerOpen}
+      onClose={() => setDrawerOpen(false)}
+      PaperProps={{ sx: { width: 280, bgcolor: "#1a1a2e" } }}
+    >
+      {/* Brand header */}
+      <Box sx={{ display: "flex", alignItems: "center", p: 2, gap: 1 }}>
+        <MaterialSymbol icon="hub" size={28} color="#64b5f6" />
+        <Typography variant="h6" sx={{ fontWeight: 700, color: "#fff" }}>
+          Turbo EA
+        </Typography>
+      </Box>
+      <Divider sx={{ borderColor: "rgba(255,255,255,0.1)" }} />
+
+      {/* Search */}
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search fact sheets..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={handleSearch}
+          sx={{
+            bgcolor: "rgba(255,255,255,0.08)",
+            borderRadius: 1,
+            "& .MuiOutlinedInput-notchedOutline": { border: "none" },
+            input: { color: "#fff", py: 0.75 },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <MaterialSymbol icon="search" size={20} color="#999" />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      <List sx={{ px: 1 }}>
+        {NAV_ITEMS.map((item) =>
+          item.children ? (
+            <Box key={item.label}>
+              <ListItemButton
+                onClick={() => setDrawerReportsOpen((p) => !p)}
+                sx={{
+                  borderRadius: 1,
+                  color: isGroupActive(item.children) ? "#fff" : "rgba(255,255,255,0.7)",
+                  bgcolor: isGroupActive(item.children) ? "rgba(255,255,255,0.12)" : "transparent",
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: 36 }}>
+                  <MaterialSymbol icon={item.icon} size={20} color="inherit" />
+                </ListItemIcon>
+                <ListItemText primary={item.label} />
+                <MaterialSymbol
+                  icon={drawerReportsOpen ? "expand_less" : "expand_more"}
+                  size={18}
+                  color="inherit"
+                />
+              </ListItemButton>
+              <Collapse in={drawerReportsOpen}>
+                <List disablePadding sx={{ pl: 2 }}>
+                  {item.children.map((child) => (
+                    <ListItemButton
+                      key={child.path}
+                      selected={isActive(child.path)}
+                      onClick={() => drawerNav(child.path)}
+                      sx={{ borderRadius: 1, color: "rgba(255,255,255,0.7)", "&.Mui-selected": { color: "#fff", bgcolor: "rgba(255,255,255,0.12)" } }}
+                    >
+                      <ListItemIcon sx={{ minWidth: 32 }}>
+                        <MaterialSymbol icon={child.icon} size={18} color="inherit" />
+                      </ListItemIcon>
+                      <ListItemText primary={child.label} primaryTypographyProps={{ fontSize: "0.85rem" }} />
+                    </ListItemButton>
+                  ))}
+                </List>
+              </Collapse>
+            </Box>
+          ) : (
+            <ListItemButton
+              key={item.label}
+              selected={isActive(item.path)}
+              onClick={() => item.path && drawerNav(item.path)}
+              sx={{
+                borderRadius: 1,
+                color: isActive(item.path) ? "#fff" : "rgba(255,255,255,0.7)",
+                "&.Mui-selected": { bgcolor: "rgba(255,255,255,0.12)" },
+              }}
+            >
+              <ListItemIcon sx={{ minWidth: 36 }}>
+                <MaterialSymbol icon={item.icon} size={20} color="inherit" />
+              </ListItemIcon>
+              <ListItemText primary={item.label} />
+            </ListItemButton>
+          ),
+        )}
+
+        <Divider sx={{ my: 1, borderColor: "rgba(255,255,255,0.1)" }} />
+
+        {/* Admin section */}
+        <ListItemButton
+          onClick={() => setDrawerAdminOpen((p) => !p)}
+          sx={{
+            borderRadius: 1,
+            color: isGroupActive(ADMIN_ITEMS as { path: string }[]) ? "#fff" : "rgba(255,255,255,0.7)",
+          }}
+        >
+          <ListItemIcon sx={{ minWidth: 36 }}>
+            <MaterialSymbol icon="admin_panel_settings" size={20} color="inherit" />
+          </ListItemIcon>
+          <ListItemText primary="Admin" />
+          <MaterialSymbol
+            icon={drawerAdminOpen ? "expand_less" : "expand_more"}
+            size={18}
+            color="inherit"
+          />
+        </ListItemButton>
+        <Collapse in={drawerAdminOpen}>
+          <List disablePadding sx={{ pl: 2 }}>
+            {ADMIN_ITEMS.map((item) => (
+              <ListItemButton
+                key={item.path}
+                selected={isActive(item.path)}
+                onClick={() => item.path && drawerNav(item.path)}
+                sx={{ borderRadius: 1, color: "rgba(255,255,255,0.7)", "&.Mui-selected": { color: "#fff", bgcolor: "rgba(255,255,255,0.12)" } }}
+              >
+                <ListItemIcon sx={{ minWidth: 32 }}>
+                  <MaterialSymbol icon={item.icon} size={18} color="inherit" />
+                </ListItemIcon>
+                <ListItemText primary={item.label} primaryTypographyProps={{ fontSize: "0.85rem" }} />
+              </ListItemButton>
+            ))}
+          </List>
+        </Collapse>
+
+        <Divider sx={{ my: 1, borderColor: "rgba(255,255,255,0.1)" }} />
+
+        {/* Create */}
+        <ListItemButton
+          onClick={() => drawerNav("/inventory?create=true")}
+          sx={{ borderRadius: 1, color: "rgba(255,255,255,0.7)" }}
+        >
+          <ListItemIcon sx={{ minWidth: 36 }}>
+            <MaterialSymbol icon="add" size={20} color="inherit" />
+          </ListItemIcon>
+          <ListItemText primary="Create Fact Sheet" />
+        </ListItemButton>
+      </List>
+
+      {/* User info at bottom */}
+      <Box sx={{ mt: "auto", p: 2 }}>
+        <Divider sx={{ mb: 1.5, borderColor: "rgba(255,255,255,0.1)" }} />
+        <Typography variant="body2" sx={{ color: "#fff", fontWeight: 600 }}>
+          {user.display_name}
+        </Typography>
+        <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.5)" }}>
+          {user.email}
+        </Typography>
+        <Button
+          fullWidth
+          size="small"
+          sx={{ mt: 1, color: "rgba(255,255,255,0.7)", textTransform: "none", justifyContent: "flex-start" }}
+          startIcon={<MaterialSymbol icon="logout" size={18} />}
+          onClick={() => { setDrawerOpen(false); onLogout(); }}
+        >
+          Logout
+        </Button>
+      </Box>
+    </Drawer>
+  );
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
@@ -92,6 +288,16 @@ export default function AppLayout({ children, user, onLogout }: Props) {
         elevation={0}
       >
         <Toolbar sx={{ gap: 0.5 }}>
+          {/* Hamburger (mobile) */}
+          {isMobile && (
+            <IconButton
+              sx={{ color: "#fff", mr: 0.5 }}
+              onClick={() => setDrawerOpen(true)}
+            >
+              <MaterialSymbol icon="menu" size={24} />
+            </IconButton>
+          )}
+
           {/* Brand */}
           <MaterialSymbol icon="hub" size={28} color="#64b5f6" />
           <Typography
@@ -100,50 +306,90 @@ export default function AppLayout({ children, user, onLogout }: Props) {
               ml: 1,
               fontWeight: 700,
               letterSpacing: "-0.5px",
-              mr: 3,
+              mr: isMobile ? 0 : 3,
               cursor: "pointer",
+              display: { xs: "none", sm: "block" },
             }}
             onClick={() => navigate("/")}
           >
             Turbo EA
           </Typography>
 
-          {/* Main nav items */}
-          {NAV_ITEMS.map((item) =>
-            item.children ? (
-              <Button
-                key={item.label}
-                size="small"
-                startIcon={<MaterialSymbol icon={item.icon} size={18} />}
-                endIcon={<MaterialSymbol icon="expand_more" size={16} />}
-                sx={navBtnSx(isGroupActive(item.children))}
-                onClick={(e) => setReportsMenu(e.currentTarget)}
-              >
-                {item.label}
-              </Button>
+          {/* Desktop / tablet nav items */}
+          {!isMobile &&
+            NAV_ITEMS.map((item) =>
+              item.children ? (
+                isCompact ? (
+                  <Tooltip key={item.label} title={item.label}>
+                    <IconButton
+                      size="small"
+                      sx={{ color: isGroupActive(item.children) ? "#fff" : "rgba(255,255,255,0.7)" }}
+                      onClick={(e) => setReportsMenu(e.currentTarget)}
+                    >
+                      <MaterialSymbol icon={item.icon} size={20} />
+                    </IconButton>
+                  </Tooltip>
+                ) : (
+                  <Button
+                    key={item.label}
+                    size="small"
+                    startIcon={<MaterialSymbol icon={item.icon} size={18} />}
+                    endIcon={<MaterialSymbol icon="expand_more" size={16} />}
+                    sx={navBtnSx(isGroupActive(item.children))}
+                    onClick={(e) => setReportsMenu(e.currentTarget)}
+                  >
+                    {item.label}
+                  </Button>
+                )
+              ) : isCompact ? (
+                <Tooltip key={item.label} title={item.label}>
+                  <IconButton
+                    size="small"
+                    sx={{
+                      color: isActive(item.path) ? "#fff" : "rgba(255,255,255,0.7)",
+                      bgcolor: isActive(item.path) ? "rgba(255,255,255,0.12)" : "transparent",
+                    }}
+                    onClick={() => item.path && navigate(item.path)}
+                  >
+                    <MaterialSymbol icon={item.icon} size={20} />
+                  </IconButton>
+                </Tooltip>
+              ) : (
+                <Button
+                  key={item.label}
+                  size="small"
+                  startIcon={<MaterialSymbol icon={item.icon} size={18} />}
+                  sx={navBtnSx(isActive(item.path))}
+                  onClick={() => item.path && navigate(item.path)}
+                >
+                  {item.label}
+                </Button>
+              ),
+            )}
+
+          {/* Admin dropdown (desktop/tablet) */}
+          {!isMobile &&
+            (isCompact ? (
+              <Tooltip title="Admin">
+                <IconButton
+                  size="small"
+                  sx={{ color: isGroupActive(ADMIN_ITEMS as { path: string }[]) ? "#fff" : "rgba(255,255,255,0.7)" }}
+                  onClick={(e) => setAdminMenu(e.currentTarget)}
+                >
+                  <MaterialSymbol icon="admin_panel_settings" size={20} />
+                </IconButton>
+              </Tooltip>
             ) : (
               <Button
-                key={item.label}
                 size="small"
-                startIcon={<MaterialSymbol icon={item.icon} size={18} />}
-                sx={navBtnSx(isActive(item.path))}
-                onClick={() => item.path && navigate(item.path)}
+                startIcon={<MaterialSymbol icon="admin_panel_settings" size={18} />}
+                endIcon={<MaterialSymbol icon="expand_more" size={16} />}
+                sx={navBtnSx(isGroupActive(ADMIN_ITEMS as { path: string }[]))}
+                onClick={(e) => setAdminMenu(e.currentTarget)}
               >
-                {item.label}
+                Admin
               </Button>
-            )
-          )}
-
-          {/* Admin dropdown */}
-          <Button
-            size="small"
-            startIcon={<MaterialSymbol icon="admin_panel_settings" size={18} />}
-            endIcon={<MaterialSymbol icon="expand_more" size={16} />}
-            sx={navBtnSx(isGroupActive(ADMIN_ITEMS as { path: string }[]))}
-            onClick={(e) => setAdminMenu(e.currentTarget)}
-          >
-            Admin
-          </Button>
+            ))}
 
           {/* Reports dropdown menu */}
           <Menu
@@ -193,43 +439,56 @@ export default function AppLayout({ children, user, onLogout }: Props) {
 
           <Box sx={{ flex: 1 }} />
 
-          {/* Search */}
-          <TextField
-            size="small"
-            placeholder="Search fact sheets..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            onKeyDown={handleSearch}
-            sx={{
-              maxWidth: 360,
-              bgcolor: "rgba(255,255,255,0.08)",
-              borderRadius: 1,
-              "& .MuiOutlinedInput-notchedOutline": { border: "none" },
-              input: { color: "#fff", py: 0.75 },
-            }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <MaterialSymbol icon="search" size={20} color="#999" />
-                </InputAdornment>
-              ),
-            }}
-          />
+          {/* Search (hidden on mobile — available in drawer) */}
+          {!isMobile && (
+            <TextField
+              size="small"
+              placeholder="Search fact sheets..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={handleSearch}
+              sx={{
+                maxWidth: isCompact ? 200 : 360,
+                bgcolor: "rgba(255,255,255,0.08)",
+                borderRadius: 1,
+                "& .MuiOutlinedInput-notchedOutline": { border: "none" },
+                input: { color: "#fff", py: 0.75 },
+              }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <MaterialSymbol icon="search" size={20} color="#999" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+          )}
 
           {/* Create button */}
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<MaterialSymbol icon="add" size={18} />}
-            sx={{ ml: 1.5, textTransform: "none" }}
-            onClick={() => navigate("/inventory?create=true")}
-          >
-            Create
-          </Button>
+          {isMobile ? (
+            <Tooltip title="Create">
+              <IconButton
+                sx={{ color: "#fff" }}
+                onClick={() => navigate("/inventory?create=true")}
+              >
+                <MaterialSymbol icon="add_circle" size={24} />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<MaterialSymbol icon="add" size={18} />}
+              sx={{ ml: 1.5, textTransform: "none" }}
+              onClick={() => navigate("/inventory?create=true")}
+            >
+              Create
+            </Button>
+          )}
 
           {/* User menu */}
           <IconButton
-            sx={{ ml: 1, color: "#fff" }}
+            sx={{ ml: isMobile ? 0 : 1, color: "#fff" }}
             onClick={(e) => setUserMenu(e.currentTarget)}
           >
             <MaterialSymbol icon="account_circle" size={28} />
@@ -260,7 +519,10 @@ export default function AppLayout({ children, user, onLogout }: Props) {
         </Toolbar>
       </AppBar>
 
-      {/* Main content — full width now, no sidebar */}
+      {/* Mobile drawer */}
+      {isMobile && renderDrawer()}
+
+      {/* Main content */}
       <Box
         component="main"
         sx={{
@@ -270,7 +532,7 @@ export default function AppLayout({ children, user, onLogout }: Props) {
           pt: "64px",
         }}
       >
-        <Box sx={{ p: 3 }}>{children}</Box>
+        <Box sx={{ p: { xs: 1.5, sm: 3 } }}>{children}</Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
Preview print fix:
- Replace window.print() with exportToPdf() so the preview's print action opens the same styled HTML in a new tab with the print dialog, producing a proper PDF export

Responsive SoAW preview toolbar:
- On small screens, buttons collapse to icon-only with tooltips
- Title truncates with ellipsis, flexWrap prevents overflow

Responsive SoAW editor toolbar:
- Same icon-only pattern on small screens for Preview, PDF, Word
- Save button always keeps its label since it's the primary action
- flexWrap added for graceful line-breaking

Responsive main AppLayout nav bar:
- Mobile (< 960px): Hamburger menu opens a full Drawer with nav items, search, collapsible Reports/Admin sections, user info, and logout
- Tablet (960-1200px): Icon-only nav buttons with tooltips, narrower search field
- Desktop (≥ 1200px): Full layout unchanged
- Brand text hidden on xs screens to save space
- Content padding reduced on mobile (1.5 vs 3)

https://claude.ai/code/session_013DhADSWjMTvquVUnEEn7ch