### PR TITLE
Add type-level subscription roles CRUD and hide/unhide for fact sheet…

### DIFF
--- a/backend/alembic/versions/010_add_subscription_roles_to_types.py
+++ b/backend/alembic/versions/010_add_subscription_roles_to_types.py
@@ -1,0 +1,64 @@
+"""add subscription_roles column to fact_sheet_types
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-02-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+DEFAULT_ROLES = [
+    {"key": "responsible", "label": "Responsible"},
+    {"key": "observer", "label": "Observer"},
+]
+
+APP_ROLES = [
+    {"key": "responsible", "label": "Responsible"},
+    {"key": "observer", "label": "Observer"},
+    {"key": "technical_application_owner", "label": "Technical Application Owner"},
+    {"key": "business_application_owner", "label": "Business Application Owner"},
+]
+
+
+def upgrade() -> None:
+    from sqlalchemy import inspect as sa_inspect
+
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("fact_sheet_types")]
+    if "subscription_roles" in columns:
+        return
+
+    op.add_column(
+        "fact_sheet_types",
+        sa.Column("subscription_roles", postgresql.JSONB(), nullable=True),
+    )
+
+    # Backfill: Application gets 4 roles, everything else gets 2
+    fact_sheet_types = sa.table(
+        "fact_sheet_types",
+        sa.column("key", sa.String),
+        sa.column("subscription_roles", postgresql.JSONB),
+    )
+    op.execute(
+        fact_sheet_types.update()
+        .where(fact_sheet_types.c.key == "Application")
+        .values(subscription_roles=APP_ROLES)
+    )
+    op.execute(
+        fact_sheet_types.update()
+        .where(fact_sheet_types.c.key != "Application")
+        .values(subscription_roles=DEFAULT_ROLES)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fact_sheet_types", "subscription_roles")

--- a/backend/app/api/v1/fact_sheets.py
+++ b/backend/app/api/v1/fact_sheets.py
@@ -198,6 +198,11 @@ async def list_fact_sheets(
     q = select(FactSheet)
     count_q = select(func.count(FactSheet.id))
 
+    # Exclude fact sheets whose type is hidden
+    hidden_types_sq = select(FactSheetType.key).where(FactSheetType.is_hidden == True)  # noqa: E712
+    q = q.where(FactSheet.type.not_in(hidden_types_sq))
+    count_q = count_q.where(FactSheet.type.not_in(hidden_types_sq))
+
     if type:
         q = q.where(FactSheet.type == type)
         count_q = count_q.where(FactSheet.type == type)

--- a/backend/app/api/v1/subscriptions.py
+++ b/backend/app/api/v1/subscriptions.py
@@ -2,51 +2,70 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.database import get_db
 from app.models.fact_sheet import FactSheet
+from app.models.fact_sheet_type import FactSheetType
 from app.models.subscription import Subscription
 from app.models.user import User
 from app.schemas.common import SubscriptionCreate
 
 router = APIRouter(tags=["subscriptions"])
 
-# Roles available for all fact sheet types
-UNIVERSAL_ROLES = {"responsible", "observer"}
-# Roles restricted to specific fact sheet types
-TYPE_SPECIFIC_ROLES = {
-    "technical_application_owner": {"Application"},
-    "business_application_owner": {"Application"},
-}
-ALL_ROLES = UNIVERSAL_ROLES | TYPE_SPECIFIC_ROLES.keys()
+# Fallback roles when a type has no subscription_roles configured
+_DEFAULT_ROLES = [
+    {"key": "responsible", "label": "Responsible"},
+    {"key": "observer", "label": "Observer"},
+]
 
-ROLE_LABELS = {
-    "responsible": "Responsible",
-    "observer": "Observer",
-    "technical_application_owner": "Technical Application Owner",
-    "business_application_owner": "Business Application Owner",
-}
+
+async def _roles_for_type(db: AsyncSession, type_key: str) -> list[dict]:
+    """Return subscription roles defined on a fact sheet type."""
+    result = await db.execute(
+        select(FactSheetType.subscription_roles).where(FactSheetType.key == type_key)
+    )
+    roles = result.scalar_one_or_none()
+    return roles if roles else _DEFAULT_ROLES
+
+
+def _role_labels(roles: list[dict]) -> dict[str, str]:
+    return {r["key"]: r["label"] for r in roles}
 
 
 @router.get("/subscription-roles")
-async def list_roles():
-    """Return role definitions for the UI."""
-    return [
-        {
-            "key": k,
-            "label": v,
-            "allowed_types": list(TYPE_SPECIFIC_ROLES[k]) if k in TYPE_SPECIFIC_ROLES else None,
-        }
-        for k, v in ROLE_LABELS.items()
-    ]
+async def list_roles(
+    type_key: str | None = Query(None, description="Filter roles by fact sheet type"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return role definitions, optionally scoped to a specific type."""
+    if type_key:
+        roles = await _roles_for_type(db, type_key)
+        return [{"key": r["key"], "label": r["label"]} for r in roles]
+
+    # Return all unique roles across all types
+    result = await db.execute(select(FactSheetType.key, FactSheetType.subscription_roles))
+    all_roles: dict[str, dict] = {}
+    for row in result.all():
+        for r in (row[1] or _DEFAULT_ROLES):
+            if r["key"] not in all_roles:
+                all_roles[r["key"]] = {"key": r["key"], "label": r["label"]}
+    return list(all_roles.values())
 
 
 @router.get("/fact-sheets/{fs_id}/subscriptions")
 async def list_subscriptions(fs_id: str, db: AsyncSession = Depends(get_db)):
