### PR TITLE
Fix DrawIO on Cloudflare and detect edge-only deletions

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,9 +33,12 @@ COPY drawio-config/high-contrast.css /usr/share/nginx/drawio/styles/high-contras
 
 # Strip PWA manifest + service-worker from DrawIO so it works behind auth
 # proxies like Cloudflare Access (browser manifest fetches don't send cookies).
+# Also inject <!--email_off--> to disable Cloudflare Email Address Obfuscation
+# which rewrites page content, breaking DrawIO's JavaScript initialisation.
 RUN sed -i \
     -e '/<link rel="manifest"/d' \
     -e '/serviceWorker/d' \
+    -e 's/<head>/<head><!--email_off-->/' \
     /usr/share/nginx/drawio/index.html
 
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,13 +23,21 @@ server {
 
     # Self-hosted DrawIO — static webapp served from the same container.
     # Loaded inside an iframe by the diagram editor; never accessed directly.
-    # "no-transform" prevents Cloudflare Rocket Loader / Auto Minify from
-    # rewriting DrawIO's JavaScript, which breaks the editor.
+
+    # DrawIO HTML — bypass Cloudflare caching entirely so Email Obfuscation,
+    # Auto Minify and other content-rewriting features never touch it.
+    location = /drawio/index.html {
+        alias /usr/share/nginx/drawio/index.html;
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        add_header Cache-Control "no-store, no-transform" always;
+    }
+
+    # DrawIO static assets (JS, CSS, images) — cacheable but no-transform.
     location ^~ /drawio/ {
         alias /usr/share/nginx/drawio/;
         add_header X-Robots-Tag "noindex, nofollow" always;
         expires 30d;
-        add_header Cache-Control "public, no-transform";
+        add_header Cache-Control "public, no-transform" always;
     }
 
     # SPA fallback


### PR DESCRIPTION
Cloudflare:
- Inject <!--email_off--> into DrawIO HTML to prevent Cloudflare's Email Address Obfuscation from rewriting page content and breaking the JavaScript initialisation
- Serve drawio/index.html with no-store, no-transform (bypasses CF caching entirely so no content-rewriting features can touch it)
- Keep static assets (JS/CSS) cacheable with no-transform

Expand/collapse:
- getGroupChildFactSheetIds now checks both vertex presence AND edge connectivity via graph.getEdgesBetween — catches edge-only deletions (user deletes a relation line but leaves the child shape)

https://claude.ai/code/session_01WgKY9v6z7U7V8rpEo9da8E