### PR TITLE
Make SoAW document fully read-only when signed

### DIFF
--- a/frontend/src/features/ea-delivery/EditableTable.tsx
+++ b/frontend/src/features/ea-delivery/EditableTable.tsx
@@ -14,9 +14,10 @@ interface Props {
   columns: string[];
   rows: string[][];
   onChange: (rows: string[][]) => void;
+  readOnly?: boolean;
 }
 
-export default function EditableTable({ columns, rows, onChange }: Props) {
+export default function EditableTable({ columns, rows, onChange, readOnly }: Props) {
   const updateCell = (ri: number, ci: number, value: string) => {
     const next = rows.map((r) => [...r]);
     next[ri][ci] = value;
@@ -52,7 +53,7 @@ export default function EditableTable({ columns, rows, onChange }: Props) {
                   {col}
                 </TableCell>
               ))}
-              <TableCell sx={{ width: 40, p: 0 }} />
+              {!readOnly && <TableCell sx={{ width: 40, p: 0 }} />}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -66,6 +67,7 @@ export default function EditableTable({ columns, rows, onChange }: Props) {
                     <InputBase
                       fullWidth
                       multiline
+                      readOnly={readOnly}
                       value={cell}
                       onChange={(e) => updateCell(ri, ci, e.target.value)}
                       sx={{
@@ -76,32 +78,36 @@ export default function EditableTable({ columns, rows, onChange }: Props) {
                     />
                   </TableCell>
                 ))}
-                <TableCell sx={{ p: 0, width: 40 }}>
-                  {rows.length > 1 && (
-                    <Tooltip title="Remove row">
-                      <IconButton
-                        size="small"
-                        className="row-action"
-                        sx={{ opacity: 0, transition: "opacity 0.15s" }}
-                        onClick={() => removeRow(ri)}
-                      >
-                        <MaterialSymbol icon="close" size={16} />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </TableCell>
+                {!readOnly && (
+                  <TableCell sx={{ p: 0, width: 40 }}>
+                    {rows.length > 1 && (
+                      <Tooltip title="Remove row">
+                        <IconButton
+                          size="small"
+                          className="row-action"
+                          sx={{ opacity: 0, transition: "opacity 0.15s" }}
+                          onClick={() => removeRow(ri)}
+                        >
+                          <MaterialSymbol icon="close" size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                )}
               </TableRow>
             ))}
           </TableBody>
         </Table>
       </TableContainer>
-      <Box sx={{ mt: 0.5 }}>
-        <Tooltip title="Add row">
-          <IconButton size="small" onClick={addRow}>
-            <MaterialSymbol icon="add" size={18} />
-          </IconButton>
-        </Tooltip>
-      </Box>
+      {!readOnly && (
+        <Box sx={{ mt: 0.5 }}>
+          <Tooltip title="Add row">
+            <IconButton size="small" onClick={addRow}>
+              <MaterialSymbol icon="add" size={18} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/frontend/src/features/ea-delivery/RichTextEditor.tsx
+++ b/frontend/src/features/ea-delivery/RichTextEditor.tsx
@@ -13,9 +13,10 @@ interface Props {
   content: string;
   onChange: (html: string) => void;
   placeholder?: string;
+  readOnly?: boolean;
 }
 
-export default function RichTextEditor({ content, onChange, placeholder }: Props) {
+export default function RichTextEditor({ content, onChange, placeholder, readOnly }: Props) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -25,10 +26,18 @@ export default function RichTextEditor({ content, onChange, placeholder }: Props
       Placeholder.configure({ placeholder: placeholder ?? "Start typing..." }),
     ],
     content,
+    editable: !readOnly,
     onUpdate: ({ editor: e }) => {
       onChange(e.getHTML());
     },
   });
+
+  // Sync editable state when readOnly changes
+  useEffect(() => {
+    if (editor) {
+      editor.setEditable(!readOnly);
+    }
+  }, [editor, readOnly]);
 
   // Sync external content changes (e.g. loading from API)
   useEffect(() => {
@@ -72,7 +81,7 @@ export default function RichTextEditor({ content, onChange, placeholder }: Props
       }}
     >
       {/* Toolbar */}
-      <Box
+      {!readOnly && <Box
         sx={{
           display: "flex",
           alignItems: "center",
@@ -144,7 +153,7 @@ export default function RichTextEditor({ content, onChange, placeholder }: Props
 
         {btn("undo", "Undo", () => editor.chain().focus().undo().run())}
         {btn("redo", "Redo", () => editor.chain().focus().redo().run())}
-      </Box>
+      </Box>}
 
       {/* Editor content */}
       <Box

--- a/frontend/src/features/ea-delivery/SoAWEditor.tsx
+++ b/frontend/src/features/ea-delivery/SoAWEditor.tsx
@@ -696,11 +696,13 @@ export default function SoAWEditor() {
           <Typography variant="h6" sx={{ fontWeight: 600, flex: 1 }}>
             Document Version History
           </Typography>
-          <Tooltip title="Add version entry">
-            <IconButton size="small" onClick={addVersionRow}>
-              <MaterialSymbol icon="add" size={18} />
-            </IconButton>
-          </Tooltip>
+          {!isSigned && (
+            <Tooltip title="Add version entry">
+              <IconButton size="small" onClick={addVersionRow}>
+                <MaterialSymbol icon="add" size={18} />
+              </IconButton>
+            </Tooltip>
+          )}
         </Box>
         <Table size="small">
           <TableHead>
@@ -719,6 +721,7 @@ export default function SoAWEditor() {
                   <TextField
                     size="small"
                     fullWidth
+                    disabled={isSigned}
                     value={row.version}
                     onChange={(e) =>
                       updateVersionRow(idx, "version", e.target.value)
@@ -732,6 +735,7 @@ export default function SoAWEditor() {
                   <TextField
                     size="small"
                     fullWidth
+                    disabled={isSigned}
                     type="date"
                     value={row.date}
                     onChange={(e) =>
@@ -747,6 +751,7 @@ export default function SoAWEditor() {
                   <TextField
                     size="small"
                     fullWidth
+                    disabled={isSigned}
                     value={row.revised_by}
                     onChange={(e) =>
                       updateVersionRow(idx, "revised_by", e.target.value)
@@ -760,6 +765,7 @@ export default function SoAWEditor() {
                   <TextField
                     size="small"
                     fullWidth
+                    disabled={isSigned}
                     value={row.description}
                     onChange={(e) =>
                       updateVersionRow(idx, "description", e.target.value)
@@ -770,7 +776,7 @@ export default function SoAWEditor() {
                   />
                 </TableCell>
                 <TableCell sx={{ p: 0.5 }}>
-                  {versionHistory.length > 1 && (
+                  {!isSigned && versionHistory.length > 1 && (
                     <IconButton size="small" onClick={() => removeVersionRow(idx)}>
                       <MaterialSymbol icon="close" size={16} />
                     </IconButton>
@@ -810,19 +816,22 @@ export default function SoAWEditor() {
                 <Typography sx={{ fontWeight: 600, flex: 1 }}>
                   {cs.title}
                 </Typography>
-                <Tooltip title="Remove custom section">
-                  <IconButton
-                    size="small"
-                    onClick={() => removeCustomSection(cs.id)}
-                  >
-                    <MaterialSymbol icon="delete_outline" size={18} />
-                  </IconButton>
-                </Tooltip>
+                {!isSigned && (
+                  <Tooltip title="Remove custom section">
+                    <IconButton
+                      size="small"
+                      onClick={() => removeCustomSection(cs.id)}
+                    >
+                      <MaterialSymbol icon="delete_outline" size={18} />
+                    </IconButton>
+                  </Tooltip>
+                )}
               </Box>
               <RichTextEditor
                 content={cs.content}
                 onChange={(html) => updateCustomContent(cs.id, html)}
                 placeholder="Enter content for this section..."
+                readOnly={isSigned}
               />
             </Paper>
           );
@@ -865,17 +874,19 @@ export default function SoAWEditor() {
               >
                 {def.title}
               </Typography>
-              <Tooltip title={isHidden ? "Show section" : "Hide section"}>
-                <IconButton
-                  size="small"
-                  onClick={() => toggleSectionHidden(def.id)}
-                >
-                  <MaterialSymbol
-                    icon={isHidden ? "visibility_off" : "visibility"}
-                    size={18}
-                  />
-                </IconButton>
-              </Tooltip>
+              {!isSigned && (
+                <Tooltip title={isHidden ? "Show section" : "Hide section"}>
+                  <IconButton
+                    size="small"
+                    onClick={() => toggleSectionHidden(def.id)}
+                  >
+                    <MaterialSymbol
+                      icon={isHidden ? "visibility_off" : "visibility"}
+                      size={18}
+                    />
+                  </IconButton>
+                </Tooltip>
+              )}
             </Box>
 
             {/* Section body */}
@@ -897,6 +908,7 @@ export default function SoAWEditor() {
                     updateSection(def.id, { content: html })
                   }
                   placeholder={def.hint}
+                  readOnly={isSigned}
                 />
               )}
 
@@ -912,6 +924,7 @@ export default function SoAWEditor() {
                       },
                     })
                   }
+                  readOnly={isSigned}
                 />
               )}
 
@@ -934,6 +947,7 @@ export default function SoAWEditor() {
                             size="small"
                             fullWidth
                             multiline
+                            disabled={isSigned}
                             placeholder="e.g. documents, diagrams, architecture decisions..."
                             value={data.togaf_data?.[phase.key] ?? ""}
                             onChange={(e) => {
@@ -966,16 +980,18 @@ export default function SoAWEditor() {
       })}
 
       {/* ── Add custom section ─────────────────────────────────────────── */}
-      <Box sx={{ display: "flex", justifyContent: "center", my: 3 }}>
-        <Button
-          variant="outlined"
-          startIcon={<MaterialSymbol icon="add" size={18} />}
-          sx={{ textTransform: "none" }}
-          onClick={() => setAddSectionOpen(true)}
-        >
-          Add Custom Section
-        </Button>
-      </Box>
+      {!isSigned && (
+        <Box sx={{ display: "flex", justifyContent: "center", my: 3 }}>
+          <Button
+            variant="outlined"
+            startIcon={<MaterialSymbol icon="add" size={18} />}
+            sx={{ textTransform: "none" }}
+            onClick={() => setAddSectionOpen(true)}
+          >
+            Add Custom Section
+          </Button>
+        </Box>
+      )}
 
       <Dialog
         open={addSectionOpen}


### PR DESCRIPTION
When a document has status "signed", all form inputs are now non-interactive — not just unsaveable. Changes:

- RichTextEditor: new readOnly prop disables TipTap editing and hides toolbar
- EditableTable: new readOnly prop disables inputs, hides add/remove buttons
- SoAWEditor: passes readOnly/disabled to all editors and fields when signed (version history, template sections, TOGAF phases, custom sections), hides section visibility toggles, delete buttons, and "Add Custom Section"

https://claude.ai/code/session_01Vmy6gdwFhLBqkdpKvowbqb