### PR TITLE
Use entity-relation edge style and make child cells expandable

### DIFF
--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -239,10 +239,16 @@ export default function DiagramEditor() {
               if (sa !== sb) return sa - sb;
               return a.name.localeCompare(b.name);
             });
-            expandFactSheetGroup(iframeRef.current, cellId, children);
+            const inserted = expandFactSheetGroup(iframeRef.current, cellId, children);
             addExpandOverlay(iframeRef.current, cellId, true, () =>
               handleToggleGroup(cellId, factSheetId, true),
             );
+            // Add expand overlays to each child so they can be expanded too
+            for (const child of inserted) {
+              addExpandOverlay(iframeRef.current, child.cellId, false, () =>
+                handleToggleGroup(child.cellId, child.factSheetId, false),
+              );
+            }
           })
           .catch(() => setSnackMsg("Failed to load relations"));
       }


### PR DESCRIPTION
- Switch connectors from straight arrows to entityRelationEdgeStyle (orthogonal routing, no arrowheads)
- After expanding a fact sheet, add + overlays to every child cell so they can be expanded recursively to any depth
- Collapse now walks the full descendant tree so nested expansions are cleaned up properly
- refreshFactSheetOverlays now covers all fact sheet cells (including previously expanded children) on diagram reload

https://claude.ai/code/session_01WgKY9v6z7U7V8rpEo9da8E