### PR TITLE
Add diagram-to-inventory sync: create fact sheets, relations, and rev…

### DIFF
--- a/frontend/src/features/diagrams/CreateOnDiagramDialog.tsx
+++ b/frontend/src/features/diagrams/CreateOnDiagramDialog.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import type { FactSheetType } from "@/types";
+
+interface Props {
+  open: boolean;
+  types: FactSheetType[];
+  onClose: () => void;
+  onCreate: (data: { type: string; name: string; description?: string }) => void;
+}
+
+/**
+ * Lightweight dialog for creating a new fact sheet directly from the diagram.
+ * Only asks for type + name (+ optional description).  The actual API call is
+ * deferred until the user synchronises from the sync panel.
+ */
+export default function CreateOnDiagramDialog({ open, types, onClose, onCreate }: Props) {
+  const [selectedType, setSelectedType] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const visibleTypes = types.filter((t) => !t.is_hidden);
+  const typeInfo = visibleTypes.find((t) => t.key === selectedType);
+  const valid = selectedType && name.trim().length > 0;
+
+  const handleCreate = () => {
+    if (!valid) return;
+    onCreate({
+      type: selectedType,
+      name: name.trim(),
+      description: description.trim() || undefined,
+    });
+    // Reset form
+    setSelectedType("");
+    setName("");
+    setDescription("");
+  };
+
+  const handleClose = () => {
+    setSelectedType("");
+    setName("");
+    setDescription("");
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <MaterialSymbol icon="note_add" size={22} color="#6a1b9a" />
+        Create Fact Sheet
+      </DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: "8px !important" }}>
+        <TextField
+          select
+          label="Type"
+          size="small"
+          fullWidth
+          value={selectedType}
+          onChange={(e) => setSelectedType(e.target.value)}
+        >
+          {visibleTypes.map((t) => (
+            <MenuItem key={t.key} value={t.key}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: "50%",
+                    bgcolor: t.color,
+                    flexShrink: 0,
+                  }}
+                />
+                {t.label}
+              </Box>
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <TextField
+          label="Name"
+          size="small"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && valid) handleCreate();
+          }}
+        />
+
+        <TextField
+          label="Description (optional)"
+          size="small"
+          fullWidth
+          multiline
+          minRows={2}
+          maxRows={4}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        {typeInfo && (
+          <Typography variant="caption" color="text.disabled">
+            Will be added to the diagram as a pending{" "}
+            <strong style={{ color: typeInfo.color }}>{typeInfo.label}</strong>.
+            Synchronise to save it to the inventory.
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button variant="contained" disabled={!valid} onClick={handleCreate}>
+          Add to Diagram
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -4,10 +4,21 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import Snackbar from "@mui/material/Snackbar";
+import Badge from "@mui/material/Badge";
+import Tooltip from "@mui/material/Tooltip";
 import CircularProgress from "@mui/material/CircularProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import FactSheetPickerDialog from "./FactSheetPickerDialog";
+import CreateOnDiagramDialog from "./CreateOnDiagramDialog";
+import RelationPickerDialog from "./RelationPickerDialog";
+import type { EdgeEndpoints } from "./RelationPickerDialog";
+import DiagramSyncPanel from "./DiagramSyncPanel";
+import type {
+  PendingFactSheet,
+  PendingRelation,
+  StaleItem,
+} from "./DiagramSyncPanel";
 import {
   buildFactSheetCellData,
   insertFactSheetIntoGraph,
@@ -16,17 +27,22 @@ import {
   expandFactSheetGroup,
   collapseFactSheetGroup,
   refreshFactSheetOverlays,
+  insertPendingFactSheet,
+  stampEdgeAsRelation,
+  markCellSynced,
+  markEdgeSynced,
+  updateCellLabel,
+  removeDiagramCell,
+  scanDiagramItems,
 } from "./drawio-shapes";
 import type { ExpandChildData } from "./drawio-shapes";
 import { useMetamodel } from "@/hooks/useMetamodel";
-import type { FactSheet, FactSheetType, Relation } from "@/types";
+import type { FactSheet, FactSheetType, Relation, RelationType } from "@/types";
 
-/**
- * DrawIO embed mode URL.
- * Defaults to self-hosted path (DrawIO static files bundled in the Docker image).
- * Override with VITE_DRAWIO_URL env var if needed (e.g. "https://embed.diagrams.net"
- * for local dev without Docker).
- */
+/* ------------------------------------------------------------------ */
+/*  DrawIO configuration                                               */
+/* ------------------------------------------------------------------ */
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _meta = import.meta as any;
 const DRAWIO_BASE_URL: string =
@@ -42,45 +58,57 @@ const DRAWIO_URL_PARAMS = new URLSearchParams({
   noExitBtn: "0",
 }).toString();
 
-/** Default empty diagram XML */
 const EMPTY_DIAGRAM =
   '<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
 
 interface DiagramData {
   id: string;
   name: string;
   type: string;
-  data: {
-    xml?: string;
-    thumbnail?: string;
-  };
+  data: { xml?: string; thumbnail?: string };
 }
 
-/** Messages FROM DrawIO iframe -> host */
 interface DrawIOMessage {
-  event: "init" | "save" | "exit" | "export" | "configure" | "insertFactSheet";
+  event:
+    | "init"
+    | "save"
+    | "exit"
+    | "export"
+    | "configure"
+    | "insertFactSheet"
+    | "createFactSheet"
+    | "edgeConnected";
   xml?: string;
   data?: string;
   modified?: boolean;
   x?: number;
   y?: number;
+  edgeCellId?: string;
+  sourceFactSheetId?: string;
+  targetFactSheetId?: string;
+  sourceType?: string;
+  targetType?: string;
+  sourceName?: string;
+  targetName?: string;
+  sourceColor?: string;
+  targetColor?: string;
 }
 
-/**
- * Bootstrap the same-origin DrawIO iframe: store the mxGraph reference on
- * window.__turboGraph so the parent can call graph.insertVertex() directly.
- *
- * Uses Draw.loadPlugin which, when called after init, executes the callback
- * immediately with the current editor.  We also inject a right-click context
- * menu item ("Insert Fact Sheet…") that posts a message back to the parent.
- */
+/* ------------------------------------------------------------------ */
+/*  Bootstrap: graph ref, context menu, edge interception              */
+/* ------------------------------------------------------------------ */
+
 function bootstrapDrawIO(iframe: HTMLIFrameElement) {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const win = iframe.contentWindow as any;
     if (!win?.Draw?.loadPlugin) return;
 
-    win.Draw.loadPlugin((ui: /* EditorUi */ Record<string, unknown>) => {
+    win.Draw.loadPlugin((ui: Record<string, unknown>) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const editor = ui.editor as any;
       const graph = editor?.graph;
@@ -88,7 +116,7 @@ function bootstrapDrawIO(iframe: HTMLIFrameElement) {
         win.__turboGraph = graph;
       }
 
-      // Inject right-click "Insert Fact Sheet…" context menu item
+      /* ---------- Right-click context menu ---------- */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const menus = ui.menus as any;
       if (menus?.createPopupMenu) {
@@ -98,7 +126,7 @@ function bootstrapDrawIO(iframe: HTMLIFrameElement) {
           menu: any,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           _cell: any,
-          evt: MouseEvent
+          evt: MouseEvent,
         ) {
           origFactory.apply(this, arguments);
           menu.addSeparator();
@@ -109,25 +137,85 @@ function bootstrapDrawIO(iframe: HTMLIFrameElement) {
           const s = graph.view.scale;
           const tr = graph.view.translate;
           const gx = Math.round(
-            (mxEvent.getClientX(evt) - offset.left + container.scrollLeft) / s - tr.x
+            (mxEvent.getClientX(evt) - offset.left + container.scrollLeft) / s - tr.x,
           );
           const gy = Math.round(
-            (mxEvent.getClientY(evt) - offset.top + container.scrollTop) / s - tr.y
+            (mxEvent.getClientY(evt) - offset.top + container.scrollTop) / s - tr.y,
           );
 
-          menu.addItem("Insert Fact Sheet\u2026", null, () => {
+          menu.addItem("Insert Existing Fact Sheet\u2026", null, () => {
             win.parent.postMessage(
               JSON.stringify({ event: "insertFactSheet", x: gx, y: gy }),
-              "*"
+              "*",
+            );
+          });
+
+          menu.addItem("Create New Fact Sheet\u2026", null, () => {
+            win.parent.postMessage(
+              JSON.stringify({ event: "createFactSheet", x: gx, y: gy }),
+              "*",
             );
           });
         };
       }
+
+      /* ---------- Edge connection interception ---------- */
+      const connHandler = graph.connectionHandler;
+      if (connHandler) {
+        connHandler.addListener(win.mxEvent.CONNECT, function (
+          _sender: unknown,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          evt: any,
+        ) {
+          const edge = evt.getProperty("cell");
+          if (!edge) return;
+
+          const model = graph.getModel();
+          const src = model.getTerminal(edge, true);
+          const tgt = model.getTerminal(edge, false);
+          if (!src || !tgt) return;
+
+          const srcFsId = src.value?.getAttribute?.("factSheetId");
+          const tgtFsId = tgt.value?.getAttribute?.("factSheetId");
+          const srcType = src.value?.getAttribute?.("factSheetType");
+          const tgtType = tgt.value?.getAttribute?.("factSheetType");
+
+          if (srcFsId && tgtFsId && srcType && tgtType) {
+            // Resolve colors via stored style (fillColor)
+            const srcStyle = model.getStyle(src) || "";
+            const tgtStyle = model.getStyle(tgt) || "";
+            const pick = (s: string) => {
+              const m = /fillColor=([^;]+)/.exec(s);
+              return m ? m[1] : "#999";
+            };
+
+            win.parent.postMessage(
+              JSON.stringify({
+                event: "edgeConnected",
+                edgeCellId: edge.id,
+                sourceFactSheetId: srcFsId,
+                targetFactSheetId: tgtFsId,
+                sourceType: srcType,
+                targetType: tgtType,
+                sourceName: src.value.getAttribute("label") || "",
+                targetName: tgt.value.getAttribute("label") || "",
+                sourceColor: pick(srcStyle),
+                targetColor: pick(tgtStyle),
+              }),
+              "*",
+            );
+          }
+        });
+      }
     });
   } catch {
-    // Cross-origin or editor not ready — fall through silently
+    // Cross-origin or editor not ready
   }
 }
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
 
 export default function DiagramEditor() {
   const { id } = useParams<{ id: string }>();
@@ -137,16 +225,33 @@ export default function DiagramEditor() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [snackMsg, setSnackMsg] = useState("");
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const { types: fsTypes } = useMetamodel();
+
+  // Metamodel
+  const { types: fsTypes, relationTypes } = useMetamodel();
   const fsTypesRef = useRef(fsTypes);
   fsTypesRef.current = fsTypes;
-  // Track whether we're waiting for a thumbnail export after save
+  const relTypesRef = useRef(relationTypes);
+  relTypesRef.current = relationTypes;
+
+  // Refs
   const pendingSaveXmlRef = useRef<string | null>(null);
-  // Graph-space coordinates from right-click context menu
   const contextInsertPosRef = useRef<{ x: number; y: number } | null>(null);
 
-  // Load diagram from API
+  // Dialog states
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [relPickerOpen, setRelPickerOpen] = useState(false);
+  const pendingEdgeRef = useRef<EdgeEndpoints | null>(null);
+
+  // Sync panel
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [pendingFS, setPendingFS] = useState<PendingFactSheet[]>([]);
+  const [pendingRels, setPendingRels] = useState<PendingRelation[]>([]);
+  const [staleItems, setStaleItems] = useState<StaleItem[]>([]);
+  const [syncing, setSyncing] = useState(false);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+
+  /* ---------- Load diagram ---------- */
   useEffect(() => {
     if (!id) return;
     api
@@ -156,7 +261,6 @@ export default function DiagramEditor() {
       .finally(() => setLoading(false));
   }, [id]);
 
-  /** Send a message to the DrawIO iframe */
   const postToDrawIO = useCallback((msg: Record<string, unknown>) => {
     const frame = iframeRef.current;
     if (frame?.contentWindow) {
@@ -164,27 +268,17 @@ export default function DiagramEditor() {
     }
   }, []);
 
-  /** Persist XML + thumbnail to the backend */
   const saveDiagram = useCallback(
     async (xml: string, thumbnail?: string) => {
       if (!diagram) return;
       setSaving(true);
       try {
         const payload: Record<string, unknown> = {
-          data: {
-            ...diagram.data,
-            xml,
-            ...(thumbnail ? { thumbnail } : {}),
-          },
+          data: { ...diagram.data, xml, ...(thumbnail ? { thumbnail } : {}) },
         };
         await api.patch(`/diagrams/${diagram.id}`, payload);
         setDiagram((prev) =>
-          prev
-            ? {
-                ...prev,
-                data: { ...prev.data, xml, ...(thumbnail ? { thumbnail } : {}) },
-              }
-            : prev
+          prev ? { ...prev, data: { ...prev.data, xml, ...(thumbnail ? { thumbnail } : {}) } } : prev,
         );
         setSnackMsg("Diagram saved");
       } catch {
@@ -193,10 +287,10 @@ export default function DiagramEditor() {
         setSaving(false);
       }
     },
-    [diagram]
+    [diagram],
   );
 
-  /** Toggle expand/collapse for a fact sheet group in the DrawIO graph */
+  /* ---------- Expand / collapse ---------- */
   const handleToggleGroup = useCallback(
     (cellId: string, factSheetId: string, currentlyExpanded: boolean) => {
       const frame = iframeRef.current;
@@ -215,8 +309,7 @@ export default function DiagramEditor() {
             const seen = new Set<string>();
             const children: ExpandChildData[] = [];
             for (const r of rels) {
-              const other =
-                r.source_id === factSheetId ? r.target : r.source;
+              const other = r.source_id === factSheetId ? r.target : r.source;
               if (!other || seen.has(other.id)) continue;
               seen.add(other.id);
               const t = fsTypesRef.current.find((tp) => tp.key === other.type);
@@ -232,7 +325,6 @@ export default function DiagramEditor() {
               setSnackMsg("No related fact sheets");
               return;
             }
-            // Sort by type then name for neat grouping
             children.sort((a, b) => {
               const sa = fsTypesRef.current.find((t) => t.key === a.type)?.sort_order ?? 99;
               const sb = fsTypesRef.current.find((t) => t.key === b.type)?.sort_order ?? 99;
@@ -243,7 +335,6 @@ export default function DiagramEditor() {
             addExpandOverlay(iframeRef.current, cellId, true, () =>
               handleToggleGroup(cellId, factSheetId, true),
             );
-            // Add expand overlays to each child so they can be expanded too
             for (const child of inserted) {
               addExpandOverlay(iframeRef.current, child.cellId, false, () =>
                 handleToggleGroup(child.cellId, child.factSheetId, false),
@@ -257,23 +348,20 @@ export default function DiagramEditor() {
     [],
   );
 
-  /** Insert a fact sheet shape directly into the DrawIO graph */
+  /* ---------- Insert existing fact sheet ---------- */
   const handleInsertFactSheet = useCallback(
     (fs: FactSheet, fsType: FactSheetType) => {
       const frame = iframeRef.current;
       if (!frame) return;
 
-      // Use right-click position, or fall back to the center of the visible canvas
-      let x: number;
-      let y: number;
+      let x: number, y: number;
       if (contextInsertPosRef.current) {
-        x = contextInsertPosRef.current.x;
-        y = contextInsertPosRef.current.y;
+        ({ x, y } = contextInsertPosRef.current);
         contextInsertPosRef.current = null;
       } else {
         const center = getVisibleCenter(frame);
-        x = center ? center.x - 90 : 100;   // offset by half-width
-        y = center ? center.y - 30 : 100;    // offset by half-height
+        x = center ? center.x - 90 : 100;
+        y = center ? center.y - 30 : 100;
       }
 
       const data = buildFactSheetCellData({
@@ -298,10 +386,307 @@ export default function DiagramEditor() {
     [handleToggleGroup],
   );
 
-  /** Handle postMessage events from DrawIO */
+  /* ---------- Create new (pending) fact sheet ---------- */
+  const handleCreateFactSheet = useCallback(
+    (data: { type: string; name: string; description?: string }) => {
+      const frame = iframeRef.current;
+      if (!frame) return;
+
+      let x: number, y: number;
+      if (contextInsertPosRef.current) {
+        ({ x, y } = contextInsertPosRef.current);
+        contextInsertPosRef.current = null;
+      } else {
+        const center = getVisibleCenter(frame);
+        x = center ? center.x - 90 : 100;
+        y = center ? center.y - 30 : 100;
+      }
+
+      const typeInfo = fsTypesRef.current.find((t) => t.key === data.type);
+      const color = typeInfo?.color || "#999";
+      const tempId = `pending-${crypto.randomUUID()}`;
+
+      const cellId = insertPendingFactSheet(frame, {
+        tempId,
+        type: data.type,
+        name: data.name,
+        color,
+        x,
+        y,
+      });
+
+      if (cellId) {
+        setSnackMsg(`"${data.name}" added (pending sync)`);
+      }
+      setCreateOpen(false);
+    },
+    [],
+  );
+
+  /* ---------- Relation picker result ---------- */
+  const handleRelationPicked = useCallback(
+    (relType: RelationType, direction: "as-is" | "reversed") => {
+      const frame = iframeRef.current;
+      const ep = pendingEdgeRef.current;
+      if (!frame || !ep) return;
+
+      const color = direction === "as-is" ? ep.sourceColor : ep.targetColor;
+
+      stampEdgeAsRelation(frame, ep.edgeCellId, relType.key, relType.label, color, true);
+
+      setRelPickerOpen(false);
+      pendingEdgeRef.current = null;
+      setSnackMsg(`Relation "${relType.label}" added (pending sync)`);
+    },
+    [],
+  );
+
+  const handleRelationCancelled = useCallback(() => {
+    // User cancelled — remove the edge
+    const frame = iframeRef.current;
+    const ep = pendingEdgeRef.current;
+    if (frame && ep) {
+      removeDiagramCell(frame, ep.edgeCellId);
+    }
+    setRelPickerOpen(false);
+    pendingEdgeRef.current = null;
+  }, []);
+
+  /* ---------- Sync panel helpers ---------- */
+  const refreshSyncPanel = useCallback(() => {
+    const frame = iframeRef.current;
+    if (!frame) return;
+
+    const { pendingFS: pfs, pendingRels: prels, syncedFS: _ } = scanDiagramItems(frame);
+
+    setPendingFS(
+      pfs.map((p) => {
+        const typeInfo = fsTypesRef.current.find((t) => t.key === p.type);
+        return {
+          cellId: p.cellId,
+          type: p.type,
+          typeLabel: typeInfo?.label || p.type,
+          typeColor: typeInfo?.color || "#999",
+          name: p.name,
+        };
+      }),
+    );
+
+    setPendingRels(
+      prels.map((p) => {
+        const srcType = fsTypesRef.current.find((t) =>
+          pfs.some((f) => f.tempId === p.sourceFactSheetId && f.type === t.key),
+        );
+        return {
+          edgeCellId: p.edgeCellId,
+          relationType: p.relationType,
+          relationLabel: p.relationLabel,
+          sourceName: p.sourceName,
+          targetName: p.targetName,
+          sourceColor: srcType?.color || "#999",
+          targetColor: "#999",
+          sourceFactSheetId: p.sourceFactSheetId,
+          targetFactSheetId: p.targetFactSheetId,
+        };
+      }),
+    );
+  }, []);
+
+  const handleSyncFS = useCallback(
+    async (cellId: string) => {
+      const frame = iframeRef.current;
+      if (!frame) return;
+      const item = pendingFS.find((p) => p.cellId === cellId);
+      if (!item) return;
+
+      setSyncing(true);
+      try {
+        const scanned = scanDiagramItems(frame);
+        const raw = scanned.pendingFS.find((p) => p.cellId === cellId);
+        const resp = await api.post<FactSheet>("/fact-sheets", {
+          type: item.type,
+          name: item.name,
+        });
+        markCellSynced(frame, cellId, resp.id, item.typeColor);
+        // Attach expand overlay now that it has a real ID
+        addExpandOverlay(frame, cellId, false, () =>
+          handleToggleGroup(cellId, resp.id, false),
+        );
+        // Update any pending relations that reference the old temp ID
+        const tempId = raw?.tempId;
+        if (tempId) {
+          const { pendingRels: currentRels } = scanDiagramItems(frame);
+          for (const rel of currentRels) {
+            if (rel.sourceFactSheetId === tempId || rel.targetFactSheetId === tempId) {
+              // The edge endpoints are already connected to the cell — the cell's
+              // factSheetId attribute was just updated, so the next scan will pick
+              // up the real ID. No extra action needed.
+            }
+          }
+        }
+        setSnackMsg(`"${item.name}" pushed to inventory`);
+        refreshSyncPanel();
+      } catch {
+        setSnackMsg("Failed to create fact sheet");
+      } finally {
+        setSyncing(false);
+      }
+    },
+    [pendingFS, handleToggleGroup, refreshSyncPanel],
+  );
+
+  const handleSyncRel = useCallback(
+    async (edgeCellId: string) => {
+      const frame = iframeRef.current;
+      if (!frame) return;
+
+      setSyncing(true);
+      try {
+        // Re-scan to get fresh IDs (in case FS was just synced)
+        const { pendingRels } = scanDiagramItems(frame);
+        const rel = pendingRels.find((r) => r.edgeCellId === edgeCellId);
+        if (!rel) return;
+
+        // Both endpoints must have real (non-pending) IDs
+        if (rel.sourceFactSheetId.startsWith("pending-") || rel.targetFactSheetId.startsWith("pending-")) {
+          setSnackMsg("Sync the connected fact sheets first");
+          return;
+        }
+
+        await api.post("/relations", {
+          type: rel.relationType,
+          source_id: rel.sourceFactSheetId,
+          target_id: rel.targetFactSheetId,
+        });
+
+        markEdgeSynced(frame, edgeCellId, "#666");
+        setSnackMsg(`Relation "${rel.relationLabel}" pushed to inventory`);
+        refreshSyncPanel();
+      } catch {
+        setSnackMsg("Failed to create relation");
+      } finally {
+        setSyncing(false);
+      }
+    },
+    [refreshSyncPanel],
+  );
+
+  const handleSyncAll = useCallback(async () => {
+    const frame = iframeRef.current;
+    if (!frame) return;
+    setSyncing(true);
+
+    try {
+      // 1. Sync all pending fact sheets first
+      const { pendingFS: pfs } = scanDiagramItems(frame);
+      for (const p of pfs) {
+        const typeInfo = fsTypesRef.current.find((t) => t.key === p.type);
+        try {
+          const resp = await api.post<FactSheet>("/fact-sheets", {
+            type: p.type,
+            name: p.name,
+          });
+          markCellSynced(frame, p.cellId, resp.id, typeInfo?.color || "#999");
+          addExpandOverlay(frame, p.cellId, false, () =>
+            handleToggleGroup(p.cellId, resp.id, false),
+          );
+        } catch {
+          setSnackMsg(`Failed to sync "${p.name}"`);
+        }
+      }
+
+      // 2. Sync all pending relations
+      const { pendingRels: prels } = scanDiagramItems(frame);
+      for (const r of prels) {
+        if (r.sourceFactSheetId.startsWith("pending-") || r.targetFactSheetId.startsWith("pending-")) {
+          continue; // skip if endpoints still pending
+        }
+        try {
+          await api.post("/relations", {
+            type: r.relationType,
+            source_id: r.sourceFactSheetId,
+            target_id: r.targetFactSheetId,
+          });
+          markEdgeSynced(frame, r.edgeCellId, "#666");
+        } catch {
+          setSnackMsg(`Failed to sync relation "${r.relationLabel}"`);
+        }
+      }
+
+      refreshSyncPanel();
+      setSnackMsg("Synchronisation complete");
+    } finally {
+      setSyncing(false);
+    }
+  }, [handleToggleGroup, refreshSyncPanel]);
+
+  const handleRemoveFS = useCallback(
+    (cellId: string) => {
+      const frame = iframeRef.current;
+      if (frame) removeDiagramCell(frame, cellId);
+      refreshSyncPanel();
+    },
+    [refreshSyncPanel],
+  );
+
+  const handleRemoveRel = useCallback(
+    (edgeCellId: string) => {
+      const frame = iframeRef.current;
+      if (frame) removeDiagramCell(frame, edgeCellId);
+      refreshSyncPanel();
+    },
+    [refreshSyncPanel],
+  );
+
+  const handleCheckUpdates = useCallback(async () => {
+    const frame = iframeRef.current;
+    if (!frame) return;
+    setCheckingUpdates(true);
+
+    try {
+      const { syncedFS } = scanDiagramItems(frame);
+      const stale: StaleItem[] = [];
+
+      for (const item of syncedFS) {
+        try {
+          const fs = await api.get<FactSheet>(`/fact-sheets/${item.factSheetId}`);
+          if (fs.name !== item.name) {
+            const typeInfo = fsTypesRef.current.find((t) => t.key === item.type);
+            stale.push({
+              cellId: item.cellId,
+              factSheetId: item.factSheetId,
+              diagramName: item.name,
+              inventoryName: fs.name,
+              typeColor: typeInfo?.color || "#999",
+            });
+          }
+        } catch {
+          // Fact sheet may have been deleted — skip
+        }
+      }
+
+      setStaleItems(stale);
+      if (stale.length === 0) setSnackMsg("All fact sheets are up to date");
+    } finally {
+      setCheckingUpdates(false);
+    }
+  }, []);
+
+  const handleAcceptStale = useCallback(
+    (cellId: string) => {
+      const frame = iframeRef.current;
+      const item = staleItems.find((s) => s.cellId === cellId);
+      if (!frame || !item) return;
+      updateCellLabel(frame, cellId, item.inventoryName);
+      setStaleItems((prev) => prev.filter((s) => s.cellId !== cellId));
+      setSnackMsg(`Updated to "${item.inventoryName}"`);
+    },
+    [staleItems],
+  );
+
+  /* ---------- PostMessage handler ---------- */
   useEffect(() => {
     const handler = (e: MessageEvent) => {
-      // Only accept messages that look like DrawIO JSON protocol
       if (typeof e.data !== "string") return;
       let msg: DrawIOMessage;
       try {
@@ -312,19 +697,14 @@ export default function DiagramEditor() {
 
       switch (msg.event) {
         case "init":
-          // Editor is ready — load the diagram XML
           postToDrawIO({
             action: "load",
             xml: diagram?.data?.xml || EMPTY_DIAGRAM,
             autosave: 0,
           });
-
-          // Bootstrap: grab the graph reference and inject context menu.
-          // Give DrawIO a tick to finish its own init processing.
           setTimeout(() => {
             if (iframeRef.current) {
               bootstrapDrawIO(iframeRef.current);
-              // Re-add expand/collapse overlays to existing fact sheet cells
               setTimeout(() => {
                 if (iframeRef.current) {
                   refreshFactSheetOverlays(iframeRef.current, handleToggleGroup);
@@ -336,25 +716,13 @@ export default function DiagramEditor() {
 
         case "save":
           if (msg.xml) {
-            // Store XML for when thumbnail export completes
             pendingSaveXmlRef.current = msg.xml;
-            // Request SVG export for thumbnail
-            postToDrawIO({
-              action: "export",
-              format: "svg",
-              spinKey: "saving",
-            });
-            // Acknowledge the save to DrawIO (clears modified state)
-            postToDrawIO({
-              action: "status",
-              messageKey: "allChangesSaved",
-              modified: false,
-            });
+            postToDrawIO({ action: "export", format: "svg", spinKey: "saving" });
+            postToDrawIO({ action: "status", messageKey: "allChangesSaved", modified: false });
           }
           break;
 
         case "export":
-          // Thumbnail SVG arrived after a save
           if (pendingSaveXmlRef.current) {
             const xml = pendingSaveXmlRef.current;
             pendingSaveXmlRef.current = null;
@@ -363,7 +731,6 @@ export default function DiagramEditor() {
           break;
 
         case "exit":
-          // If modified, save first then navigate
           if (msg.modified && msg.xml) {
             saveDiagram(msg.xml).then(() => navigate("/diagrams"));
           } else {
@@ -372,12 +739,28 @@ export default function DiagramEditor() {
           break;
 
         case "insertFactSheet":
-          // Custom event from our injected context menu item
-          contextInsertPosRef.current = {
-            x: msg.x ?? 100,
-            y: msg.y ?? 100,
-          };
+          contextInsertPosRef.current = { x: msg.x ?? 100, y: msg.y ?? 100 };
           setPickerOpen(true);
+          break;
+
+        case "createFactSheet":
+          contextInsertPosRef.current = { x: msg.x ?? 100, y: msg.y ?? 100 };
+          setCreateOpen(true);
+          break;
+
+        case "edgeConnected":
+          if (msg.edgeCellId && msg.sourceType && msg.targetType) {
+            pendingEdgeRef.current = {
+              edgeCellId: msg.edgeCellId,
+              sourceType: msg.sourceType,
+              targetType: msg.targetType,
+              sourceName: msg.sourceName || "?",
+              targetName: msg.targetName || "?",
+              sourceColor: msg.sourceColor || "#999",
+              targetColor: msg.targetColor || "#999",
+            };
+            setRelPickerOpen(true);
+          }
           break;
 
         default:
@@ -389,6 +772,15 @@ export default function DiagramEditor() {
     return () => window.removeEventListener("message", handler);
   }, [diagram, postToDrawIO, saveDiagram, navigate, handleToggleGroup]);
 
+  // Refresh sync panel counts whenever it opens
+  useEffect(() => {
+    if (syncOpen) refreshSyncPanel();
+  }, [syncOpen, refreshSyncPanel]);
+
+  /* ---------- Derived ---------- */
+  const totalPending = pendingFS.length + pendingRels.length;
+
+  /* ---------- Render ---------- */
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
@@ -396,10 +788,7 @@ export default function DiagramEditor() {
       </Box>
     );
   }
-
-  if (!diagram) {
-    return <Typography color="error">Diagram not found</Typography>;
-  }
+  if (!diagram) return <Typography color="error">Diagram not found</Typography>;
 
   const iframeSrc = `${DRAWIO_BASE_URL}?${DRAWIO_URL_PARAMS}`;
 
@@ -420,10 +809,25 @@ export default function DiagramEditor() {
         <IconButton size="small" onClick={() => navigate("/diagrams")}>
           <MaterialSymbol icon="arrow_back" size={20} />
         </IconButton>
-        <Typography variant="subtitle1" fontWeight={600} noWrap>
+        <Typography variant="subtitle1" fontWeight={600} noWrap sx={{ flex: 1 }}>
           {diagram.name}
         </Typography>
         {saving && <CircularProgress size={16} sx={{ ml: 1 }} />}
+
+        {/* Sync button */}
+        <Tooltip title="Synchronise diagram with inventory">
+          <IconButton size="small" onClick={() => setSyncOpen(true)}>
+            <Badge
+              badgeContent={totalPending}
+              color="warning"
+              max={99}
+              invisible={totalPending === 0}
+              sx={{ "& .MuiBadge-badge": { fontSize: "0.6rem", height: 16, minWidth: 16 } }}
+            >
+              <MaterialSymbol icon="sync" size={20} />
+            </Badge>
+          </IconButton>
+        </Tooltip>
       </Box>
 
       {/* DrawIO canvas */}
@@ -432,27 +836,49 @@ export default function DiagramEditor() {
           <iframe
             ref={iframeRef}
             src={iframeSrc}
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              width: "100%",
-              height: "100%",
-              border: "none",
-            }}
+            style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: "none" }}
             title="Diagram Editor"
           />
         </Box>
       </Box>
 
-      {/* Fact sheet picker dialog — opened from DrawIO right-click menu */}
+      {/* Dialogs */}
       <FactSheetPickerDialog
         open={pickerOpen}
-        onClose={() => {
-          setPickerOpen(false);
-          contextInsertPosRef.current = null;
-        }}
+        onClose={() => { setPickerOpen(false); contextInsertPosRef.current = null; }}
         onInsert={handleInsertFactSheet}
+      />
+
+      <CreateOnDiagramDialog
+        open={createOpen}
+        types={fsTypes}
+        onClose={() => { setCreateOpen(false); contextInsertPosRef.current = null; }}
+        onCreate={handleCreateFactSheet}
+      />
+
+      <RelationPickerDialog
+        open={relPickerOpen}
+        endpoints={pendingEdgeRef.current}
+        relationTypes={relationTypes}
+        onClose={handleRelationCancelled}
+        onSelect={handleRelationPicked}
+      />
+
+      <DiagramSyncPanel
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        pendingFS={pendingFS}
+        pendingRels={pendingRels}
+        staleItems={staleItems}
+        syncing={syncing}
+        onSyncAll={handleSyncAll}
+        onSyncFS={handleSyncFS}
+        onSyncRel={handleSyncRel}
+        onRemoveFS={handleRemoveFS}
+        onRemoveRel={handleRemoveRel}
+        onAcceptStale={handleAcceptStale}
+        onCheckUpdates={handleCheckUpdates}
+        checkingUpdates={checkingUpdates}
       />
 
       <Snackbar

--- a/frontend/src/features/diagrams/DiagramSyncPanel.tsx
+++ b/frontend/src/features/diagrams/DiagramSyncPanel.tsx
@@ -1,0 +1,264 @@
+import Box from "@mui/material/Box";
+import Drawer from "@mui/material/Drawer";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Divider from "@mui/material/Divider";
+import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
+import CircularProgress from "@mui/material/CircularProgress";
+import MaterialSymbol from "@/components/MaterialSymbol";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface PendingFactSheet {
+  cellId: string;
+  type: string;
+  typeLabel: string;
+  typeColor: string;
+  name: string;
+  description?: string;
+}
+
+export interface PendingRelation {
+  edgeCellId: string;
+  relationType: string;
+  relationLabel: string;
+  sourceName: string;
+  targetName: string;
+  sourceColor: string;
+  targetColor: string;
+  /** Real or pending- prefixed IDs of the connected fact sheets */
+  sourceFactSheetId: string;
+  targetFactSheetId: string;
+}
+
+export interface StaleItem {
+  cellId: string;
+  factSheetId: string;
+  diagramName: string;
+  inventoryName: string;
+  typeColor: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  pendingFS: PendingFactSheet[];
+  pendingRels: PendingRelation[];
+  staleItems: StaleItem[];
+  syncing: boolean;
+  onSyncAll: () => void;
+  onSyncFS: (cellId: string) => void;
+  onSyncRel: (edgeCellId: string) => void;
+  onRemoveFS: (cellId: string) => void;
+  onRemoveRel: (edgeCellId: string) => void;
+  onAcceptStale: (cellId: string) => void;
+  onCheckUpdates: () => void;
+  checkingUpdates: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export default function DiagramSyncPanel({
+  open,
+  onClose,
+  pendingFS,
+  pendingRels,
+  staleItems,
+  syncing,
+  onSyncAll,
+  onSyncFS,
+  onSyncRel,
+  onRemoveFS,
+  onRemoveRel,
+  onAcceptStale,
+  onCheckUpdates,
+  checkingUpdates,
+}: Props) {
+  const totalPending = pendingFS.length + pendingRels.length;
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose} PaperProps={{ sx: { width: 360 } }}>
+      {/* Header */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 2,
+          py: 1.5,
+          borderBottom: "1px solid #e0e0e0",
+        }}
+      >
+        <MaterialSymbol icon="sync" size={22} color="#1976d2" />
+        <Typography variant="subtitle1" fontWeight={700} sx={{ flex: 1 }}>
+          Synchronise
+        </Typography>
+        <IconButton size="small" onClick={onClose}>
+          <MaterialSymbol icon="close" size={18} />
+        </IconButton>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: "auto", px: 2, py: 1.5 }}>
+        {/* ---- Actions bar ---- */}
+        <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+          <Button
+            size="small"
+            variant="contained"
+            disabled={totalPending === 0 || syncing}
+            startIcon={syncing ? <CircularProgress size={14} /> : <MaterialSymbol icon="cloud_upload" size={16} />}
+            onClick={onSyncAll}
+          >
+            Push all ({totalPending})
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={checkingUpdates}
+            startIcon={checkingUpdates ? <CircularProgress size={14} /> : <MaterialSymbol icon="cloud_download" size={16} />}
+            onClick={onCheckUpdates}
+          >
+            Check updates
+          </Button>
+        </Box>
+
+        {/* ---- Pending fact sheets ---- */}
+        {pendingFS.length > 0 && (
+          <>
+            <SectionTitle icon="note_add" label="New Fact Sheets" count={pendingFS.length} />
+            {pendingFS.map((fs) => (
+              <ItemRow key={fs.cellId}>
+                <Box
+                  sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: fs.typeColor, flexShrink: 0 }}
+                />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" noWrap fontWeight={500}>
+                    {fs.name}
+                  </Typography>
+                  <Typography variant="caption" color="text.disabled">
+                    {fs.typeLabel}
+                  </Typography>
+                </Box>
+                <Tooltip title="Push to inventory">
+                  <IconButton size="small" onClick={() => onSyncFS(fs.cellId)} disabled={syncing}>
+                    <MaterialSymbol icon="cloud_upload" size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Remove from diagram">
+                  <IconButton size="small" onClick={() => onRemoveFS(fs.cellId)} disabled={syncing}>
+                    <MaterialSymbol icon="delete_outline" size={16} color="#c62828" />
+                  </IconButton>
+                </Tooltip>
+              </ItemRow>
+            ))}
+          </>
+        )}
+
+        {/* ---- Pending relations ---- */}
+        {pendingRels.length > 0 && (
+          <>
+            <SectionTitle icon="link" label="New Relations" count={pendingRels.length} />
+            {pendingRels.map((rel) => (
+              <ItemRow key={rel.edgeCellId}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" noWrap fontWeight={500}>
+                    {rel.sourceName}{" "}
+                    <Typography component="span" variant="caption" color="text.disabled">
+                      → {rel.relationLabel} →
+                    </Typography>{" "}
+                    {rel.targetName}
+                  </Typography>
+                </Box>
+                <Tooltip title="Push to inventory">
+                  <IconButton size="small" onClick={() => onSyncRel(rel.edgeCellId)} disabled={syncing}>
+                    <MaterialSymbol icon="cloud_upload" size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Remove from diagram">
+                  <IconButton size="small" onClick={() => onRemoveRel(rel.edgeCellId)} disabled={syncing}>
+                    <MaterialSymbol icon="delete_outline" size={16} color="#c62828" />
+                  </IconButton>
+                </Tooltip>
+              </ItemRow>
+            ))}
+          </>
+        )}
+
+        {/* ---- Stale / out-of-sync items ---- */}
+        {staleItems.length > 0 && (
+          <>
+            <SectionTitle icon="update" label="Inventory Changed" count={staleItems.length} />
+            {staleItems.map((item) => (
+              <ItemRow key={item.cellId}>
+                <Box
+                  sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: item.typeColor, flexShrink: 0 }}
+                />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" noWrap>
+                    <s style={{ color: "#999" }}>{item.diagramName}</s>{" "}
+                    <strong>{item.inventoryName}</strong>
+                  </Typography>
+                </Box>
+                <Tooltip title="Accept update from inventory">
+                  <IconButton size="small" onClick={() => onAcceptStale(item.cellId)}>
+                    <MaterialSymbol icon="check" size={16} color="#2e7d32" />
+                  </IconButton>
+                </Tooltip>
+              </ItemRow>
+            ))}
+          </>
+        )}
+
+        {/* ---- Empty state ---- */}
+        {totalPending === 0 && staleItems.length === 0 && (
+          <Box sx={{ textAlign: "center", py: 4 }}>
+            <MaterialSymbol icon="check_circle" size={36} color="#66bb6a" />
+            <Typography variant="body2" color="text.disabled" sx={{ mt: 1 }}>
+              Everything is in sync.
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Drawer>
+  );
+}
+
+/* ---- Small helpers ---- */
+
+function SectionTitle({ icon, label, count }: { icon: string; label: string; count: number }) {
+  return (
+    <>
+      <Divider sx={{ my: 1.5 }} />
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1 }}>
+        <MaterialSymbol icon={icon} size={16} color="#666" />
+        <Typography variant="subtitle2" fontWeight={700}>
+          {label}
+        </Typography>
+        <Chip size="small" label={count} sx={{ height: 18, fontSize: "0.65rem" }} />
+      </Box>
+    </>
+  );
+}
+
+function ItemRow({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        py: 0.75,
+        px: 1,
+        borderRadius: 1,
+        "&:hover": { bgcolor: "action.hover" },
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/features/diagrams/RelationPickerDialog.tsx
+++ b/frontend/src/features/diagrams/RelationPickerDialog.tsx
@@ -1,0 +1,129 @@
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import type { RelationType } from "@/types";
+
+export interface EdgeEndpoints {
+  edgeCellId: string;
+  sourceType: string;
+  targetType: string;
+  sourceName: string;
+  targetName: string;
+  sourceColor: string;
+  targetColor: string;
+}
+
+interface Props {
+  open: boolean;
+  endpoints: EdgeEndpoints | null;
+  relationTypes: RelationType[];
+  onClose: () => void;
+  onSelect: (relationType: RelationType, direction: "as-is" | "reversed") => void;
+}
+
+/**
+ * Dialog shown when the user draws an edge between two fact-sheet cells.
+ * Lists the valid relation types from the metamodel and lets the user pick one.
+ * Supports both directions: source→target and target→source.
+ */
+export default function RelationPickerDialog({
+  open,
+  endpoints,
+  relationTypes,
+  onClose,
+  onSelect,
+}: Props) {
+  if (!endpoints) return null;
+
+  // Find relation types valid for this pair (in either direction)
+  const matches: Array<{ rt: RelationType; direction: "as-is" | "reversed" }> = [];
+  for (const rt of relationTypes) {
+    if (rt.is_hidden) continue;
+    if (rt.source_type_key === endpoints.sourceType && rt.target_type_key === endpoints.targetType) {
+      matches.push({ rt, direction: "as-is" });
+    }
+    if (rt.source_type_key === endpoints.targetType && rt.target_type_key === endpoints.sourceType) {
+      matches.push({ rt, direction: "reversed" });
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <MaterialSymbol icon="link" size={22} color="#1976d2" />
+        Pick Relation Type
+      </DialogTitle>
+      <DialogContent sx={{ px: 1, pt: "0 !important" }}>
+        {/* Show source → target labels */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, px: 2, py: 1.5 }}>
+          <Chip
+            size="small"
+            label={endpoints.sourceName}
+            sx={{ bgcolor: endpoints.sourceColor + "22", fontWeight: 600, maxWidth: 140 }}
+          />
+          <MaterialSymbol icon="arrow_forward" size={16} color="#999" />
+          <Chip
+            size="small"
+            label={endpoints.targetName}
+            sx={{ bgcolor: endpoints.targetColor + "22", fontWeight: 600, maxWidth: 140 }}
+          />
+        </Box>
+
+        {matches.length === 0 ? (
+          <Typography variant="body2" color="text.disabled" sx={{ px: 2, py: 2 }}>
+            No valid relation types exist between these two fact sheet types in the metamodel.
+          </Typography>
+        ) : (
+          <List dense disablePadding>
+            {matches.map(({ rt, direction }) => {
+              const srcName = direction === "as-is" ? endpoints.sourceName : endpoints.targetName;
+              const tgtName = direction === "as-is" ? endpoints.targetName : endpoints.sourceName;
+              return (
+                <ListItemButton
+                  key={`${rt.key}-${direction}`}
+                  onClick={() => onSelect(rt, direction)}
+                  sx={{ borderRadius: 1, mx: 1, my: 0.25 }}
+                >
+                  <ListItemText
+                    primary={rt.label}
+                    secondary={
+                      <>
+                        {srcName} → {tgtName}
+                        {rt.description && (
+                          <>
+                            {" · "}
+                            {rt.description}
+                          </>
+                        )}
+                      </>
+                    }
+                    primaryTypographyProps={{ fontWeight: 600 }}
+                    secondaryTypographyProps={{ fontSize: "0.75rem" }}
+                  />
+                  <Chip
+                    size="small"
+                    label={rt.cardinality}
+                    variant="outlined"
+                    sx={{ ml: 1, height: 20, fontSize: "0.65rem", color: "text.disabled" }}
+                  />
+                </ListItemButton>
+              );
+            })}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
…iew panel

- CreateOnDiagramDialog: lightweight dialog to create fact sheets directly on the diagram via right-click context menu
- RelationPickerDialog: metamodel-constrained relation type picker shown when drawing edges between fact sheet cells
- DiagramSyncPanel: right-drawer review panel showing pending fact sheets, pending relations, and inventory drift (stale items)
- drawio-shapes.ts: new helpers for pending cells (dashed style), edge stamping, cell scanning, sync marking, and label updates
- DiagramEditor.tsx: wired up all new dialogs, edge interception via connectionHandler, sync panel state, and toolbar sync button with badge

https://claude.ai/code/session_01WgKY9v6z7U7V8rpEo9da8E