### PR TITLE
Fix EOL report impact count and add live search to navigation bar

### DIFF
--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -806,7 +806,8 @@ async def eol_report(
     items = []
     counts = {"eol": 0, "approaching": 0, "supported": 0}
     manual_count = 0
-    impacted_app_ids: set[str] = set()
+    eol_impacted_app_ids: set[str] = set()
+    approaching_impacted_app_ids: set[str] = set()
 
     # 4a. API-linked items
     for fs in api_sheets:
@@ -831,9 +832,12 @@ async def eol_report(
 
         # Impact: affected apps
         affected_apps = it_to_apps.get(str(fs.id), [])
-        if status in ("eol", "approaching") and fs.type == "ITComponent":
+        if fs.type == "ITComponent":
             for app in affected_apps:
-                impacted_app_ids.add(app["id"])
+                if status == "eol":
+                    eol_impacted_app_ids.add(app["id"])
+                elif status == "approaching":
+                    approaching_impacted_app_ids.add(app["id"])
 
         items.append({
             "id": str(fs.id),
@@ -860,9 +864,12 @@ async def eol_report(
 
         # Impact: affected apps
         affected_apps = it_to_apps.get(str(fs.id), [])
-        if status in ("eol", "approaching") and fs.type == "ITComponent":
+        if fs.type == "ITComponent":
             for app in affected_apps:
-                impacted_app_ids.add(app["id"])
+                if status == "eol":
+                    eol_impacted_app_ids.add(app["id"])
+                elif status == "approaching":
+                    approaching_impacted_app_ids.add(app["id"])
 
         # Build synthetic cycle_data from lifecycle dates for timeline display
         manual_cycle_data = {}
@@ -897,7 +904,8 @@ async def eol_report(
             "eol": counts["eol"],
             "approaching": counts["approaching"],
             "supported": counts["supported"],
-            "impacted_apps": len(impacted_app_ids),
+            "impacted_apps": len(eol_impacted_app_ids),
+            "approaching_impacted_apps": len(approaching_impacted_app_ids - eol_impacted_app_ids),
             "manual": manual_count,
         },
     }

--- a/frontend/src/features/reports/EolReport.tsx
+++ b/frontend/src/features/reports/EolReport.tsx
@@ -64,6 +64,7 @@ interface EolReportData {
     approaching: number;
     supported: number;
     impacted_apps: number;
+    approaching_impacted_apps: number;
     manual: number;
   };
 }
@@ -429,7 +430,7 @@ export default function EolReport() {
                 `, impacting ${data.summary.impacted_apps} application${data.summary.impacted_apps > 1 ? "s" : ""}`}
             </Alert>
           )}
-          {data.summary.eol === 0 && data.summary.approaching > 0 && (
+          {data.summary.approaching > 0 && (
             <Alert
               severity="warning"
               icon={<MaterialSymbol icon="warning" size={20} />}
@@ -437,6 +438,8 @@ export default function EolReport() {
               <strong>{data.summary.approaching}</strong> item
               {data.summary.approaching > 1 ? "s are" : " is"} approaching End
               of Life within 6 months
+              {data.summary.approaching_impacted_apps > 0 &&
+                `, impacting ${data.summary.approaching_impacted_apps} additional application${data.summary.approaching_impacted_apps > 1 ? "s" : ""}`}
             </Alert>
           )}
 


### PR DESCRIPTION
Fix overcounting in EOL report where impacted_apps included applications from both EOL and approaching items. Split into separate counts so the alert accurately reflects only EOL-impacted applications.

Add dynamic search results dropdown to the navigation search bar that shows matching fact sheets with type icon, color, and label as the user types, with debounced API calls and click-to-navigate.

https://claude.ai/code/session_01SCYds85nVxr38HD8sZW7bd