### PR TITLE
Add fuzzy EOL auto-search on fact sheet creation and admin mass EOL l…

### DIFF
--- a/backend/app/api/v1/eol.py
+++ b/backend/app/api/v1/eol.py
@@ -6,11 +6,19 @@ end-of-life / release-cycle data without running into CORS restrictions.
 
 from __future__ import annotations
 
+import re
+from difflib import SequenceMatcher
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
+from app.database import get_db
+from app.models.fact_sheet import FactSheet
+from app.models.user import User
 
 router = APIRouter(prefix="/eol", tags=["End of Life"])
 
@@ -44,6 +52,34 @@ class EolCycle(BaseModel):
     link: str | None = None
 
 
+class EolProductMatch(BaseModel):
+    """A product with a fuzzy match score."""
+
+    name: str
+    score: float
+
+
+class MassEolCandidate(BaseModel):
+    """A candidate EOL match for a fact sheet."""
+
+    fact_sheet_id: str
+    fact_sheet_name: str
+    fact_sheet_type: str
+    eol_product: str
+    score: float
+
+
+class MassEolResult(BaseModel):
+    """Result of mass EOL search for a single fact sheet."""
+
+    fact_sheet_id: str
+    fact_sheet_name: str
+    fact_sheet_type: str
+    current_eol_product: str | None = None
+    current_eol_cycle: str | None = None
+    candidates: list[MassEolCandidate]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -56,6 +92,106 @@ async def _get_client() -> httpx.AsyncClient:
     if _client is None or _client.is_closed:
         _client = httpx.AsyncClient(timeout=15.0)
     return _client
+
+
+# In-memory cache for the product list (refreshed every 30 min max)
+_products_cache: list[str] | None = None
+_products_cache_time: float = 0
+
+
+async def _get_all_products() -> list[str]:
+    """Fetch and cache the full product list from endoflife.date."""
+    global _products_cache, _products_cache_time  # noqa: N816
+    import time
+
+    now = time.time()
+    if _products_cache is not None and (now - _products_cache_time) < 1800:
+        return _products_cache
+
+    client = await _get_client()
+    try:
+        resp = await client.get(f"{EOL_BASE}/all.json")
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        if _products_cache is not None:
+            return _products_cache
+        raise HTTPException(
+            status_code=502, detail=f"endoflife.date API error: {exc}"
+        ) from exc
+
+    _products_cache = resp.json()
+    _products_cache_time = now
+    return _products_cache  # type: ignore[return-value]
+
+
+def _normalize(text: str) -> str:
+    """Normalize a string for fuzzy comparison: lowercase, strip separators."""
+    return re.sub(r"[\s\-_./]+", "", text.lower())
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercase tokens on separators."""
+    return [t for t in re.split(r"[\s\-_./]+", text.lower()) if t]
+
+
+def _fuzzy_score(query: str, product: str) -> float:
+    """Compute a fuzzy match score between a search query and a product name.
+
+    Returns a float between 0.0 and 1.0. Higher is better.
+    Uses a combination of:
+      - Normalized substring match (high weight)
+      - Token overlap (medium weight)
+      - SequenceMatcher ratio (fallback)
+    """
+    q_norm = _normalize(query)
+    p_norm = _normalize(product)
+
+    if not q_norm:
+        return 0.0
+
+    # Exact normalized match
+    if q_norm == p_norm:
+        return 1.0
+
+    # Substring match on normalized form
+    if q_norm in p_norm:
+        return 0.9 + 0.1 * (len(q_norm) / len(p_norm))
+
+    if p_norm in q_norm:
+        return 0.85
+
+    # Token-based scoring
+    q_tokens = _tokenize(query)
+    p_tokens = _tokenize(product)
+
+    if q_tokens and p_tokens:
+        # Count how many query tokens are substrings of any product token
+        matches = 0
+        for qt in q_tokens:
+            for pt in p_tokens:
+                if qt in pt or pt in qt:
+                    matches += 1
+                    break
+        token_score = matches / len(q_tokens) if q_tokens else 0
+    else:
+        token_score = 0.0
+
+    # SequenceMatcher on normalized strings
+    seq_score = SequenceMatcher(None, q_norm, p_norm).ratio()
+
+    # Weighted combination
+    return max(token_score * 0.7 + seq_score * 0.3, seq_score)
+
+
+def _fuzzy_search(query: str, products: list[str], limit: int = 20, threshold: float = 0.3) -> list[tuple[str, float]]:
+    """Return products sorted by fuzzy match score, above threshold."""
+    scored = []
+    for p in products:
+        score = _fuzzy_score(query, p)
+        if score >= threshold:
+            scored.append((p, score))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored[:limit]
 
 
 # ---------------------------------------------------------------------------
@@ -73,19 +209,28 @@ async def list_products(
     An optional *search* query filters the list client-side (the upstream API
     is purely static JSON and does not support server-side filtering).
     """
