### PR TITLE
Add admin-configurable display currency for all cost values

### DIFF
--- a/backend/alembic/versions/012_add_general_settings.py
+++ b/backend/alembic/versions/012_add_general_settings.py
@@ -1,0 +1,41 @@
+"""add general_settings column to app_settings
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-02-13
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "012"
+down_revision: Union[str, None] = "011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    from sqlalchemy import inspect as sa_inspect
+
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+
+    if inspector.has_table("app_settings"):
+        columns = [c["name"] for c in inspector.get_columns("app_settings")]
+        if "general_settings" not in columns:
+            op.add_column(
+                "app_settings",
+                sa.Column(
+                    "general_settings",
+                    postgresql.JSONB(),
+                    server_default="{}",
+                    nullable=True,
+                ),
+            )
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "general_settings")

--- a/backend/app/models/app_settings.py
+++ b/backend/app/models/app_settings.py
@@ -16,6 +16,7 @@ class AppSettings(Base):
 
     id: Mapped[str] = mapped_column(String(50), primary_key=True, default="default")
     email_settings: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    general_settings: Mapped[dict | None] = mapped_column(JSONB, default=dict)
     custom_logo: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     custom_logo_mime: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(

--- a/frontend/src/features/admin/SettingsAdmin.tsx
+++ b/frontend/src/features/admin/SettingsAdmin.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
@@ -13,6 +14,30 @@ import Divider from "@mui/material/Divider";
 import Chip from "@mui/material/Chip";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
+import { useCurrency } from "@/hooks/useCurrency";
+
+const CURRENCIES = [
+  { code: "USD", label: "US Dollar ($)" },
+  { code: "EUR", label: "Euro (\u20ac)" },
+  { code: "GBP", label: "British Pound (\u00a3)" },
+  { code: "CHF", label: "Swiss Franc (CHF)" },
+  { code: "JPY", label: "Japanese Yen (\u00a5)" },
+  { code: "CNY", label: "Chinese Yuan (\u00a5)" },
+  { code: "CAD", label: "Canadian Dollar (CA$)" },
+  { code: "AUD", label: "Australian Dollar (A$)" },
+  { code: "SEK", label: "Swedish Krona (kr)" },
+  { code: "NOK", label: "Norwegian Krone (kr)" },
+  { code: "DKK", label: "Danish Krone (kr)" },
+  { code: "PLN", label: "Polish Z\u0142oty (z\u0142)" },
+  { code: "INR", label: "Indian Rupee (\u20b9)" },
+  { code: "BRL", label: "Brazilian Real (R$)" },
+  { code: "KRW", label: "South Korean Won (\u20a9)" },
+  { code: "SGD", label: "Singapore Dollar (S$)" },
+  { code: "HKD", label: "Hong Kong Dollar (HK$)" },
+  { code: "ZAR", label: "South African Rand (R)" },
+  { code: "MXN", label: "Mexican Peso (MX$)" },
+  { code: "TRY", label: "Turkish Lira (\u20ba)" },
+];
 
 interface EmailSettings {
   smtp_host: string;
@@ -43,6 +68,11 @@ export default function SettingsAdmin() {
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Currency state
+  const { currency: currentCurrency, invalidate: invalidateCurrency } = useCurrency();
+  const [selectedCurrency, setSelectedCurrency] = useState("USD");
+  const [savingCurrency, setSavingCurrency] = useState(false);
+
   const [smtpHost, setSmtpHost] = useState("");
   const [smtpPort, setSmtpPort] = useState(587);
   const [smtpUser, setSmtpUser] = useState("");
@@ -56,8 +86,9 @@ export default function SettingsAdmin() {
     Promise.all([
       api.get<EmailSettings>("/settings/email"),
       api.get<LogoInfo>("/settings/logo/info"),
+      api.get<{ currency: string }>("/settings/currency"),
     ])
-      .then(([emailData, logoData]) => {
+      .then(([emailData, logoData, currencyData]) => {
         setSmtpHost(emailData.smtp_host);
         setSmtpPort(emailData.smtp_port);
         setSmtpUser(emailData.smtp_user);
@@ -67,6 +98,7 @@ export default function SettingsAdmin() {
         setAppBaseUrl(emailData.app_base_url);
         setConfigured(emailData.configured);
         setHasCustomLogo(logoData.has_custom_logo);
+        setSelectedCurrency(currencyData.currency);
       })
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
       .finally(() => setLoading(false));
@@ -151,6 +183,20 @@ export default function SettingsAdmin() {
       setError(err instanceof Error ? err.message : "Failed to reset logo");
     } finally {
       setUploadingLogo(false);
+    }
+  };
+
+  const handleCurrencySave = async () => {
+    setSavingCurrency(true);
+    setError("");
+    try {
+      await api.patch("/settings/currency", { currency: selectedCurrency });
+      invalidateCurrency(selectedCurrency);
+      setSnack("Currency updated");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save currency");
+    } finally {
+      setSavingCurrency(false);
     }
   };
 
@@ -264,6 +310,53 @@ export default function SettingsAdmin() {
               </Button>
             )}
           </Box>
+        </Box>
+      </Paper>
+
+      {/* Currency Settings */}
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Box sx={{ display: "flex", alignItems: "center", mb: 2, gap: 1 }}>
+          <MaterialSymbol icon="payments" size={22} color="#555" />
+          <Typography variant="h6" fontWeight={600}>
+            Currency
+          </Typography>
+          <Chip
+            label={currentCurrency}
+            size="small"
+            color="default"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          Choose the currency used to display all cost values across reports,
+          dashboards, and fact sheet details.
+        </Typography>
+
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <TextField
+            select
+            size="small"
+            label="Display Currency"
+            value={selectedCurrency}
+            onChange={(e) => setSelectedCurrency(e.target.value)}
+            sx={{ minWidth: 280 }}
+          >
+            {CURRENCIES.map((c) => (
+              <MenuItem key={c.code} value={c.code}>
+                {c.code} — {c.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<MaterialSymbol icon="save" size={18} />}
+            sx={{ textTransform: "none" }}
+            onClick={handleCurrencySave}
+            disabled={savingCurrency || selectedCurrency === currentCurrency}
+          >
+            {savingCurrency ? "Saving..." : "Save"}
+          </Button>
         </Box>
       </Paper>
 

--- a/frontend/src/features/reports/CapabilityMapReport.tsx
+++ b/frontend/src/features/reports/CapabilityMapReport.tsx
@@ -18,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 import ReportShell from "./ReportShell";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
+import { useCurrency } from "@/hooks/useCurrency";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -347,6 +348,7 @@ function CapabilityCard({
   maxVal,
   onCapClick,
   onAppClick,
+  fmtCost,
 }: {
   node: CapNode;
   displayLevel: number;
@@ -356,10 +358,11 @@ function CapabilityCard({
   maxVal: number;
   onCapClick: (cap: CapNode) => void;
   onAppClick: (id: string) => void;
+  fmtCost: (v: number) => string;
 }) {
   const val = metricValue(node, metric);
   const fmtVal = (v: number) =>
-    metric === "total_cost" ? `$${(v / 1000).toFixed(0)}k` : String(v);
+    metric === "total_cost" ? fmtCost(v) : String(v);
 
   // Apps to display at THIS node — pushed to deepest visible level
   const visibleApps = useMemo(
@@ -519,6 +522,7 @@ function CapabilityCard({
               maxVal={maxVal}
               onCapClick={onCapClick}
               onAppClick={onAppClick}
+              fmtCost={fmtCost}
             />
           </Box>
         ))}
@@ -618,6 +622,7 @@ const HOST_OPTS = [
 
 export default function CapabilityMapReport() {
   const navigate = useNavigate();
+  const { fmtShort } = useCurrency();
 
   // Data
   const [data, setData] = useState<CapItem[] | null>(null);
@@ -686,8 +691,8 @@ export default function CapabilityMapReport() {
   }, [tree, metric]);
 
   const fmtVal = useCallback(
-    (v: number) => (metric === "total_cost" ? `$${(v / 1000).toFixed(0)}k` : String(v)),
-    [metric],
+    (v: number) => (metric === "total_cost" ? fmtShort(v) : String(v)),
+    [metric, fmtShort],
   );
 
   const handleAppClick = useCallback(
@@ -976,6 +981,7 @@ export default function CapabilityMapReport() {
               maxVal={maxVal}
               onCapClick={setDrawer}
               onAppClick={handleAppClick}
+              fmtCost={fmtShort}
             />
           ))}
         </Box>
@@ -1007,7 +1013,7 @@ export default function CapabilityMapReport() {
                     {o.key === "app_count"
                       ? drawer.deepAppCount
                       : o.key === "total_cost"
-                        ? `$${(metricValue(drawer, o.key) / 1000).toFixed(0)}k`
+                          ? fmtShort(metricValue(drawer, o.key))
                         : metricValue(drawer, o.key)}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">

--- a/frontend/src/features/reports/CostReport.tsx
+++ b/frontend/src/features/reports/CostReport.tsx
@@ -16,6 +16,7 @@ import { Treemap, ResponsiveContainer, Tooltip as RTooltip } from "recharts";
 import ReportShell from "./ReportShell";
 import MetricCard from "./MetricCard";
 import { useMetamodel } from "@/hooks/useMetamodel";
+import { useCurrency } from "@/hooks/useCurrency";
 import { api } from "@/api/client";
 import type { FieldDef } from "@/types";
 
@@ -33,8 +34,6 @@ interface CostGroup {
   cost: number;
 }
 
-const fmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
-
 function pickNumberFields(schema: { fields: FieldDef[] }[]): FieldDef[] {
   const out: FieldDef[] = [];
   for (const s of schema) for (const f of s.fields) if (f.type === "number") out.push(f);
@@ -48,11 +47,12 @@ function treemapColor(index: number): string {
   return COLORS[index % COLORS.length];
 }
 
-// Custom treemap content
+// Custom treemap content — receives formatter via extra props from Recharts spread
 const TreemapContent = ({
-  x, y, width, height, name, cost, index,
+  x, y, width, height, name, cost, index, costFmt,
 }: {
   x: number; y: number; width: number; height: number; name: string; cost: number; index: number;
+  costFmt: Intl.NumberFormat;
 }) => {
   if (width < 4 || height < 4) return null;
   const showLabel = width > 50 && height > 30;
@@ -67,7 +67,7 @@ const TreemapContent = ({
       )}
       {showCost && (
         <text x={x + 6} y={y + 30} fontSize={10} fill="rgba(255,255,255,0.8)">
-          {fmt.format(cost)}
+          {costFmt.format(cost)}
         </text>
       )}
     </g>
@@ -77,6 +77,7 @@ const TreemapContent = ({
 export default function CostReport() {
   const navigate = useNavigate();
   const { types, loading: ml } = useMetamodel();
+  const { fmt } = useCurrency();
   const [fsType, setFsType] = useState("Application");
   const [costField, setCostField] = useState("totalAnnualCost");
   const [groupBy, setGroupBy] = useState("");
@@ -187,7 +188,7 @@ export default function CostReport() {
                 data={treemapData}
                 dataKey="size"
                 stroke="#fff"
-                content={<TreemapContent x={0} y={0} width={0} height={0} name="" cost={0} index={0} />}
+                content={<TreemapContent x={0} y={0} width={0} height={0} name="" cost={0} index={0} costFmt={fmt} />}
               >
                 <RTooltip content={<Tip />} />
               </Treemap>

--- a/frontend/src/hooks/useCurrency.ts
+++ b/frontend/src/hooks/useCurrency.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { api } from "@/api/client";
+
+let _cache: string | null = null;
+const _listeners = new Set<(c: string) => void>();
+
+function notify(c: string) {
+  _cache = c;
+  for (const fn of _listeners) fn(c);
+}
+
+export function useCurrency() {
+  const [currency, setCurrency] = useState(_cache || "USD");
+  const [loading, setLoading] = useState(!_cache);
+
+  useEffect(() => {
+    _listeners.add(setCurrency);
+    if (!_cache) {
+      api
+        .get<{ currency: string }>("/settings/currency")
+        .then((r) => notify(r.currency))
+        .finally(() => setLoading(false));
+    }
+    return () => {
+      _listeners.delete(setCurrency);
+    };
+  }, []);
+
+  /** Full-format: e.g. $1,200,000 or 1.200.000 € */
+  const fmt = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: 0,
+      }),
+    [currency],
+  );
+
+  /** Currency symbol extracted from the formatter, e.g. "$", "€" */
+  const symbol = useMemo(() => {
+    const parts = fmt.formatToParts(0);
+    return parts.find((p) => p.type === "currency")?.value || currency;
+  }, [fmt, currency]);
+
+  /** Short format for tight spaces: e.g. $450k, €1.2M */
+  const fmtShort = useCallback(
+    (v: number) => {
+      if (Math.abs(v) >= 1_000) {
+        return `${symbol}${(v / 1_000).toFixed(0)}k`;
+      }
+      return fmt.format(v);
+    },
+    [symbol, fmt],
+  );
+
+  /** Call after admin changes the currency to update all consumers. */
+  const invalidate = useCallback((newCurrency: string) => {
+    notify(newCurrency);
+  }, []);
+
+  return { currency, loading, fmt, fmtShort, symbol, invalidate };
+}


### PR DESCRIPTION
Backend: new general_settings JSONB column on app_settings with public GET /settings/currency and admin PATCH /settings/currency endpoints. Default is USD. Migration 012 adds the column.

Frontend: new useCurrency hook (singleton cache with live broadcast to all consumers) provides Intl.NumberFormat-based fmt and fmtShort helpers. CostReport and CapabilityMapReport now use the hook instead of hardcoded USD/$. SettingsAdmin gains a Currency section with a dropdown of 20 common currencies and immediate save.

https://claude.ai/code/session_01Vmy6gdwFhLBqkdpKvowbqb