### PR TITLE
Widen VendorField search dropdown for long fact sheet names

### DIFF
--- a/frontend/src/components/VendorField.tsx
+++ b/frontend/src/components/VendorField.tsx
@@ -221,6 +221,7 @@ export default function VendorField({
     <>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
         <Autocomplete
+          fullWidth
           freeSolo
           size={size}
           value={inputValue}
@@ -243,6 +244,10 @@ export default function VendorField({
           getOptionLabel={(opt) =>
             typeof opt === "string" ? opt : opt.inputValue ?? opt.name
           }
+          slotProps={{
+            popper: { sx: { minWidth: 360, maxWidth: "90vw" }, placement: "bottom-start" },
+            paper: { sx: { "& .MuiAutocomplete-option": { whiteSpace: "normal", wordBreak: "break-word" } } },
+          }}
           filterOptions={(opts, params) => {
             const filtered = filter(opts, params);
             const { inputValue: iv } = params;


### PR DESCRIPTION
- Add fullWidth to Autocomplete so the input fills available space
- Set popper minWidth: 360 with maxWidth: 90vw for responsiveness
- Allow option text to wrap (whiteSpace: normal, wordBreak: break-word) so long provider names are fully visible in the dropdown

https://claude.ai/code/session_01SCYds85nVxr38HD8sZW7bd