### PR TITLE
Fix todo creation modal allowing duplicate submissions on mobile

### DIFF
--- a/frontend/src/features/fact-sheets/FactSheetDetail.tsx
+++ b/frontend/src/features/fact-sheets/FactSheetDetail.tsx
@@ -1361,6 +1361,7 @@ function TodosTab({ fsId }: { fsId: string }) {
   const [newDesc, setNewDesc] = useState("");
   const [newAssignee, setNewAssignee] = useState("");
   const [newDueDate, setNewDueDate] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const load = useCallback(() => {
     api
@@ -1375,16 +1376,21 @@ function TodosTab({ fsId }: { fsId: string }) {
   }, []);
 
   const handleAdd = async () => {
-    if (!newDesc.trim()) return;
-    const payload: Record<string, unknown> = { description: newDesc };
-    if (newAssignee) payload.assigned_to = newAssignee;
-    if (newDueDate) payload.due_date = newDueDate;
-    await api.post(`/fact-sheets/${fsId}/todos`, payload);
-    setNewDesc("");
-    setNewAssignee("");
-    setNewDueDate("");
-    setDialogOpen(false);
-    load();
+    if (!newDesc.trim() || saving) return;
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = { description: newDesc };
+      if (newAssignee) payload.assigned_to = newAssignee;
+      if (newDueDate) payload.due_date = newDueDate;
+      await api.post(`/fact-sheets/${fsId}/todos`, payload);
+      setNewDesc("");
+      setNewAssignee("");
+      setNewDueDate("");
+      setDialogOpen(false);
+      load();
+    } finally {
+      setSaving(false);
+    }
   };
 
   const toggleStatus = async (todo: Todo) => {
@@ -1511,8 +1517,8 @@ function TodosTab({ fsId }: { fsId: string }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" disabled={!newDesc.trim()} onClick={handleAdd}>
-            Add
+          <Button variant="contained" disabled={!newDesc.trim() || saving} onClick={handleAdd}>
+            {saving ? "Adding…" : "Add"}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
Add saving guard state to TodosTab's handleAdd function. The button and Enter key are now disabled while the API call is in-flight, preventing duplicate todos from being created on slow connections.

https://claude.ai/code/session_01NXrwgP8rA5nP5u6gd78Amr