### PR TITLE
Fix survey related-FS autocomplete and send 500 error

### DIFF
--- a/backend/app/api/v1/surveys.py
+++ b/backend/app/api/v1/surveys.py
@@ -464,6 +464,7 @@ async def send_survey(
     survey.status = "active"
     survey.sent_at = datetime.now(timezone.utc)
     await db.commit()
+    await db.refresh(survey)
 
     stats = await _get_response_stats(db, survey.id)
     return {**_survey_to_dict(survey, stats), "targets_created": created}
@@ -489,6 +490,7 @@ async def close_survey(
     survey.status = "closed"
     survey.closed_at = datetime.now(timezone.utc)
     await db.commit()
+    await db.refresh(survey)
 
     stats = await _get_response_stats(db, survey.id)
     return _survey_to_dict(survey, stats)


### PR DESCRIPTION
- Autocomplete: track selected items as objects (not just IDs) so they persist across search queries; merge selected with search results; use controlled inputValue with reset-guard
- send_survey / close_survey: add db.refresh(survey) after commit to prevent async lazy-load error when serializing the response

https://claude.ai/code/session_0138ZT7DCAKp7nWynmd55xQi