-    client = await _get_client()
-    try:
-        resp = await client.get(f"{EOL_BASE}/all.json")
-        resp.raise_for_status()
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"endoflife.date API error: {exc}") from exc
-
-    products: list[str] = resp.json()
+    products = await _get_all_products()
     if search:
         q = search.lower()
         products = [p for p in products if q in p.lower()]
 
     return [EolProduct(name=p) for p in products[:100]]
+
+
+@router.get("/products/fuzzy", response_model=list[EolProductMatch])
+async def fuzzy_search_products(
+    search: str = Query(..., min_length=2, description="Fuzzy search query"),
+    limit: int = Query(10, ge=1, le=50, description="Max results"),
+    _user=Depends(get_current_user),
+):
+    """Fuzzy-search products on endoflife.date.
+
+    Returns products ranked by fuzzy match score. Handles common
+    mismatches like "SAP HANA" → "sap-hana", "Node.js" → "nodejs", etc.
+    """
+    products = await _get_all_products()
+    matches = _fuzzy_search(search, products, limit=limit)
+    return [EolProductMatch(name=name, score=round(score, 3)) for name, score in matches]
 
 
 @router.get("/products/{product}", response_model=list[EolCycle])
@@ -114,3 +259,140 @@ async def get_product_cycles(
         ) from exc
 
     return resp.json()
