### PR TITLE
Fix AppSettings model: add datetime type to Mapped[updated_at]

### DIFF
--- a/backend/app/models/app_settings.py
+++ b/backend/app/models/app_settings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -14,6 +16,6 @@ class AppSettings(Base):
 
     id: Mapped[str] = mapped_column(String(50), primary_key=True, default="default")
     email_settings: Mapped[dict | None] = mapped_column(JSONB, default=dict)
-    updated_at: Mapped = mapped_column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )


### PR DESCRIPTION
The untyped Mapped annotation caused SQLAlchemy 2.0 to fail on model registration, crashing the backend on startup (502).

https://claude.ai/code/session_0138ZT7DCAKp7nWynmd55xQi