+    # Fetch the fact sheet type so we can resolve role labels
+    fs_result = await db.execute(
+        select(FactSheet.type).where(FactSheet.id == uuid.UUID(fs_id))
+    )
+    fs_type = fs_result.scalar_one_or_none()
+    roles = await _roles_for_type(db, fs_type) if fs_type else _DEFAULT_ROLES
+    labels = _role_labels(roles)
+
     result = await db.execute(
         select(Subscription).where(Subscription.fact_sheet_id == uuid.UUID(fs_id))
     )
@@ -58,7 +77,7 @@ async def list_subscriptions(fs_id: str, db: AsyncSession = Depends(get_db)):
             "user_display_name": s.user.display_name if s.user else None,
             "user_email": s.user.email if s.user else None,
             "role": s.role,
-            "role_label": ROLE_LABELS.get(s.role, s.role),
+            "role_label": labels.get(s.role, s.role),
             "created_at": s.created_at.isoformat() if s.created_at else None,
         }
         for s in subs
@@ -72,24 +91,18 @@ async def create_subscription(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
-    if body.role not in ALL_ROLES:
-        raise HTTPException(400, f"Invalid role '{body.role}'. Valid: {sorted(ALL_ROLES)}")
+    # Load fact sheet to get its type
+    fs_result = await db.execute(
+        select(FactSheet.type).where(FactSheet.id == uuid.UUID(fs_id))
+    )
+    fs_type = fs_result.scalar_one_or_none()
+    if not fs_type:
+        raise HTTPException(404, "Fact sheet not found")
 
-    # Check type-specific role constraints
-    if body.role in TYPE_SPECIFIC_ROLES:
-        fs_result = await db.execute(
-            select(FactSheet.type).where(FactSheet.id == uuid.UUID(fs_id))
-        )
-        fs_type = fs_result.scalar_one_or_none()
-        if not fs_type:
-            raise HTTPException(404, "Fact sheet not found")
-        allowed = TYPE_SPECIFIC_ROLES[body.role]
-        if fs_type not in allowed:
-            raise HTTPException(
-                400,
-                f"Role '{body.role}' is only allowed for types: {sorted(allowed)}. "
-                f"This fact sheet is type '{fs_type}'.",
-            )
+    roles = await _roles_for_type(db, fs_type)
+    valid_keys = {r["key"] for r in roles}
+    if body.role not in valid_keys:
+        raise HTTPException(400, f"Invalid role '{body.role}'. Valid for {fs_type}: {sorted(valid_keys)}")
 
     # Prevent duplicate role for same user on same fact sheet
     existing = await db.execute(
@@ -110,12 +123,14 @@ async def create_subscription(
     db.add(sub)
     await db.commit()
     await db.refresh(sub)
+
+    labels = _role_labels(roles)
     return {
         "id": str(sub.id),
         "user_id": str(sub.user_id),
         "user_display_name": sub.user.display_name if sub.user else None,
         "role": sub.role,
-        "role_label": ROLE_LABELS.get(sub.role, sub.role),
+        "role_label": labels.get(sub.role, sub.role),
     }
 
 
@@ -131,27 +146,25 @@ async def update_subscription(
     if not sub:
         raise HTTPException(404, "Subscription not found")
 
-    if body.role not in ALL_ROLES:
-        raise HTTPException(400, f"Invalid role '{body.role}'. Valid: {sorted(ALL_ROLES)}")
-
-    if body.role in TYPE_SPECIFIC_ROLES:
-        fs_result = await db.execute(
-            select(FactSheet.type).where(FactSheet.id == sub.fact_sheet_id)
-        )
-        fs_type = fs_result.scalar_one_or_none()
-        allowed = TYPE_SPECIFIC_ROLES[body.role]
-        if fs_type and fs_type not in allowed:
-            raise HTTPException(
-                400, f"Role '{body.role}' is only allowed for types: {sorted(allowed)}"
-            )
+    # Look up the fact sheet type to validate the new role
+    fs_result = await db.execute(
+        select(FactSheet.type).where(FactSheet.id == sub.fact_sheet_id)
+    )
+    fs_type = fs_result.scalar_one_or_none()
+    roles = await _roles_for_type(db, fs_type) if fs_type else _DEFAULT_ROLES
+    valid_keys = {r["key"] for r in roles}
+    if body.role not in valid_keys:
+        raise HTTPException(400, f"Invalid role '{body.role}'. Valid: {sorted(valid_keys)}")
 
     sub.role = body.role
     await db.commit()
+
+    labels = _role_labels(roles)
     return {
         "id": str(sub.id),
         "user_id": str(sub.user_id),
         "role": sub.role,
-        "role_label": ROLE_LABELS.get(sub.role, sub.role),
+        "role_label": labels.get(sub.role, sub.role),
     }
 
 

--- a/backend/app/models/fact_sheet_type.py
+++ b/backend/app/models/fact_sheet_type.py
@@ -21,6 +21,7 @@ class FactSheetType(Base, UUIDMixin, TimestampMixin):
     has_hierarchy: Mapped[bool] = mapped_column(Boolean, default=False)
     subtypes: Mapped[list | None] = mapped_column(JSONB, default=list)  # [{key, label}]
     fields_schema: Mapped[list] = mapped_column(JSONB, default=list)
+    subscription_roles: Mapped[list | None] = mapped_column(JSONB, default=list)  # [{key, label}]
     built_in: Mapped[bool] = mapped_column(Boolean, default=True)
     is_hidden: Mapped[bool] = mapped_column(Boolean, default=False)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -533,7 +533,17 @@ async def seed_metamodel(db: AsyncSession) -> None:
     if result.scalar_one_or_none() is not None:
         return  # Already seeded
 
+    _default_roles = [
+        {"key": "responsible", "label": "Responsible"},
+        {"key": "observer", "label": "Observer"},
+    ]
+    _app_roles = _default_roles + [
+        {"key": "technical_application_owner", "label": "Technical Application Owner"},
+        {"key": "business_application_owner", "label": "Business Application Owner"},
+    ]
+
     for i, t in enumerate(TYPES):
+        roles = _app_roles if t["key"] == "Application" else _default_roles
         fst = FactSheetType(
             key=t["key"],
             label=t["label"],
@@ -544,6 +554,7 @@ async def seed_metamodel(db: AsyncSession) -> None:
             has_hierarchy=t.get("has_hierarchy", False),
             subtypes=t.get("subtypes", []),
             fields_schema=t.get("fields_schema", []),
+            subscription_roles=t.get("subscription_roles", roles),
             built_in=True,
             is_hidden=t.get("is_hidden", False),
             sort_order=t.get("sort_order", i),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,6 +39,11 @@ export interface SectionDef {
   fields: FieldDef[];
 }
 
+export interface SubscriptionRoleDefinition {
+  key: string;
+  label: string;
+}
+
 export interface FactSheetType {
   key: string;
   label: string;
@@ -49,6 +54,7 @@ export interface FactSheetType {
   has_hierarchy: boolean;
   subtypes?: SubtypeDef[];
   fields_schema: SectionDef[];
+  subscription_roles?: SubscriptionRoleDefinition[];
   built_in: boolean;
   is_hidden: boolean;
   sort_order: number;


### PR DESCRIPTION
… types

Subscription Roles:
- Add subscription_roles JSONB column to FactSheetType model with migration (010) that backfills Application with 4 roles, all others with 2
- Rewrite subscriptions.py to read roles from the type instead of hardcoded constants; /subscription-roles now accepts ?type_key for scoped queries
- Validate subscription create/update against the type's configured roles
- Add delete protection: PATCH /metamodel/types blocks removing roles that have active subscriptions on fact sheets of that type
- Add Subscription Roles section to MetamodelAdmin TypeDetailDrawer with inline add/remove, matching the existing Subtypes pattern
- Update seed.py to populate subscription_roles for new databases

Hide/Unhide Fact Sheet Types:
- Add visibility toggle (eye icon) to type cards and detail drawer header
- Filter fact sheets of hidden types from GET /fact-sheets by default using a NOT IN subquery on hidden type keys
- Filter relations involving hidden-type fact sheets from GET /relations
- Hidden types' fact sheets and relations are invisible across inventory, reports, and all other views that consume these endpoints

https://claude.ai/code/session_01NXrwgP8rA5nP5u6gd78Amr