### PR TITLE
Improve reports: timeline sliders, initiative dates, remove GroupBy

### DIFF
--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -214,12 +214,15 @@ async def roadmap(
     items = []
     for fs in sheets:
         lc = fs.lifecycle or {}
-        if any(lc.values()):
+        attrs = fs.attributes or {}
+        if any(lc.values()) or attrs.get("startDate") or attrs.get("endDate"):
             items.append({
                 "id": str(fs.id),
                 "name": fs.name,
                 "type": fs.type,
+                "subtype": fs.subtype,
                 "lifecycle": lc,
+                "attributes": attrs,
             })
     return {"items": items}
 

--- a/frontend/src/features/reports/CostReport.tsx
+++ b/frontend/src/features/reports/CostReport.tsx
@@ -12,9 +12,12 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TableSortLabel from "@mui/material/TableSortLabel";
+import Slider from "@mui/material/Slider";
+import Chip from "@mui/material/Chip";
 import { Treemap, ResponsiveContainer, Tooltip as RTooltip } from "recharts";
 import ReportShell from "./ReportShell";
 import MetricCard from "./MetricCard";
+import MaterialSymbol from "@/components/MaterialSymbol";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useCurrency } from "@/hooks/useCurrency";
 import { api } from "@/api/client";
@@ -24,14 +27,8 @@ interface CostItem {
   id: string;
   name: string;
   cost: number;
-  group?: string;
   lifecycle?: Record<string, string>;
   attributes?: Record<string, unknown>;
-}
-
-interface CostGroup {
-  name: string;
-  cost: number;
 }
 
 function pickNumberFields(schema: { fields: FieldDef[] }[]): FieldDef[] {
@@ -40,14 +37,38 @@ function pickNumberFields(schema: { fields: FieldDef[] }[]): FieldDef[] {
   return out;
 }
 
-// Color palette for treemap
+/* ------------------------------------------------------------------ */
+/*  Lifecycle helpers                                                   */
+/* ------------------------------------------------------------------ */
+
+const LIFECYCLE_PHASES = ["plan", "phaseIn", "active", "phaseOut", "endOfLife"];
+
+function parseDate(s: string | undefined): number | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d.getTime();
+}
+
+function isItemAliveAtDate(lc: Record<string, string> | undefined, dateMs: number): boolean {
+  if (!lc) return true;
+  const dates = LIFECYCLE_PHASES.map((p) => parseDate(lc[p])).filter((d): d is number => d != null);
+  if (dates.length === 0) return true;
+  if (Math.min(...dates) > dateMs) return false;
+  const eol = parseDate(lc.endOfLife);
+  if (eol != null && eol <= dateMs) return false;
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Treemap helpers                                                     */
+/* ------------------------------------------------------------------ */
+
 const COLORS = ["#1565c0", "#1976d2", "#1e88e5", "#2196f3", "#42a5f5", "#64b5f6", "#90caf9", "#bbdefb", "#0d47a1", "#1565c0"];
 
 function treemapColor(index: number): string {
   return COLORS[index % COLORS.length];
 }
 
-// Custom treemap content — receives formatter via extra props from Recharts spread
 const TreemapContent = ({
   x, y, width, height, name, cost, index, costFmt,
 }: {
@@ -62,7 +83,7 @@ const TreemapContent = ({
       <rect x={x} y={y} width={width} height={height} fill={treemapColor(index)} stroke="#fff" strokeWidth={2} rx={3} />
       {showLabel && (
         <text x={x + 6} y={y + 16} fontSize={11} fontWeight={600} fill="#fff">
-          {name.length > Math.floor(width / 7) ? name.slice(0, Math.floor(width / 7) - 1) + "…" : name}
+          {name.length > Math.floor(width / 7) ? name.slice(0, Math.floor(width / 7) - 1) + "\u2026" : name}
         </text>
       )}
       {showCost && (
@@ -74,37 +95,77 @@ const TreemapContent = ({
   );
 };
 
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
+
 export default function CostReport() {
   const navigate = useNavigate();
   const { types, loading: ml } = useMetamodel();
   const { fmt } = useCurrency();
   const [fsType, setFsType] = useState("Application");
   const [costField, setCostField] = useState("totalAnnualCost");
-  const [groupBy, setGroupBy] = useState("");
-  const [items, setItems] = useState<CostItem[] | null>(null);
-  const [total, setTotal] = useState(0);
-  const [, setGroups] = useState<CostGroup[] | null>(null);
+  const [rawItems, setRawItems] = useState<CostItem[] | null>(null);
   const [view, setView] = useState<"chart" | "table">("chart");
   const [sortK, setSortK] = useState("cost");
   const [sortD, setSortD] = useState<"asc" | "desc">("desc");
 
+  // Timeline slider
+  const todayMs = useMemo(() => Date.now(), []);
+  const [timelineDate, setTimelineDate] = useState(todayMs);
+
   const typeDef = useMemo(() => types.find((t) => t.key === fsType), [types, fsType]);
   const numFields = useMemo(() => (typeDef ? pickNumberFields(typeDef.fields_schema) : []), [typeDef]);
 
-  // Related types for groupBy options
-  const groupTypes = useMemo(() => types.filter((t) => t.key !== fsType), [types, fsType]);
-
   useEffect(() => {
     const p = new URLSearchParams({ type: fsType, cost_field: costField });
-    if (groupBy) p.set("group_by", groupBy);
-    api.get<{ items: CostItem[]; total: number; groups: CostGroup[] | null }>(`/reports/cost-treemap?${p}`).then((r) => {
-      setItems(r.items);
-      setTotal(r.total);
-      setGroups(r.groups);
+    api.get<{ items: CostItem[]; total: number }>(`/reports/cost-treemap?${p}`).then((r) => {
+      setRawItems(r.items);
     });
-  }, [fsType, costField, groupBy]);
+  }, [fsType, costField]);
 
-  if (ml || items === null)
+  // Compute date range from lifecycle data
+  const { dateRange, yearMarks } = useMemo(() => {
+    const now = todayMs;
+    const pad3y = 3 * 365.25 * 86400000;
+    if (!rawItems || rawItems.length === 0)
+      return { dateRange: { min: now - pad3y, max: now + pad3y }, yearMarks: [] as { value: number; label: string }[] };
+
+    let minD = Infinity, maxD = -Infinity;
+    for (const item of rawItems) {
+      for (const p of LIFECYCLE_PHASES) {
+        const d = parseDate(item.lifecycle?.[p]);
+        if (d != null) { minD = Math.min(minD, d); maxD = Math.max(maxD, d); }
+      }
+    }
+    if (minD === Infinity)
+      return { dateRange: { min: now - pad3y, max: now + pad3y }, yearMarks: [] as { value: number; label: string }[] };
+
+    const pad = 365.25 * 86400000;
+    minD -= pad; maxD += pad;
+    const marks: { value: number; label: string }[] = [];
+    const sy = new Date(minD).getFullYear(), ey = new Date(maxD).getFullYear();
+    for (let y = sy; y <= ey + 1; y++) {
+      const t = new Date(y, 0, 1).getTime();
+      if (t >= minD && t <= maxD) marks.push({ value: t, label: String(y) });
+    }
+    return { dateRange: { min: minD, max: maxD }, yearMarks: marks };
+  }, [rawItems, todayMs]);
+
+  const hasLifecycleData = useMemo(() => {
+    if (!rawItems) return false;
+    return rawItems.some((item) => item.lifecycle && LIFECYCLE_PHASES.some((p) => item.lifecycle?.[p]));
+  }, [rawItems]);
+
+  // Filter items by timeline date
+  const { items, total } = useMemo(() => {
+    if (!rawItems) return { items: [] as CostItem[], total: 0 };
+    const filtered = rawItems.filter((item) => isItemAliveAtDate(item.lifecycle, timelineDate));
+    const t = filtered.reduce((sum, item) => sum + item.cost, 0);
+    return { items: filtered, total: t };
+  }, [rawItems, timelineDate]);
+
+  if (ml || rawItems === null)
     return <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}><CircularProgress /></Box>;
 
   const topDriver = items.length > 0 ? items[0] : null;
@@ -122,9 +183,11 @@ export default function CostReport() {
   const sorted = [...items].sort((a, b) => {
     const d = sortD === "asc" ? 1 : -1;
     if (sortK === "cost") return (a.cost - b.cost) * d;
-    if (sortK === "group") return (a.group || "").localeCompare(b.group || "") * d;
     return a.name.localeCompare(b.name) * d;
   });
+
+  const fmtSliderDate = (v: number) =>
+    new Date(v).toLocaleDateString("en-US", { year: "numeric", month: "short" });
 
   const Tip = ({ active, payload }: { active?: boolean; payload?: { payload: { name: string; cost: number; size: number } }[] }) => {
     if (!active || !payload?.[0]) return null;
@@ -153,10 +216,32 @@ export default function CostReport() {
           <TextField select size="small" label="Cost Field" value={costField} onChange={(e) => setCostField(e.target.value)} sx={{ minWidth: 160 }}>
             {numFields.map((f) => <MenuItem key={f.key} value={f.key}>{f.label}</MenuItem>)}
           </TextField>
-          <TextField select size="small" label="Group By" value={groupBy} onChange={(e) => setGroupBy(e.target.value)} sx={{ minWidth: 160 }}>
-            <MenuItem value="">None</MenuItem>
-            {groupTypes.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
-          </TextField>
+
+          {hasLifecycleData && (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2, width: "100%", pt: 0.5 }}>
+              <MaterialSymbol icon="calendar_month" size={18} color="#999" />
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                Timeline:
+              </Typography>
+              <Slider
+                value={timelineDate}
+                min={dateRange.min}
+                max={dateRange.max}
+                step={86400000}
+                onChange={(_, v) => setTimelineDate(v as number)}
+                valueLabelDisplay="auto"
+                valueLabelFormat={fmtSliderDate}
+                marks={yearMarks}
+                sx={{ flex: 1, mx: 1 }}
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap", minWidth: 100 }}>
+                {new Date(timelineDate).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
+              </Typography>
+              {Math.abs(timelineDate - todayMs) > 86400000 && (
+                <Chip size="small" label="Today" variant="outlined" onClick={() => setTimelineDate(todayMs)} sx={{ fontSize: "0.72rem" }} />
+              )}
+            </Box>
+          )}
         </>
       }
     >
@@ -203,7 +288,6 @@ export default function CostReport() {
                 <TableCell><TableSortLabel active={sortK === "name"} direction={sortK === "name" ? sortD : "asc"} onClick={() => sort("name")}>Name</TableSortLabel></TableCell>
                 <TableCell align="right"><TableSortLabel active={sortK === "cost"} direction={sortK === "cost" ? sortD : "asc"} onClick={() => sort("cost")}>Cost</TableSortLabel></TableCell>
                 <TableCell align="right">% of Total</TableCell>
-                {groupBy && <TableCell><TableSortLabel active={sortK === "group"} direction={sortK === "group" ? sortD : "asc"} onClick={() => sort("group")}>Group</TableSortLabel></TableCell>}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -211,15 +295,13 @@ export default function CostReport() {
                 <TableRow key={d.id} hover sx={{ cursor: "pointer" }} onClick={() => navigate(`/fact-sheets/${d.id}`)}>
                   <TableCell sx={{ fontWeight: 500 }}>{d.name}</TableCell>
                   <TableCell align="right">{fmt.format(d.cost)}</TableCell>
-                  <TableCell align="right">{total > 0 ? `${((d.cost / total) * 100).toFixed(1)}%` : "—"}</TableCell>
-                  {groupBy && <TableCell>{d.group || "Ungrouped"}</TableCell>}
+                  <TableCell align="right">{total > 0 ? `${((d.cost / total) * 100).toFixed(1)}%` : "\u2014"}</TableCell>
                 </TableRow>
               ))}
               <TableRow sx={{ bgcolor: "#f5f5f5" }}>
                 <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
                 <TableCell align="right" sx={{ fontWeight: 700 }}>{fmt.format(total)}</TableCell>
                 <TableCell align="right" sx={{ fontWeight: 700 }}>100%</TableCell>
-                {groupBy && <TableCell />}
               </TableRow>
             </TableBody>
           </Table>

--- a/frontend/src/features/reports/LifecycleReport.tsx
+++ b/frontend/src/features/reports/LifecycleReport.tsx
@@ -15,18 +15,30 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TableSortLabel from "@mui/material/TableSortLabel";
 import Chip from "@mui/material/Chip";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import ReportShell from "./ReportShell";
 import ReportLegend from "./ReportLegend";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
 
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
 interface RoadmapItem {
   id: string;
   name: string;
   type: string;
+  subtype?: string;
   lifecycle: Record<string, string>;
+  attributes?: Record<string, unknown>;
 }
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
 
 const PHASES = [
   { key: "plan", label: "Plan", color: "#9e9e9e" },
@@ -35,6 +47,38 @@ const PHASES = [
   { key: "phaseOut", label: "Phase Out", color: "#ff9800" },
   { key: "endOfLife", label: "End of Life", color: "#f44336" },
 ];
+
+const INITIATIVE_COLORS: Record<string, Record<string, { label: string; color: string }>> = {
+  initiativeStatus: {
+    onTrack: { label: "On Track", color: "#4caf50" },
+    atRisk: { label: "At Risk", color: "#ff9800" },
+    offTrack: { label: "Off Track", color: "#d32f2f" },
+    onHold: { label: "On Hold", color: "#9e9e9e" },
+    completed: { label: "Completed", color: "#1976d2" },
+  },
+  businessValue: {
+    high: { label: "High", color: "#2e7d32" },
+    medium: { label: "Medium", color: "#ff9800" },
+    low: { label: "Low", color: "#9e9e9e" },
+  },
+  effort: {
+    high: { label: "High", color: "#d32f2f" },
+    medium: { label: "Medium", color: "#ff9800" },
+    low: { label: "Low", color: "#4caf50" },
+  },
+};
+
+const INITIATIVE_COLOR_OPTIONS = [
+  { key: "initiativeStatus", label: "Status" },
+  { key: "businessValue", label: "Business Value" },
+  { key: "effort", label: "Effort" },
+];
+
+const UNSET_BAR_COLOR = "#bdbdbd";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
 
 function parseDate(s: string | undefined): number | null {
   if (!s) return null;
@@ -52,9 +96,13 @@ function currentPhase(lc: Record<string, string>): string {
 }
 
 function fmtDate(s: string | undefined): string {
-  if (!s) return "—";
+  if (!s) return "\u2014";
   return new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short" });
 }
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
 
 export default function LifecycleReport() {
   const navigate = useNavigate();
@@ -65,6 +113,19 @@ export default function LifecycleReport() {
   const [sortK, setSortK] = useState("name");
   const [sortD, setSortD] = useState<"asc" | "desc">("asc");
   const timelineRef = useRef<HTMLDivElement>(null);
+
+  // Initiative-specific controls
+  const [useInitiativeDates, setUseInitiativeDates] = useState(false);
+  const [initiativeColorBy, setInitiativeColorBy] = useState("initiativeStatus");
+
+  const isInitiativeType = fsType === "Initiative";
+
+  // Reset initiative toggle when switching away from Initiative type
+  useEffect(() => {
+    if (!isInitiativeType) {
+      setUseInitiativeDates(false);
+    }
+  }, [isInitiativeType]);
 
   useEffect(() => {
     const params = fsType ? `?type=${fsType}` : "";
@@ -85,6 +146,13 @@ export default function LifecycleReport() {
       for (const p of PHASES) {
         const t = parseDate(d.lifecycle[p.key]);
         if (t != null) { dMin = Math.min(dMin, t); dMax = Math.max(dMax, t); }
+      }
+      // Also consider initiative startDate/endDate from attributes
+      if (d.attributes) {
+        const sd = parseDate(d.attributes.startDate as string);
+        const ed = parseDate(d.attributes.endDate as string);
+        if (sd != null) { dMin = Math.min(dMin, sd); dMax = Math.max(dMax, sd); }
+        if (ed != null) { dMin = Math.min(dMin, ed); dMax = Math.max(dMax, ed); }
       }
     }
     const tMin = Math.min(vMin, dMin === Infinity ? vMin : dMin);
@@ -125,7 +193,13 @@ export default function LifecycleReport() {
     return counts;
   }, [items]);
 
-  // Scroll so the ±5yr viewport is visible (viewMin at left edge)
+  // Initiative color legend
+  const initiativeColorLegend = useMemo(() => {
+    if (!useInitiativeDates) return null;
+    return INITIATIVE_COLORS[initiativeColorBy];
+  }, [useInitiativeDates, initiativeColorBy]);
+
+  // Scroll so the +/-5yr viewport is visible (viewMin at left edge)
   useLayoutEffect(() => {
     const el = timelineRef.current;
     if (!el || items.length === 0 || !totalRange) return;
@@ -143,8 +217,17 @@ export default function LifecycleReport() {
     if (sortK === "type") return a.type.localeCompare(b.type) * d;
     if (sortK === "phase") return currentPhase(a.lifecycle).localeCompare(currentPhase(b.lifecycle)) * d;
     if (sortK === "eol") return ((a.lifecycle.endOfLife || "z").localeCompare(b.lifecycle.endOfLife || "z")) * d;
+    if (sortK === "startDate") return ((a.attributes?.startDate as string || "z").localeCompare(b.attributes?.startDate as string || "z")) * d;
+    if (sortK === "endDate") return ((a.attributes?.endDate as string || "z").localeCompare(b.attributes?.endDate as string || "z")) * d;
+    if (sortK === "status") return ((a.attributes?.[initiativeColorBy] as string || "z").localeCompare(b.attributes?.[initiativeColorBy] as string || "z")) * d;
     return 0;
   });
+
+  function getInitiativeBarColor(item: RoadmapItem): string {
+    const val = item.attributes?.[initiativeColorBy] as string | undefined;
+    if (!val) return UNSET_BAR_COLOR;
+    return INITIATIVE_COLORS[initiativeColorBy]?.[val]?.color ?? UNSET_BAR_COLOR;
+  }
 
   return (
     <ReportShell
@@ -154,21 +237,70 @@ export default function LifecycleReport() {
       view={view}
       onViewChange={setView}
       toolbar={
-        <TextField select size="small" label="Fact Sheet Type" value={fsType} onChange={(e) => setFsType(e.target.value)} sx={{ minWidth: 180 }}>
-          <MenuItem value="">All Types</MenuItem>
-          {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
-        </TextField>
+        <>
+          <TextField select size="small" label="Fact Sheet Type" value={fsType} onChange={(e) => setFsType(e.target.value)} sx={{ minWidth: 180 }}>
+            <MenuItem value="">All Types</MenuItem>
+            {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
+          </TextField>
+
+          {isInitiativeType && (
+            <>
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={useInitiativeDates}
+                    onChange={(_, v) => setUseInitiativeDates(v)}
+                  />
+                }
+                label={
+                  <Typography variant="body2" color="text.secondary">
+                    Initiative Dates
+                  </Typography>
+                }
+              />
+              {useInitiativeDates && (
+                <TextField
+                  select
+                  size="small"
+                  label="Color By"
+                  value={initiativeColorBy}
+                  onChange={(e) => setInitiativeColorBy(e.target.value)}
+                  sx={{ minWidth: 150 }}
+                >
+                  {INITIATIVE_COLOR_OPTIONS.map((o) => (
+                    <MenuItem key={o.key} value={o.key}>{o.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            </>
+          )}
+        </>
       }
       legend={
         <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}>
-          <ReportLegend items={PHASES.map((p) => ({ label: p.label, color: p.color }))} />
-          {PHASES.map((p) => (
-            <Chip key={p.key} size="small" label={`${phaseCounts[p.key]}`} sx={{ bgcolor: p.color, color: "#fff", fontWeight: 600, fontSize: "0.7rem", height: 20 }} />
-          ))}
+          {useInitiativeDates && initiativeColorLegend ? (
+            <>
+              <ReportLegend
+                items={Object.values(initiativeColorLegend).map((v) => ({ label: v.label, color: v.color }))}
+              />
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Box sx={{ width: 12, height: 12, borderRadius: "50%", bgcolor: UNSET_BAR_COLOR, flexShrink: 0 }} />
+                <Typography variant="caption" color="text.secondary">Not set</Typography>
+              </Box>
+            </>
+          ) : (
+            <>
+              <ReportLegend items={PHASES.map((p) => ({ label: p.label, color: p.color }))} />
+              {PHASES.map((p) => (
+                <Chip key={p.key} size="small" label={`${phaseCounts[p.key]}`} sx={{ bgcolor: p.color, color: "#fff", fontWeight: 600, fontSize: "0.7rem", height: 20 }} />
+              ))}
+            </>
+          )}
         </Box>
       }
     >
-      {eolCount > 0 && (
+      {!useInitiativeDates && eolCount > 0 && (
         <Alert severity="warning" sx={{ mb: 2 }} icon={<MaterialSymbol icon="warning" size={20} />}>
           {eolCount} item{eolCount > 1 ? "s" : ""} at End of Life
         </Alert>
@@ -185,7 +317,7 @@ export default function LifecycleReport() {
                 <Box sx={{ height: 24, mb: 1 }} />
                 {items.map((item) => {
                   const cp = currentPhase(item.lifecycle);
-                  const isEol = cp === "endOfLife";
+                  const isEol = !useInitiativeDates && cp === "endOfLife";
                   return (
                     <Box
                       key={item.id}
@@ -219,6 +351,49 @@ export default function LifecycleReport() {
 
                   {/* Timeline bars */}
                   {items.map((item) => {
+                    if (useInitiativeDates) {
+                      // Initiative dates mode: single bar from startDate to endDate
+                      const startMs = parseDate(item.attributes?.startDate as string);
+                      const endMs = parseDate(item.attributes?.endDate as string);
+                      if (!startMs && !endMs) {
+                        return <Box key={item.id} sx={{ height: 32 }} />;
+                      }
+                      const barStart = startMs ?? endMs!;
+                      const barEnd = endMs ?? totalMax;
+                      const left = ((barStart - totalMin) / totalRange) * 100;
+                      const width = Math.max(((barEnd - barStart) / totalRange) * 100, 0.5);
+                      const barColor = getInitiativeBarColor(item);
+                      const colorVal = item.attributes?.[initiativeColorBy] as string | undefined;
+                      const colorLabel = colorVal
+                        ? INITIATIVE_COLORS[initiativeColorBy]?.[colorVal]?.label ?? colorVal
+                        : "Not set";
+                      const tipText = `${fmtDate(item.attributes?.startDate as string)} \u2192 ${fmtDate(item.attributes?.endDate as string)} \u00B7 ${colorLabel}`;
+
+                      return (
+                        <Box
+                          key={item.id}
+                          sx={{ position: "relative", height: 32, cursor: "pointer", "&:hover": { bgcolor: "#f5f5f5" } }}
+                          onClick={() => navigate(`/fact-sheets/${item.id}`)}
+                        >
+                          <Box sx={{ position: "absolute", top: 8, left: 0, right: 0, height: 16 }}>
+                            <Tooltip title={tipText}>
+                              <Box
+                                sx={{
+                                  position: "absolute",
+                                  left: `${left}%`,
+                                  width: `${width}%`,
+                                  height: "100%",
+                                  bgcolor: barColor,
+                                  borderRadius: "3px",
+                                }}
+                              />
+                            </Tooltip>
+                          </Box>
+                        </Box>
+                      );
+                    }
+
+                    // Standard lifecycle phases mode
                     const segments: { left: number; width: number; color: string; label: string }[] = [];
                     let eolPct: number | null = null;
                     for (let i = 0; i < PHASES.length; i++) {
@@ -295,12 +470,41 @@ export default function LifecycleReport() {
               <TableRow>
                 <TableCell><TableSortLabel active={sortK === "name"} direction={sortK === "name" ? sortD : "asc"} onClick={() => sort("name")}>Name</TableSortLabel></TableCell>
                 <TableCell><TableSortLabel active={sortK === "type"} direction={sortK === "type" ? sortD : "asc"} onClick={() => sort("type")}>Type</TableSortLabel></TableCell>
-                <TableCell><TableSortLabel active={sortK === "phase"} direction={sortK === "phase" ? sortD : "asc"} onClick={() => sort("phase")}>Current Phase</TableSortLabel></TableCell>
-                {PHASES.map((p) => <TableCell key={p.key}>{p.label}</TableCell>)}
+                {useInitiativeDates ? (
+                  <>
+                    <TableCell><TableSortLabel active={sortK === "startDate"} direction={sortK === "startDate" ? sortD : "asc"} onClick={() => sort("startDate")}>Start Date</TableSortLabel></TableCell>
+                    <TableCell><TableSortLabel active={sortK === "endDate"} direction={sortK === "endDate" ? sortD : "asc"} onClick={() => sort("endDate")}>End Date</TableSortLabel></TableCell>
+                    <TableCell><TableSortLabel active={sortK === "status"} direction={sortK === "status" ? sortD : "asc"} onClick={() => sort("status")}>{INITIATIVE_COLOR_OPTIONS.find((o) => o.key === initiativeColorBy)?.label}</TableSortLabel></TableCell>
+                  </>
+                ) : (
+                  <>
+                    <TableCell><TableSortLabel active={sortK === "phase"} direction={sortK === "phase" ? sortD : "asc"} onClick={() => sort("phase")}>Current Phase</TableSortLabel></TableCell>
+                    {PHASES.map((p) => <TableCell key={p.key}>{p.label}</TableCell>)}
+                  </>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
               {sorted.map((d) => {
+                if (useInitiativeDates) {
+                  const colorVal = d.attributes?.[initiativeColorBy] as string | undefined;
+                  const colorInfo = colorVal ? INITIATIVE_COLORS[initiativeColorBy]?.[colorVal] : null;
+                  return (
+                    <TableRow key={d.id} hover sx={{ cursor: "pointer" }} onClick={() => navigate(`/fact-sheets/${d.id}`)}>
+                      <TableCell sx={{ fontWeight: 500 }}>{d.name}</TableCell>
+                      <TableCell>{d.type}</TableCell>
+                      <TableCell>{fmtDate(d.attributes?.startDate as string)}</TableCell>
+                      <TableCell>{fmtDate(d.attributes?.endDate as string)}</TableCell>
+                      <TableCell>
+                        {colorInfo ? (
+                          <Chip size="small" label={colorInfo.label} sx={{ bgcolor: colorInfo.color, color: "#fff", fontWeight: 600, height: 22, fontSize: "0.72rem" }} />
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">{"\u2014"}</Typography>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                }
                 const cp = currentPhase(d.lifecycle);
                 const phase = PHASES.find((p) => p.key === cp);
                 return (


### PR DESCRIPTION
- Capability Map: Add timeline slider to filter apps by lifecycle date, showing what the IT landscape looks like at any point in time. Apps not yet started or already retired are hidden. Metrics (app count, cost, risk) are now computed from filtered apps in the tree (deep values).

- Cost Analysis: Remove GroupBy field. Add timeline slider to filter cost items by lifecycle date, dynamically recalculating totals.

- Lifecycle Report: When type is Initiative, show "Initiative Dates" toggle to render bars based on startDate/endDate attributes instead of lifecycle phases. Add "Color By" selector (Status, Business Value, Effort) with matching legend. Table view adapts columns accordingly.

- Backend: Roadmap endpoint now returns subtype and attributes so the frontend can access initiative startDate/endDate/status fields.

https://claude.ai/code/session_01YYPE7PznT8dTQaQEc2gGSX