### PR TITLE
Show revision number on SoAW cards, rename menu to Delivery

### DIFF
--- a/frontend/src/features/ea-delivery/EADeliveryPage.tsx
+++ b/frontend/src/features/ea-delivery/EADeliveryPage.tsx
@@ -287,6 +287,11 @@ export default function EADeliveryPage() {
         <MaterialSymbol icon="description" size={20} color="#e65100" />
         <Typography sx={{ ml: 1, fontSize: "0.9rem", flex: 1 }}>
           {s.name}
+          {s.revision_number > 1 && (
+            <Typography component="span" sx={{ ml: 0.5, fontSize: "0.8rem", color: "text.secondary" }}>
+              (Rev {s.revision_number})
+            </Typography>
+          )}
         </Typography>
         <Chip
           label={STATUS_LABELS[s.status] ?? s.status}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -48,7 +48,7 @@ const NAV_ITEMS: NavItem[] = [
     ],
   },
   { label: "Diagrams", icon: "schema", path: "/diagrams" },
-  { label: "EA Delivery", icon: "architecture", path: "/ea-delivery" },
+  { label: "Delivery", icon: "architecture", path: "/ea-delivery" },
   { label: "Todos", icon: "checklist", path: "/todos" },
 ];
 


### PR DESCRIPTION
- Display "(Rev N)" next to SoAW name in EA Delivery page when revision > 1
- Rename navigation menu item from "EA Delivery" to "Delivery"

https://claude.ai/code/session_0138ZT7DCAKp7nWynmd55xQi