+
+
+@router.post("/mass-search", response_model=list[MassEolResult])
+async def mass_eol_search(
+    type_key: str = Query(..., description="Fact sheet type to search (Application or ITComponent)"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Mass-search EOL products for all fact sheets of a given type.
+
+    Finds fuzzy matches on endoflife.date for each fact sheet name.
+    Only returns fact sheets that have potential matches. Admin only.
+    """
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    if type_key not in ("Application", "ITComponent"):
+        raise HTTPException(
+            status_code=400,
+            detail="Only Application and ITComponent types support EOL linking",
+        )
+
+    # Fetch all active fact sheets of the given type
+    stmt = (
+        select(FactSheet)
+        .where(FactSheet.type == type_key)
+        .where(FactSheet.status == "ACTIVE")
+        .order_by(FactSheet.name)
+    )
+    result = await db.execute(stmt)
+    fact_sheets = result.scalars().all()
+
+    if not fact_sheets:
+        return []
+
+    # Fetch EOL product list
+    products = await _get_all_products()
+
+    # Build results with fuzzy matches for each fact sheet
+    results: list[MassEolResult] = []
+
+    # Process in parallel using asyncio (fuzzy search is CPU-bound but fast)
+    for fs in fact_sheets:
+        matches = _fuzzy_search(fs.name, products, limit=5, threshold=0.35)
+        current_product = (fs.attributes or {}).get("eol_product")
+        current_cycle = (fs.attributes or {}).get("eol_cycle")
+
+        candidates = [
+            MassEolCandidate(
+                fact_sheet_id=str(fs.id),
+                fact_sheet_name=fs.name,
+                fact_sheet_type=fs.type,
+                eol_product=name,
+                score=round(score, 3),
+            )
+            for name, score in matches
+        ]
+
+        results.append(
+            MassEolResult(
+                fact_sheet_id=str(fs.id),
+                fact_sheet_name=fs.name,
+                fact_sheet_type=fs.type,
+                current_eol_product=current_product,
+                current_eol_cycle=current_cycle,
+                candidates=candidates,
+            )
+        )
+
+    return results
+
+
+@router.post("/mass-link")
+async def mass_eol_link(
+    links: list[dict],
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Bulk-link fact sheets to EOL products/cycles.
+
+    Expects a list of: [{fact_sheet_id, eol_product, eol_cycle}].
+    For ITComponent type, lifecycle dates are synced from EOL data.
+    Admin only.
+    """
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    client = await _get_client()
+    updated = []
+
+    for link in links:
+        fs_id = link.get("fact_sheet_id")
+        product = link.get("eol_product")
+        cycle = link.get("eol_cycle")
+        if not fs_id or not product or not cycle:
+            continue
+
+        stmt = select(FactSheet).where(FactSheet.id == fs_id)
+        result = await db.execute(stmt)
+        fs = result.scalar_one_or_none()
+        if not fs:
+            continue
+
+        # Update attributes
+        attrs = dict(fs.attributes or {})
+        attrs["eol_product"] = product
+        attrs["eol_cycle"] = cycle
+        fs.attributes = attrs
+
+        # For ITComponent: sync lifecycle dates
+        if fs.type == "ITComponent":
+            try:
+                resp = await client.get(f"{EOL_BASE}/{product}.json")
+                if resp.status_code == 200:
+                    cycles_data = resp.json()
+                    match = next(
+                        (c for c in cycles_data if str(c.get("cycle")) == str(cycle)),
+                        None,
+                    )
+                    if match:
+                        lifecycle = dict(fs.lifecycle or {})
+                        if match.get("releaseDate"):
+                            lifecycle["active"] = match["releaseDate"]
+                        support = match.get("support")
+                        if isinstance(support, str):
+                            lifecycle["phaseOut"] = support
+                        eol_val = match.get("eol")
+                        if isinstance(eol_val, str):
+                            lifecycle["endOfLife"] = eol_val
+                        fs.lifecycle = lifecycle
+            except httpx.HTTPError:
+                pass  # Link without lifecycle sync on error
+
+        updated.append(str(fs.id))
+
+    await db.commit()
+    return {"updated": updated, "count": len(updated)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import SettingsAdmin from "@/features/admin/SettingsAdmin";
 import SurveysAdmin from "@/features/admin/SurveysAdmin";
 import SurveyBuilder from "@/features/admin/SurveyBuilder";
 import SurveyResults from "@/features/admin/SurveyResults";
+import EolAdmin from "@/features/admin/EolAdmin";
 import MySurveys from "@/features/surveys/MySurveys";
 import SurveyRespond from "@/features/surveys/SurveyRespond";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -97,6 +98,7 @@ export default function App() {
             <Route path="/admin/tags" element={<TagsAdmin />} />
             <Route path="/admin/users" element={<UsersAdmin />} />
             <Route path="/admin/settings" element={<SettingsAdmin />} />
+            <Route path="/admin/eol" element={<EolAdmin />} />
             <Route path="/admin/surveys" element={<SurveysAdmin />} />
             <Route path="/admin/surveys/new" element={<SurveyBuilder />} />
             <Route path="/admin/surveys/:id/results" element={<SurveyResults />} />

--- a/frontend/src/components/EolLinkSection.tsx
+++ b/frontend/src/components/EolLinkSection.tsx
@@ -579,9 +579,10 @@ interface EolLinkDialogProps {
   open: boolean;
   onClose: () => void;
   onLink: (product: string, cycle: string) => void;
+  initialProduct?: string;
 }
 
-export function EolLinkDialog({ open, onClose, onLink }: EolLinkDialogProps) {
+export function EolLinkDialog({ open, onClose, onLink, initialProduct }: EolLinkDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Link End-of-Life Data</DialogTitle>
@@ -596,6 +597,7 @@ export function EolLinkDialog({ open, onClose, onLink }: EolLinkDialogProps) {
             onClose();
           }}
           onCancel={onClose}
+          initialProduct={initialProduct}
         />
       </DialogContent>
       <DialogActions />

--- a/frontend/src/features/admin/EolAdmin.tsx
+++ b/frontend/src/features/admin/EolAdmin.tsx
@@ -1,0 +1,601 @@
+import { useState, useEffect, useCallback } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Alert from "@mui/material/Alert";
+import LinearProgress from "@mui/material/LinearProgress";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { MassEolResult, EolCycle } from "@/types";
+
+type LinkSelection = Record<
+  string,
+  { product: string; cycle: string } | null
+>;
+
+function computeEolStatus(cycle: EolCycle): {
+  label: string;
+  color: string;
+} {
+  const eol = cycle.eol;
+  if (eol === true) return { label: "End of Life", color: "#f44336" };
+  if (typeof eol === "string") {
+    const eolDate = new Date(eol);
+    const now = new Date();
+    if (eolDate <= now) return { label: "End of Life", color: "#f44336" };
+    const sixMonths = new Date();
+    sixMonths.setMonth(sixMonths.getMonth() + 6);
+    if (eolDate <= sixMonths)
+      return { label: "Approaching EOL", color: "#ff9800" };
+  }
+  return { label: "Supported", color: "#4caf50" };
+}
+
+// ── Cycle Picker Dialog ──────────────────────────────────────────
+
+interface CyclePickerProps {
+  open: boolean;
+  onClose: () => void;
+  factSheetId: string;
+  factSheetName: string;
+  product: string;
+  onSelect: (fsId: string, product: string, cycle: string) => void;
+}
+
+function CyclePickerDialog({
+  open,
+  onClose,
+  factSheetId,
+  factSheetName,
+  product,
+  onSelect,
+}: CyclePickerProps) {
+  const [cycles, setCycles] = useState<EolCycle[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [selectedCycle, setSelectedCycle] = useState("");
+
+  useEffect(() => {
+    if (!open || !product) return;
+    setLoading(true);
+    setError("");
+    setSelectedCycle("");
+    api
+      .get<EolCycle[]>(`/eol/products/${encodeURIComponent(product)}`)
+      .then((res) => setCycles(res))
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to fetch cycles"))
+      .finally(() => setLoading(false));
+  }, [open, product]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Select Version for {factSheetName}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2, mt: 1 }}>
+          Product: <strong>{product}</strong>. Select the version/cycle that matches
+          your deployment.
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {loading && <LinearProgress sx={{ mb: 2 }} />}
+        {!loading && cycles.length > 0 && (
+          <FormControl fullWidth size="small">
+            <InputLabel>Version / Cycle</InputLabel>
+            <Select
+              value={selectedCycle}
+              label="Version / Cycle"
+              onChange={(e) => setSelectedCycle(e.target.value)}
+            >
+              {cycles.map((c) => {
+                const status = computeEolStatus(c);
+                return (
+                  <MenuItem key={c.cycle} value={c.cycle}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        width: "100%",
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight={500}>
+                        {c.cycle}
+                      </Typography>
+                      {c.latest && (
+                        <Typography variant="caption" color="text.secondary">
+                          (latest: {c.latest})
+                        </Typography>
+                      )}
+                      <Box sx={{ ml: "auto" }}>
+                        <Chip
+                          size="small"
+                          label={status.label}
+                          sx={{
+                            bgcolor: status.color,
+                            color: "#fff",
+                            height: 20,
+                            fontSize: "0.65rem",
+                          }}
+                        />
+                      </Box>
+                    </Box>
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        )}
+        {!loading && cycles.length === 0 && !error && (
+          <Typography variant="body2" color="text.secondary">
+            No release cycles found for "{product}".
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          disabled={!selectedCycle}
+          onClick={() => {
+            onSelect(factSheetId, product, selectedCycle);
+            onClose();
+          }}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+// ── Main Admin Page ──────────────────────────────────────────────
+
+export default function EolAdmin() {
+  const [typeKey, setTypeKey] = useState<"Application" | "ITComponent">("ITComponent");
+  const [results, setResults] = useState<MassEolResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [selections, setSelections] = useState<LinkSelection>({});
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<{ count: number } | null>(null);
+  const [filter, setFilter] = useState<"all" | "unlinked" | "linked">("all");
+
+  // Cycle picker dialog
+  const [cyclePickerOpen, setCyclePickerOpen] = useState(false);
+  const [cyclePickerFsId, setCyclePickerFsId] = useState("");
+  const [cyclePickerFsName, setCyclePickerFsName] = useState("");
+  const [cyclePickerProduct, setCyclePickerProduct] = useState("");
+
+  const handleSearch = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    setSelections({});
+    setSaveResult(null);
+    try {
+      const res = await api.post<MassEolResult[]>(
+        `/eol/mass-search?type_key=${encodeURIComponent(typeKey)}`
+      );
+      setResults(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to search");
+    } finally {
+      setLoading(false);
+    }
+  }, [typeKey]);
+
+  const openCyclePicker = (fsId: string, fsName: string, product: string) => {
+    setCyclePickerFsId(fsId);
+    setCyclePickerFsName(fsName);
+    setCyclePickerProduct(product);
+    setCyclePickerOpen(true);
+  };
+
+  const handleCycleSelected = (fsId: string, product: string, cycle: string) => {
+    setSelections((prev) => ({
+      ...prev,
+      [fsId]: { product, cycle },
+    }));
+  };
+
+  const handleRemoveSelection = (fsId: string) => {
+    setSelections((prev) => {
+      const next = { ...prev };
+      delete next[fsId];
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    const links = Object.entries(selections)
+      .filter(([, sel]) => sel !== null)
+      .map(([fsId, sel]) => ({
+        fact_sheet_id: fsId,
+        eol_product: sel!.product,
+        eol_cycle: sel!.cycle,
+      }));
+
+    if (links.length === 0) return;
+
+    setSaving(true);
+    setError("");
+    try {
+      const res = await api.post<{ count: number; updated: string[] }>(
+        "/eol/mass-link",
+        links
+      );
+      setSaveResult({ count: res.count });
+      // Refresh results
+      await handleSearch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const filteredResults = results.filter((r) => {
+    if (filter === "unlinked") return !r.current_eol_product;
+    if (filter === "linked") return !!r.current_eol_product;
+    return true;
+  });
+
+  const selectedCount = Object.keys(selections).length;
+  const unlinkedCount = results.filter((r) => !r.current_eol_product).length;
+  const linkedCount = results.filter((r) => !!r.current_eol_product).length;
+  const withCandidatesCount = results.filter(
+    (r) => !r.current_eol_product && r.candidates.length > 0
+  ).length;
+
+  return (
+    <Box sx={{ maxWidth: 1100, mx: "auto" }}>
+      <Typography variant="h5" fontWeight={700} sx={{ mb: 1 }}>
+        Mass EOL Search
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Automatically find End-of-Life data for your IT Components and
+        Applications by fuzzy-matching their names against endoflife.date.
+        Select a product match, choose the version, and bulk-link them.
+      </Typography>
+
+      {/* Controls */}
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Box sx={{ display: "flex", gap: 2, alignItems: "flex-end", flexWrap: "wrap" }}>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Fact Sheet Type</InputLabel>
+              <Select
+                value={typeKey}
+                label="Fact Sheet Type"
+                onChange={(e) =>
+                  setTypeKey(e.target.value as "Application" | "ITComponent")
+                }
+              >
+                <MenuItem value="ITComponent">
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <MaterialSymbol icon="memory" size={18} color="#d29270" />
+                    IT Component
+                  </Box>
+                </MenuItem>
+                <MenuItem value="Application">
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <MaterialSymbol icon="apps" size={18} color="#0f7eb5" />
+                    Application
+                  </Box>
+                </MenuItem>
+              </Select>
+            </FormControl>
+            <Button
+              variant="contained"
+              onClick={handleSearch}
+              disabled={loading}
+              startIcon={
+                loading ? (
+                  <CircularProgress size={18} color="inherit" />
+                ) : (
+                  <MaterialSymbol icon="search" size={18} />
+                )
+              }
+            >
+              {loading ? "Searching..." : "Search EOL Data"}
+            </Button>
+            {results.length > 0 && (
+              <FormControl size="small" sx={{ minWidth: 140 }}>
+                <InputLabel>Filter</InputLabel>
+                <Select
+                  value={filter}
+                  label="Filter"
+                  onChange={(e) =>
+                    setFilter(e.target.value as "all" | "unlinked" | "linked")
+                  }
+                >
+                  <MenuItem value="all">All ({results.length})</MenuItem>
+                  <MenuItem value="unlinked">
+                    Unlinked ({unlinkedCount})
+                  </MenuItem>
+                  <MenuItem value="linked">Linked ({linkedCount})</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+          </Box>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
+          {error}
+        </Alert>
+      )}
+
+      {saveResult && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSaveResult(null)}>
+          Successfully linked {saveResult.count} fact sheet(s) to EOL data.
+        </Alert>
+      )}
+
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
+
+      {/* Summary stats */}
+      {results.length > 0 && !loading && (
+        <Box sx={{ display: "flex", gap: 2, mb: 3, flexWrap: "wrap" }}>
+          <Card sx={{ flex: 1, minWidth: 140 }}>
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Typography variant="caption" color="text.secondary">
+                Total
+              </Typography>
+              <Typography variant="h6" fontWeight={700}>
+                {results.length}
+              </Typography>
+            </CardContent>
+          </Card>
+          <Card sx={{ flex: 1, minWidth: 140 }}>
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Typography variant="caption" color="text.secondary">
+                Already Linked
+              </Typography>
+              <Typography variant="h6" fontWeight={700} color="success.main">
+                {linkedCount}
+              </Typography>
+            </CardContent>
+          </Card>
+          <Card sx={{ flex: 1, minWidth: 140 }}>
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Typography variant="caption" color="text.secondary">
+                Unlinked
+              </Typography>
+              <Typography variant="h6" fontWeight={700} color="warning.main">
+                {unlinkedCount}
+              </Typography>
+            </CardContent>
+          </Card>
+          <Card sx={{ flex: 1, minWidth: 140 }}>
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Typography variant="caption" color="text.secondary">
+                Matches Found
+              </Typography>
+              <Typography variant="h6" fontWeight={700} color="info.main">
+                {withCandidatesCount}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
+
+      {/* Results list */}
+      {filteredResults.map((r) => {
+        const selection = selections[r.fact_sheet_id];
+        const isAlreadyLinked = !!r.current_eol_product;
+
+        return (
+          <Card
+            key={r.fact_sheet_id}
+            sx={{
+              mb: 1.5,
+              borderLeft: 4,
+              borderColor: selection
+                ? "success.main"
+                : isAlreadyLinked
+                  ? "info.main"
+                  : r.candidates.length > 0
+                    ? "warning.main"
+                    : "divider",
+            }}
+          >
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 2,
+                  flexWrap: "wrap",
+                }}
+              >
+                {/* Fact sheet info */}
+                <Box sx={{ minWidth: 200, flex: "0 0 auto" }}>
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {r.fact_sheet_name}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {r.fact_sheet_type}
+                  </Typography>
+                  {isAlreadyLinked && (
+                    <Box sx={{ mt: 0.5, display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <MaterialSymbol icon="check_circle" size={14} color="#4caf50" />
+                      <Typography variant="caption" color="success.main">
+                        {r.current_eol_product} {r.current_eol_cycle}
+                      </Typography>
+                    </Box>
+                  )}
+                </Box>
+
+                {/* Current selection or candidates */}
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  {selection ? (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        p: 1,
+                        bgcolor: "rgba(76, 175, 80, 0.06)",
+                        borderRadius: 1,
+                      }}
+                    >
+                      <MaterialSymbol icon="check_circle" size={18} color="#4caf50" />
+                      <Typography variant="body2">
+                        Will link to{" "}
+                        <strong>
+                          {selection.product} {selection.cycle}
+                        </strong>
+                      </Typography>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveSelection(r.fact_sheet_id)}
+                        sx={{ ml: "auto" }}
+                      >
+                        <MaterialSymbol icon="close" size={16} />
+                      </IconButton>
+                    </Box>
+                  ) : r.candidates.length > 0 ? (
+                    <Box>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block", mb: 0.5 }}
+                      >
+                        Suggested matches:
+                      </Typography>
+                      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                        {r.candidates.map((c) => (
+                          <Tooltip
+                            key={c.eol_product}
+                            title={`Match score: ${Math.round(c.score * 100)}% — Click to select version`}
+                          >
+                            <Chip
+                              label={c.eol_product}
+                              size="small"
+                              variant="outlined"
+                              onClick={() =>
+                                openCyclePicker(
+                                  r.fact_sheet_id,
+                                  r.fact_sheet_name,
+                                  c.eol_product
+                                )
+                              }
+                              icon={<MaterialSymbol icon="link" size={14} />}
+                              sx={{
+                                cursor: "pointer",
+                                borderColor:
+                                  c.score >= 0.7 ? "success.main" : "divider",
+                                fontWeight: c.score >= 0.7 ? 600 : 400,
+                                "&:hover": { bgcolor: "action.hover" },
+                              }}
+                            />
+                          </Tooltip>
+                        ))}
+                      </Box>
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      No matches found on endoflife.date
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {/* No results */}
+      {!loading && results.length === 0 && (
+        <Card>
+          <CardContent sx={{ textAlign: "center", py: 6 }}>
+            <MaterialSymbol icon="search" size={48} color="#ccc" />
+            <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+              Click "Search EOL Data" to scan your{" "}
+              {typeKey === "ITComponent" ? "IT Components" : "Applications"} against
+              endoflife.date
+            </Typography>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Floating action bar */}
+      {selectedCount > 0 && (
+        <Box
+          sx={{
+            position: "sticky",
+            bottom: 16,
+            mt: 2,
+            p: 2,
+            bgcolor: "background.paper",
+            borderRadius: 2,
+            boxShadow: 6,
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            border: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <MaterialSymbol icon="link" size={20} color="#1976d2" />
+          <Typography variant="body2" fontWeight={600}>
+            {selectedCount} fact sheet(s) selected for EOL linking
+          </Typography>
+          <Box sx={{ ml: "auto", display: "flex", gap: 1 }}>
+            <Button
+              size="small"
+              onClick={() => setSelections({})}
+            >
+              Clear All
+            </Button>
+            <Button
+              variant="contained"
+              size="small"
+              onClick={handleSave}
+              disabled={saving}
+              startIcon={
+                saving ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <MaterialSymbol icon="save" size={16} />
+                )
+              }
+            >
+              {saving ? "Saving..." : "Apply Links"}
+            </Button>
+          </Box>
+        </Box>
+      )}
+
+      {/* Cycle picker dialog */}
+      <CyclePickerDialog
+        open={cyclePickerOpen}
+        onClose={() => setCyclePickerOpen(false)}
+        factSheetId={cyclePickerFsId}
+        factSheetName={cyclePickerFsName}
+        product={cyclePickerProduct}
+        onSelect={handleCycleSelected}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/features/fact-sheets/FactSheetDetail.tsx
+++ b/frontend/src/features/fact-sheets/FactSheetDetail.tsx
@@ -1836,6 +1836,7 @@ export default function FactSheetDetail() {
       {/* ── Sections ── */}
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 3 }}>
         <DescriptionSection fs={fs} onSave={handleUpdate} />
+        <EolLinkSection fs={fs} onSave={handleUpdate} />
         <LifecycleSection fs={fs} onSave={handleUpdate} />
         {typeConfig?.fields_schema.map((section) => (
           <AttributeSection
@@ -1845,7 +1846,6 @@ export default function FactSheetDetail() {
             onSave={handleUpdate}
           />
         ))}
-        <EolLinkSection fs={fs} onSave={handleUpdate} />
         <HierarchySection fs={fs} onUpdate={() => api.get<FactSheet>(`/fact-sheets/${fs.id}`).then(setFs)} />
         <RelationsSection fsId={fs.id} fsType={fs.type} />
       </Box>

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -64,6 +64,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { label: "Users", icon: "group", path: "/admin/users" },
   { label: "Surveys", icon: "assignment", path: "/admin/surveys" },
   { label: "Settings", icon: "settings", path: "/admin/settings" },
+  { label: "EOL Search", icon: "update", path: "/admin/eol" },
 ];
 
 interface Props {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -427,6 +427,28 @@ export interface EolCycle {
   link?: string | null;
 }
 
+export interface EolProductMatch {
+  name: string;
+  score: number;
+}
+
+export interface MassEolCandidate {
+  fact_sheet_id: string;
+  fact_sheet_name: string;
+  fact_sheet_type: string;
+  eol_product: string;
+  score: number;
+}
+
+export interface MassEolResult {
+  fact_sheet_id: string;
+  fact_sheet_name: string;
+  fact_sheet_type: string;
+  current_eol_product?: string | null;
+  current_eol_cycle?: string | null;
+  candidates: MassEolCandidate[];
+}
+
 export interface DiagramSummary {
   id: string;
   name: string;


### PR DESCRIPTION
…inking

- Backend: Add fuzzy search endpoint (GET /eol/products/fuzzy) using token-based + SequenceMatcher scoring with product list caching
- Backend: Add mass-search (POST /eol/mass-search) and mass-link (POST /eol/mass-link) admin-only endpoints for bulk EOL operations
- Frontend: Auto-search endoflife.date when typing fact sheet name in CreateFactSheetDialog, showing clickable suggestions below description
- Frontend: Move EOL section above Lifecycle in FactSheetDetail page
- Frontend: Add admin Mass EOL Search page with type filter, fuzzy matching results, version picker dialog, and bulk apply workflow
- Add EolProductMatch, MassEolCandidate, MassEolResult TypeScript types

https://claude.ai/code/session_01SCYds85nVxr38HD8sZW7bd