### PR TITLE
Fix predefined template name not showing on transformations

### DIFF
--- a/backend/alembic/versions/015_add_template_name_to_transformations.py
+++ b/backend/alembic/versions/015_add_template_name_to_transformations.py
@@ -1,0 +1,27 @@
+"""Add template_name column to transformations for predefined template tracking
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-02-13
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "015"
+down_revision: Union[str, None] = "014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transformations",
+        sa.Column("template_name", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("transformations", "template_name")

--- a/backend/app/api/v1/transformations.py
+++ b/backend/app/api/v1/transformations.py
@@ -64,6 +64,18 @@ def _tx_to_response(tx: Transformation) -> TransformationResponse:
             "name": tx.template.name,
             "target_fact_sheet_type": tx.template.target_fact_sheet_type,
         }
+    elif tx.template_name:
+        # Predefined templates aren't stored in DB — reconstruct ref from name
+        for pt in PREDEFINED_TEMPLATES:
+            if pt["name"] == tx.template_name:
+                template_ref = {
+                    "id": f"predefined:{pt['name'].lower().replace(' ', '_')}",
+                    "name": pt["name"],
+                    "target_fact_sheet_type": pt["target_fact_sheet_type"],
+                }
+                break
+        if not template_ref:
+            template_ref = {"id": "", "name": tx.template_name, "target_fact_sheet_type": ""}
     initiative_ref = None
     if tx.initiative:
         initiative_ref = {
@@ -272,6 +284,7 @@ async def create_transformation(
                     break
             if not template_schema:
                 raise HTTPException(status_code=404, detail="Predefined template not found")
+            tx.template_name = template_schema["name"]
         else:
             # Custom template from DB
             tpl_result = await db.execute(
@@ -283,6 +296,7 @@ async def create_transformation(
             if not tpl:
                 raise HTTPException(status_code=404, detail="Template not found")
             tx.template_id = tpl.id
+            tx.template_name = tpl.name
             template_schema = {
                 "implied_impacts_schema": tpl.implied_impacts_schema or [],
             }

--- a/backend/app/models/transformation.py
+++ b/backend/app/models/transformation.py
@@ -26,6 +26,7 @@ class Transformation(Base, UUIDMixin, TimestampMixin):
         ForeignKey("transformation_templates.id", ondelete="SET NULL"),
         nullable=True,
     )
+    template_name: Mapped[str | None] = mapped_column(String(500), nullable=True)
     status: Mapped[str] = mapped_column(
         String(50), default="draft", nullable=False
     )  # draft, planned, executed


### PR DESCRIPTION
Predefined templates (e.g., Introduce Application) aren't stored in the DB, so tx.template_id stays NULL and the response returned template: null.

Added a template_name column to transformations that gets set for both predefined and custom templates at creation time. The _tx_to_response helper now reconstructs a template ref from PREDEFINED_TEMPLATES when the relationship is NULL but template_name is set.

https://claude.ai/code/session_01LhTT6ECGWihrUUCQ82SqoR