### PR TITLE
Add smart vendor field with Provider search, link, and create

### DIFF
--- a/frontend/src/components/CreateFactSheetDialog.tsx
+++ b/frontend/src/components/CreateFactSheetDialog.tsx
@@ -21,11 +21,13 @@ import Chip from "@mui/material/Chip";
 import LinearProgress from "@mui/material/LinearProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { EolLinkDialog } from "@/components/EolLinkSection";
+import VendorField from "@/components/VendorField";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
 import type { FieldDef, FactSheet, EolCycle, EolProductMatch } from "@/types";
 
 const EOL_ELIGIBLE_TYPES = ["Application", "ITComponent"];
+const VENDOR_ELIGIBLE_TYPES = ["Application", "ITComponent"];
 
 interface Props {
   open: boolean;
@@ -634,8 +636,20 @@ export default function CreateFactSheetDialog({
           </Box>
         )}
 
-        {/* Required fields from schema */}
-        {requiredFields.length > 0 && requiredFields.map((f) => renderField(f))}
+        {/* Vendor field for eligible types */}
+        {VENDOR_ELIGIBLE_TYPES.includes(selectedType) && (
+          <Box sx={{ mb: 2 }}>
+            <VendorField
+              value={(attributes.vendor as string) ?? ""}
+              onChange={(v) => setAttr("vendor", v)}
+              fsType={selectedType}
+              size="small"
+            />
+          </Box>
+        )}
+
+        {/* Required fields from schema (skip vendor since we render it above) */}
+        {requiredFields.length > 0 && requiredFields.filter((f) => f.key !== "vendor").map((f) => renderField(f))}
 
         {/* EOL picker dialog */}
         <EolLinkDialog

--- a/frontend/src/components/VendorField.tsx
+++ b/frontend/src/components/VendorField.tsx
@@ -1,0 +1,326 @@
+/**
+ * Smart vendor field that searches existing Provider fact sheets and
+ * offers to link or create one. When a Provider is selected, the vendor
+ * text attribute is updated and a relProviderToITC / relProviderToApp
+ * relation is created automatically.
+ */
+import { useState, useEffect, useCallback } from "react";
+import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { Relation } from "@/types";
+
+interface ProviderOption {
+  id: string;
+  name: string;
+  isNew?: boolean;
+  inputValue?: string;
+}
+
+const filter = createFilterOptions<ProviderOption>();
+
+/** Only ITComponent has a built-in Provider relation type. */
+const RELATION_TYPE_MAP: Record<string, string> = {
+  ITComponent: "relProviderToITC",
+};
+
+interface VendorFieldProps {
+  /** Current vendor text value */
+  value: string;
+  /** Called when vendor text changes */
+  onChange: (value: string | undefined) => void;
+  /** Fact sheet type (ITComponent or Application) */
+  fsType: string;
+  /** Fact sheet ID — if provided, relations are managed automatically */
+  fsId?: string;
+  /** Size variant */
+  size?: "small" | "medium";
+  /** Label override */
+  label?: string;
+  /** Called after a relation is created/removed (to refresh RelationsSection) */
+  onRelationChange?: () => void;
+}
+
+export default function VendorField({
+  value,
+  onChange,
+  fsType,
+  fsId,
+  size = "small",
+  label = "Vendor",
+  onRelationChange,
+}: VendorFieldProps) {
+  const [inputValue, setInputValue] = useState(value || "");
+  const [options, setOptions] = useState<ProviderOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [linkedProvider, setLinkedProvider] = useState<ProviderOption | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingProvider, setPendingProvider] = useState<ProviderOption | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  // Sync input value when external value changes
+  useEffect(() => {
+    setInputValue(value || "");
+  }, [value]);
+
+  // Check existing Provider relation on mount
+  useEffect(() => {
+    if (!fsId) return;
+    const relType = RELATION_TYPE_MAP[fsType];
+    if (!relType) return;
+
+    api
+      .get<Relation[]>(`/relations?fact_sheet_id=${fsId}&type=${relType}`)
+      .then((rels) => {
+        // Find the Provider linked to this fact sheet
+        for (const r of rels) {
+          const isTarget = r.target_id === fsId;
+          const provider = isTarget ? r.source : r.target;
+          if (provider?.name) {
+            setLinkedProvider({ id: provider.id, name: provider.name });
+            break;
+          }
+        }
+      })
+      .catch(() => {});
+  }, [fsId, fsType]);
+
+  // Search providers
+  const searchProviders = useCallback(
+    async (query: string) => {
+      if (query.length < 1) {
+        setOptions([]);
+        return;
+      }
+      setLoading(true);
+      try {
+        const res = await api.get<{ items: { id: string; name: string }[] }>(
+          `/fact-sheets?type=Provider&search=${encodeURIComponent(query)}&page_size=10`
+        );
+        setOptions(res.items.map((p) => ({ id: p.id, name: p.name })));
+      } catch {
+        setOptions([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  // Debounced search
+  useEffect(() => {
+    const timer = setTimeout(() => searchProviders(inputValue), 300);
+    return () => clearTimeout(timer);
+  }, [inputValue, searchProviders]);
+
+  const handleSelect = async (provider: ProviderOption) => {
+    if (provider.isNew) {
+      // Create new Provider fact sheet
+      setPendingProvider(provider);
+      setConfirmOpen(true);
+      return;
+    }
+
+    // Set vendor text
+    onChange(provider.name);
+    setInputValue(provider.name);
+
+    // Create relation if we have a fact sheet ID
+    if (fsId) {
+      await linkProvider(provider.id);
+    }
+  };
+
+  const handleCreateAndLink = async () => {
+    if (!pendingProvider?.inputValue) return;
+    setCreating(true);
+    try {
+      const newFs = await api.post<{ id: string; name: string }>("/fact-sheets", {
+        type: "Provider",
+        name: pendingProvider.inputValue,
+      });
+
+      onChange(newFs.name);
+      setInputValue(newFs.name);
+      setLinkedProvider({ id: newFs.id, name: newFs.name });
+
+      if (fsId) {
+        await linkProvider(newFs.id);
+      }
+    } catch {
+      // Silent fail — vendor text is still set
+    } finally {
+      setCreating(false);
+      setConfirmOpen(false);
+      setPendingProvider(null);
+    }
+  };
+
+  const linkProvider = async (providerId: string) => {
+    const relType = RELATION_TYPE_MAP[fsType];
+    if (!relType || !fsId) return;
+
+    try {
+      // Remove existing provider relations first
+      const existing = await api.get<Relation[]>(
+        `/relations?fact_sheet_id=${fsId}&type=${relType}`
+      );
+      for (const r of existing) {
+        await api.delete(`/relations/${r.id}`);
+      }
+
+      // Create new relation (Provider is source, ITComponent/App is target)
+      await api.post("/relations", {
+        type: relType,
+        source_id: providerId,
+        target_id: fsId,
+      });
+
+      setLinkedProvider({ id: providerId, name: "" });
+
+      // Refresh to get the name
+      const rels = await api.get<Relation[]>(
+        `/relations?fact_sheet_id=${fsId}&type=${relType}`
+      );
+      for (const r of rels) {
+        const isTarget = r.target_id === fsId;
+        const provider = isTarget ? r.source : r.target;
+        if (provider?.name) {
+          setLinkedProvider({ id: provider.id, name: provider.name });
+          break;
+        }
+      }
+
+      onRelationChange?.();
+    } catch {
+      // Relation creation failed silently
+    }
+  };
+
+  return (
+    <>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+        <Autocomplete
+          freeSolo
+          size={size}
+          value={inputValue}
+          inputValue={inputValue}
+          onInputChange={(_e, newVal, reason) => {
+            setInputValue(newVal);
+            if (reason === "input") {
+              onChange(newVal || undefined);
+            }
+          }}
+          onChange={(_e, newVal) => {
+            if (newVal && typeof newVal !== "string") {
+              handleSelect(newVal as ProviderOption);
+            } else if (typeof newVal === "string") {
+              onChange(newVal || undefined);
+            }
+          }}
+          options={options}
+          loading={loading}
+          getOptionLabel={(opt) =>
+            typeof opt === "string" ? opt : opt.inputValue ?? opt.name
+          }
+          filterOptions={(opts, params) => {
+            const filtered = filter(opts, params);
+            const { inputValue: iv } = params;
+            // Add "Create new" option if no exact match
+            if (iv && !opts.some((o) => o.name.toLowerCase() === iv.toLowerCase())) {
+              filtered.push({
+                id: "__new__",
+                name: `Create Provider "${iv}"`,
+                isNew: true,
+                inputValue: iv,
+              });
+            }
+            return filtered;
+          }}
+          renderOption={(props, option) => {
+            const { key, ...rest } = props;
+            return (
+              <li key={key} {...rest}>
+                {option.isNew ? (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, color: "primary.main" }}>
+                    <MaterialSymbol icon="add_circle" size={18} />
+                    <Typography variant="body2">{option.name}</Typography>
+                  </Box>
+                ) : (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <MaterialSymbol icon="storefront" size={18} color="#ffa31f" />
+                    <Typography variant="body2">{option.name}</Typography>
+                  </Box>
+                )}
+              </li>
+            );
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={label}
+              placeholder="Search existing providers or type a new name..."
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {loading ? <CircularProgress color="inherit" size={16} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+              sx={{ minWidth: 300 }}
+            />
+          )}
+        />
+        {linkedProvider && linkedProvider.name && (
+          <Chip
+            size="small"
+            label={linkedProvider.name}
+            icon={<MaterialSymbol icon="storefront" size={14} />}
+            variant="outlined"
+            sx={{
+              alignSelf: "flex-start",
+              borderColor: "#ffa31f",
+              color: "#e68a00",
+              "& .MuiChip-icon": { color: "#ffa31f" },
+              fontSize: "0.75rem",
+            }}
+          />
+        )}
+      </Box>
+
+      {/* Create Provider confirmation dialog */}
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Create New Provider</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            No existing Provider matches "{pendingProvider?.inputValue}".
+            Create a new Provider fact sheet and link it?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreateAndLink}
+            disabled={creating}
+            startIcon={creating ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {creating ? "Creating..." : "Create & Link"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/features/fact-sheets/FactSheetDetail.tsx
+++ b/frontend/src/features/fact-sheets/FactSheetDetail.tsx
@@ -32,6 +32,7 @@ import MaterialSymbol from "@/components/MaterialSymbol";
 import QualitySealBadge from "@/components/QualitySealBadge";
 import LifecycleBadge from "@/components/LifecycleBadge";
 import EolLinkSection from "@/components/EolLinkSection";
+import VendorField from "@/components/VendorField";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
 import Dialog from "@mui/material/Dialog";
@@ -466,6 +467,8 @@ function LifecycleSection({
 }
 
 // ── Section: Type-specific attributes ───────────────────────────
+const VENDOR_ELIGIBLE_TYPES = ["ITComponent", "Application"];
+
 function AttributeSection({
   section,
   fs,
@@ -479,7 +482,6 @@ function AttributeSection({
   const [attrs, setAttrs] = useState<Record<string, unknown>>(
     fs.attributes || {}
   );
-
   useEffect(() => {
     setAttrs(fs.attributes || {});
   }, [fs.attributes]);
@@ -492,6 +494,9 @@ function AttributeSection({
   const setAttr = (key: string, value: unknown) => {
     setAttrs((prev) => ({ ...prev, [key]: value }));
   };
+
+  const isVendorField = (field: FieldDef) =>
+    field.key === "vendor" && VENDOR_ELIGIBLE_TYPES.includes(fs.type);
 
   // Count filled fields in this section
   const filled = section.fields.filter((f) => {
@@ -536,6 +541,15 @@ function AttributeSection({
                     <FieldValue field={field} value={attrs[field.key]} />
                     <Chip size="small" label="auto" sx={{ height: 18, fontSize: "0.6rem", ml: 0.5 }} />
                   </Box>
+                ) : isVendorField(field) ? (
+                  <VendorField
+                    key={field.key}
+                    value={(attrs[field.key] as string) ?? ""}
+                    onChange={(v) => setAttr(field.key, v)}
+                    fsType={fs.type}
+                    fsId={fs.id}
+                    onRelationChange={() => {}}
+                  />
                 ) : (
                   <FieldEditor
                     key={field.key}


### PR DESCRIPTION
- New VendorField component: Autocomplete that searches existing Provider fact sheets as the user types, with option to create a new Provider
- For ITComponent: selecting/creating a Provider also creates a relProviderToITC relation automatically (replaces any existing one)
- For Application: searches Providers for name suggestions (no relation type exists for Provider→Application in the default metamodel)
- Integrated into AttributeSection edit mode for the "vendor" field
- Integrated into CreateFactSheetDialog for ITComponent and Application
- Provider options shown with storefront icon, create option with add icon
- Linked Provider shown as chip below the field in edit mode

https://claude.ai/code/session_01SCYds85nVxr38HD8sZW7bd