### PR TITLE
Add badge indicators for open todos and pending surveys

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -395,6 +395,11 @@ export interface SurveyRespondForm {
   existing_responses: Record<string, { current_value: unknown; new_value: unknown; confirmed: boolean }>;
 }
 
+export interface BadgeCounts {
+  open_todos: number;
+  pending_surveys: number;
+}
+
 export interface DiagramSummary {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
This PR adds visual badge indicators to the navigation bar to display counts of open todos and pending surveys, helping users quickly see what action items need their attention.

## Key Changes

**Frontend:**
- Added `BadgeCounts` type to track open todos and pending surveys counts
- Implemented badge count fetching via new `/notifications/badge-counts` API endpoint
- Added real-time updates using event stream for relevant events (todo/survey creation, updates, deletions, responses)
- Added refresh on route navigation to catch actions completed within the app
- Wrapped navigation icons with Material-UI `Badge` components showing red dot indicators when counts > 0
- Applied badges to both mobile drawer and desktop navigation items

**Backend:**
- Created new `/notifications/badge-counts` endpoint that returns:
  - `open_todos`: count of todos with "open" status assigned to or created by the user
  - `pending_surveys`: count of survey responses with "pending" status for the user
- Updated notification service to allow self-notifications for batch/admin actions (survey requests, todo assignments)
- Modified email service functions to return boolean indicating whether email was actually sent
- Updated notification creation to only mark email as sent if the send operation succeeded

## Implementation Details
- Badge counts are fetched on component mount and whenever the location pathname changes
- Real-time event stream listens for: `notification.created`, `todo.created/updated/deleted`, `survey.sent/responded`
- The `hasBadge()` helper function determines visibility based on navigation item label and count thresholds
- Email sending now properly tracks success/failure to avoid marking unsent emails as sent

https://claude.ai/code/session_01NXrwgP8rA5nP5u6gd78Amr