### PR TITLE
Add web portals feature for public fact sheet sharing

### DIFF
--- a/backend/alembic/versions/013_add_web_portals.py
+++ b/backend/alembic/versions/013_add_web_portals.py
@@ -1,0 +1,52 @@
+"""add web_portals table
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-02-14
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "013"
+down_revision: Union[str, None] = "012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "web_portals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("slug", sa.String(200), nullable=False, unique=True, index=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("fact_sheet_type", sa.String(100), nullable=False),
+        sa.Column("filters", postgresql.JSONB(), nullable=True),
+        sa.Column("display_fields", postgresql.JSONB(), nullable=True),
+        sa.Column("card_config", postgresql.JSONB(), nullable=True),
+        sa.Column("is_published", sa.Boolean(), server_default="false"),
+        sa.Column(
+            "created_by",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("web_portals")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -20,6 +20,7 @@ from app.api.v1 import (
     tags,
     todos,
     users,
+    web_portals,
 )
 
 api_router = APIRouter()
@@ -42,3 +43,4 @@ api_router.include_router(users.router)
 api_router.include_router(notifications.router)
 api_router.include_router(surveys.router)
 api_router.include_router(settings.router)
+api_router.include_router(web_portals.router)

--- a/backend/app/api/v1/web_portals.py
+++ b/backend/app/api/v1/web_portals.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import re
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.models.fact_sheet import FactSheet
+from app.models.fact_sheet_type import FactSheetType
+from app.models.relation import Relation
+from app.models.relation_type import RelationType
+from app.models.tag import FactSheetTag, Tag, TagGroup
+from app.models.user import User
+from app.models.web_portal import WebPortal
+from app.schemas.common import WebPortalCreate, WebPortalUpdate
+
+router = APIRouter(prefix="/web-portals", tags=["web-portals"])
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _portal_to_dict(p: WebPortal) -> dict:
+    return {
+        "id": str(p.id),
+        "name": p.name,
+        "slug": p.slug,
+        "description": p.description,
+        "fact_sheet_type": p.fact_sheet_type,
+        "filters": p.filters,
+        "display_fields": p.display_fields,
+        "card_config": p.card_config,
+        "is_published": p.is_published,
+        "created_by": str(p.created_by) if p.created_by else None,
+        "created_at": p.created_at.isoformat() if p.created_at else None,
+        "updated_at": p.updated_at.isoformat() if p.updated_at else None,
+    }
+
+
+# ── Admin CRUD (auth required) ──────────────────────────────────────────
+
+
+@router.get("")
+async def list_portals(
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(WebPortal).order_by(WebPortal.created_at.desc())
+    )
+    return [_portal_to_dict(p) for p in result.scalars().all()]
+
+
+@router.post("", status_code=201)
+async def create_portal(
+    body: WebPortalCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if user.role != "admin":
+        raise HTTPException(403, "Only admins can create web portals")
+    if not _SLUG_RE.match(body.slug):
+        raise HTTPException(
+            400,
+            "Slug must contain only lowercase letters, numbers, and hyphens",
+        )
+    # Check slug uniqueness
+    existing = await db.execute(
+        select(WebPortal).where(WebPortal.slug == body.slug)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(400, "A portal with this slug already exists")
+    # Validate fact sheet type exists
+    fst = await db.execute(
+        select(FactSheetType).where(FactSheetType.key == body.fact_sheet_type)
+    )
+    if not fst.scalar_one_or_none():
+        raise HTTPException(400, f"Fact sheet type '{body.fact_sheet_type}' not found")
+
+    portal = WebPortal(
+        name=body.name,
+        slug=body.slug,
+        description=body.description,
+        fact_sheet_type=body.fact_sheet_type,
+        filters=body.filters,
+        display_fields=body.display_fields,
+        card_config=body.card_config,
+        is_published=body.is_published,
+        created_by=user.id,
+    )
+    db.add(portal)
+    await db.commit()
+    await db.refresh(portal)
+    return _portal_to_dict(portal)
+
+
+@router.get("/{portal_id}")
+async def get_portal(
+    portal_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(WebPortal).where(WebPortal.id == uuid.UUID(portal_id))
+    )
+    portal = result.scalar_one_or_none()
+    if not portal:
+        raise HTTPException(404, "Portal not found")
+    return _portal_to_dict(portal)
+
+
+@router.patch("/{portal_id}")
+async def update_portal(
+    portal_id: str,
+    body: WebPortalUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if user.role != "admin":
+        raise HTTPException(403, "Only admins can update web portals")
+    result = await db.execute(
+        select(WebPortal).where(WebPortal.id == uuid.UUID(portal_id))
+    )
+    portal = result.scalar_one_or_none()
+    if not portal:
+        raise HTTPException(404, "Portal not found")
+
+    updates = body.model_dump(exclude_unset=True)
+
+    if "slug" in updates:
+        if not _SLUG_RE.match(updates["slug"]):
+            raise HTTPException(
+                400,
+                "Slug must contain only lowercase letters, numbers, and hyphens",
+            )
+        dup = await db.execute(
+            select(WebPortal).where(
+                WebPortal.slug == updates["slug"],
+                WebPortal.id != portal.id,
+            )
+        )
+        if dup.scalar_one_or_none():
+            raise HTTPException(400, "A portal with this slug already exists")
+
+    for field, value in updates.items():
+        setattr(portal, field, value)
+
+    await db.commit()
+    await db.refresh(portal)
+    return _portal_to_dict(portal)
+
+
+@router.delete("/{portal_id}", status_code=204)
+async def delete_portal(
+    portal_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if user.role != "admin":
+        raise HTTPException(403, "Only admins can delete web portals")
+    result = await db.execute(
+        select(WebPortal).where(WebPortal.id == uuid.UUID(portal_id))
+    )
+    portal = result.scalar_one_or_none()
+    if not portal:
+        raise HTTPException(404, "Portal not found")
+    await db.delete(portal)
+    await db.commit()
+
+
+# ── Public endpoints (no auth) ──────────────────────────────────────────
+
+
+@router.get("/public/{slug}")
+async def get_public_portal(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(WebPortal).where(WebPortal.slug == slug, WebPortal.is_published == True)  # noqa: E712
+    )
+    portal = result.scalar_one_or_none()
+    if not portal:
+        raise HTTPException(404, "Portal not found")
+
+    # Also return the type metadata so frontend can render properly
+    fst_result = await db.execute(
+        select(FactSheetType).where(FactSheetType.key == portal.fact_sheet_type)
+    )
+    fst = fst_result.scalar_one_or_none()
+
+    type_info = None
+    if fst:
+        type_info = {
+            "key": fst.key,
+            "label": fst.label,
+            "icon": fst.icon,
+            "color": fst.color,
+            "fields_schema": fst.fields_schema,
+            "subtypes": fst.subtypes,
+        }
+
+    # Fetch available relation types for this fact sheet type (for filter options)
+    rel_types_result = await db.execute(
+        select(RelationType).where(
+            or_(
+                RelationType.source_type_key == portal.fact_sheet_type,
+                RelationType.target_type_key == portal.fact_sheet_type,
+            ),
+            RelationType.is_hidden == False,  # noqa: E712
+        )
+    )
+    rel_types = [
+        {
+            "key": rt.key,
+            "label": rt.label,
+            "reverse_label": rt.reverse_label,
+            "source_type_key": rt.source_type_key,
+            "target_type_key": rt.target_type_key,
+        }
+        for rt in rel_types_result.scalars().all()
+    ]
+
+    # Fetch available tag groups
+    tag_groups_result = await db.execute(
+        select(TagGroup).order_by(TagGroup.name)
+    )
+    tag_groups = []
+    for tg in tag_groups_result.scalars().all():
+        tags_result = await db.execute(
+            select(Tag).where(Tag.tag_group_id == tg.id).order_by(Tag.name)
+        )
+        tag_groups.append({
+            "id": str(tg.id),
+            "name": tg.name,
+            "tags": [
+                {"id": str(t.id), "name": t.name, "color": t.color}
+                for t in tags_result.scalars().all()
+            ],
+        })
+
+    return {
+        "id": str(portal.id),
+        "name": portal.name,
+        "slug": portal.slug,
+        "description": portal.description,
+        "fact_sheet_type": portal.fact_sheet_type,
+        "filters": portal.filters,
+        "display_fields": portal.display_fields,
+        "card_config": portal.card_config,
+        "type_info": type_info,
+        "relation_types": rel_types,
+        "tag_groups": tag_groups,
+    }
+
+
+@router.get("/public/{slug}/fact-sheets")
+async def get_public_portal_fact_sheets(
+    slug: str,
+    search: str | None = Query(None),
+    subtype: str | None = Query(None),
+    tag_ids: str | None = Query(None),
+    related_type: str | None = Query(None),
+    related_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(24, ge=1, le=100),
+    sort_by: str = Query("name"),
+    sort_dir: str = Query("asc"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Public endpoint: returns fact sheets for a published portal with optional filtering."""
+    result = await db.execute(
+        select(WebPortal).where(WebPortal.slug == slug, WebPortal.is_published == True)  # noqa: E712
+    )
+    portal = result.scalar_one_or_none()
+    if not portal:
+        raise HTTPException(404, "Portal not found")
+
+    q = select(FactSheet).where(
+        FactSheet.type == portal.fact_sheet_type,
+        FactSheet.status == "ACTIVE",
+    )
+    count_q = select(func.count(FactSheet.id)).where(
+        FactSheet.type == portal.fact_sheet_type,
+        FactSheet.status == "ACTIVE",
+    )
+
+    # Apply portal-level preset filters
+    portal_filters = portal.filters or {}
+    if portal_filters.get("subtypes"):
+        q = q.where(FactSheet.subtype.in_(portal_filters["subtypes"]))
+        count_q = count_q.where(FactSheet.subtype.in_(portal_filters["subtypes"]))
+    if portal_filters.get("quality_seals"):
+        q = q.where(FactSheet.quality_seal.in_(portal_filters["quality_seals"]))
+        count_q = count_q.where(FactSheet.quality_seal.in_(portal_filters["quality_seals"]))
+
+    # Apply user-supplied search
+    if search:
+        like = f"%{search}%"
+        q = q.where(
+            or_(FactSheet.name.ilike(like), FactSheet.description.ilike(like))
+        )
+        count_q = count_q.where(
+            or_(FactSheet.name.ilike(like), FactSheet.description.ilike(like))
+        )
+
+    # Filter by subtype (user)
+    if subtype:
+        q = q.where(FactSheet.subtype == subtype)
+        count_q = count_q.where(FactSheet.subtype == subtype)
+
+    # Filter by tags
+    if tag_ids:
+        ids = [t.strip() for t in tag_ids.split(",") if t.strip()]
+        if ids:
+            tag_uuids = [uuid.UUID(tid) for tid in ids]
+            tagged_fs = select(FactSheetTag.fact_sheet_id).where(
+                FactSheetTag.tag_id.in_(tag_uuids)
+            )
+            q = q.where(FactSheet.id.in_(tagged_fs))
+            count_q = count_q.where(FactSheet.id.in_(tagged_fs))
+
+    # Filter by relationship to a specific fact sheet
+    if related_type and related_id:
+        rid = uuid.UUID(related_id)
+        related_fs = select(Relation.target_id).where(
+            Relation.type == related_type,
+            Relation.source_id == rid,
+        ).union(
+            select(Relation.source_id).where(
+                Relation.type == related_type,
+                Relation.target_id == rid,
+            )
+        )
+        q = q.where(FactSheet.id.in_(related_fs))
+        count_q = count_q.where(FactSheet.id.in_(related_fs))
+
+    # Sorting
+    sort_col = getattr(FactSheet, sort_by, FactSheet.name)
+    q = q.order_by(sort_col.desc() if sort_dir == "desc" else sort_col.asc())
+    q = q.offset((page - 1) * page_size).limit(page_size)
+
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    fs_result = await db.execute(q)
+    fact_sheets = fs_result.scalars().all()
+
+    # Collect tag data for the result fact sheets
+    fs_ids = [fs.id for fs in fact_sheets]
+    tags_map: dict[str, list] = {}
+    if fs_ids:
+        tag_rows = await db.execute(
+            select(
+                FactSheetTag.fact_sheet_id,
+                Tag.id,
+                Tag.name,
+                Tag.color,
+                TagGroup.name.label("group_name"),
+            )
+            .join(Tag, Tag.id == FactSheetTag.tag_id)
+            .join(TagGroup, TagGroup.id == Tag.tag_group_id)
+            .where(FactSheetTag.fact_sheet_id.in_(fs_ids))
+        )
+        for row in tag_rows.all():
+            fsid = str(row[0])
+            tags_map.setdefault(fsid, []).append({
+                "id": str(row[1]),
+                "name": row[2],
+                "color": row[3],
+                "group_name": row[4],
+            })
+
+    # Collect relations for the result fact sheets (to show related items)
+    relations_map: dict[str, list] = {}
+    if fs_ids:
+        # Source relations
+        src_rows = await db.execute(
+            select(
+                Relation.source_id,
+                Relation.type,
+                Relation.target_id,
+                FactSheet.name.label("target_name"),
+                FactSheet.type.label("target_type"),
+            )
+            .join(FactSheet, FactSheet.id == Relation.target_id)
+            .where(Relation.source_id.in_(fs_ids))
+        )
+        for row in src_rows.all():
+            fsid = str(row[0])
+            relations_map.setdefault(fsid, []).append({
+                "type": row[1],
+                "related_id": str(row[2]),
+                "related_name": row[3],
+                "related_type": row[4],
+                "direction": "outgoing",
+            })
+        # Target relations
+        tgt_rows = await db.execute(
+            select(
+                Relation.target_id,
+                Relation.type,
+                Relation.source_id,
+                FactSheet.name.label("source_name"),
+                FactSheet.type.label("source_type"),
+            )
+            .join(FactSheet, FactSheet.id == Relation.source_id)
+            .where(Relation.target_id.in_(fs_ids))
+        )
+        for row in tgt_rows.all():
+            fsid = str(row[0])
+            relations_map.setdefault(fsid, []).append({
+                "type": row[1],
+                "related_id": str(row[2]),
+                "related_name": row[3],
+                "related_type": row[4],
+                "direction": "incoming",
+            })
+
+    items = []
+    for fs in fact_sheets:
+        fsid = str(fs.id)
+        items.append({
+            "id": fsid,
+            "name": fs.name,
+            "type": fs.type,
+            "subtype": fs.subtype,
+            "description": fs.description,
+            "lifecycle": fs.lifecycle,
+            "attributes": fs.attributes,
+            "quality_seal": fs.quality_seal,
+            "completion": fs.completion,
+            "tags": tags_map.get(fsid, []),
+            "relations": relations_map.get(fsid, []),
+            "updated_at": fs.updated_at.isoformat() if fs.updated_at else None,
+        })
+
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.survey import Survey, SurveyResponse
 from app.models.tag import FactSheetTag, Tag, TagGroup
 from app.models.todo import Todo
 from app.models.user import User
+from app.models.web_portal import WebPortal
 
 __all__ = [
     "Base",
@@ -39,4 +40,5 @@ __all__ = [
     "AppSettings",
     "Survey",
     "SurveyResponse",
+    "WebPortal",
 ]

--- a/backend/app/models/web_portal.py
+++ b/backend/app/models/web_portal.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDMixin
+
+
+class WebPortal(Base, UUIDMixin, TimestampMixin):
+    __tablename__ = "web_portals"
+
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    slug: Mapped[str] = mapped_column(String(200), nullable=False, unique=True, index=True)
+    description: Mapped[str | None] = mapped_column(Text)
+    fact_sheet_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    filters: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    display_fields: Mapped[list | None] = mapped_column(JSONB, default=list)
+    card_config: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    is_published: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -152,6 +152,28 @@ class EventResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WebPortalCreate(BaseModel):
+    name: str
+    slug: str
+    description: str | None = None
+    fact_sheet_type: str
+    filters: dict | None = None
+    display_fields: list | None = None
+    card_config: dict | None = None
+    is_published: bool = False
+
+
+class WebPortalUpdate(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+    fact_sheet_type: str | None = None
+    filters: dict | None = None
+    display_fields: list | None = None
+    card_config: dict | None = None
+    is_published: bool | None = None
+
+
 # Fix forward refs
 TagGroupResponse.model_rebuild()
 CommentResponse.model_rebuild()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,8 @@ import SurveyResults from "@/features/admin/SurveyResults";
 import EolAdmin from "@/features/admin/EolAdmin";
 import MySurveys from "@/features/surveys/MySurveys";
 import SurveyRespond from "@/features/surveys/SurveyRespond";
+import WebPortalsAdmin from "@/features/admin/WebPortalsAdmin";
+import PortalViewer from "@/features/web-portals/PortalViewer";
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 
@@ -48,7 +50,8 @@ const theme = createTheme({
   },
 });
 
-export default function App() {
+/** Inner component that handles authenticated vs public routes. */
+function AppRoutes() {
   const { user, loading, login, register, logout } = useAuth();
 
   if (loading) {
@@ -61,51 +64,70 @@ export default function App() {
 
   if (!user) {
     return (
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <LoginPage onLogin={login} onRegister={register} />
-      </ThemeProvider>
+      <Routes>
+        {/* Public portal route — accessible without login */}
+        <Route path="/portal/:slug" element={<PortalViewer />} />
+        {/* Everything else redirects to login */}
+        <Route path="*" element={<LoginPage onLogin={login} onRegister={register} />} />
+      </Routes>
     );
   }
 
   return (
+    <Routes>
+      {/* Public portal route — also accessible when logged in */}
+      <Route path="/portal/:slug" element={<PortalViewer />} />
+      {/* Authenticated routes */}
+      <Route
+        path="*"
+        element={
+          <AppLayout user={user} onLogout={logout}>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/inventory" element={<InventoryPage />} />
+              <Route path="/fact-sheets/:id" element={<FactSheetDetail />} />
+              <Route path="/reports/portfolio" element={<PortfolioReport />} />
+              <Route path="/reports/capability-map" element={<CapabilityMapReport />} />
+              <Route path="/reports/lifecycle" element={<LifecycleReport />} />
+              <Route path="/reports/dependencies" element={<DependencyReport />} />
+              <Route path="/reports/cost" element={<CostReport />} />
+              <Route path="/reports/matrix" element={<MatrixReport />} />
+              <Route path="/reports/data-quality" element={<DataQualityReport />} />
+              <Route path="/reports/eol" element={<EolReport />} />
+              <Route path="/diagrams" element={<DiagramsPage />} />
+              <Route path="/diagrams/:id" element={<DiagramEditor />} />
+              <Route path="/ea-delivery" element={<EADeliveryPage />} />
+              <Route path="/ea-delivery/soaw/new" element={<SoAWEditor />} />
+              <Route path="/ea-delivery/soaw/:id/preview" element={<SoAWPreview />} />
+              <Route path="/ea-delivery/soaw/:id" element={<SoAWEditor />} />
+              <Route path="/todos" element={<TodosPage />} />
+              <Route path="/surveys" element={<MySurveys />} />
+              <Route path="/surveys/:surveyId/respond/:factSheetId" element={<SurveyRespond />} />
+              <Route path="/admin/metamodel" element={<MetamodelAdmin />} />
+              <Route path="/admin/tags" element={<TagsAdmin />} />
+              <Route path="/admin/users" element={<UsersAdmin />} />
+              <Route path="/admin/settings" element={<SettingsAdmin />} />
+              <Route path="/admin/eol" element={<EolAdmin />} />
+              <Route path="/admin/surveys" element={<SurveysAdmin />} />
+              <Route path="/admin/surveys/new" element={<SurveyBuilder />} />
+              <Route path="/admin/surveys/:id/results" element={<SurveyResults />} />
+              <Route path="/admin/surveys/:id" element={<SurveyBuilder />} />
+              <Route path="/admin/web-portals" element={<WebPortalsAdmin />} />
+              <Route path="*" element={<Navigate to="/" />} />
+            </Routes>
+          </AppLayout>
+        }
+      />
+    </Routes>
+  );
+}
+
+export default function App() {
+  return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <BrowserRouter>
-        <AppLayout user={user} onLogout={logout}>
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/inventory" element={<InventoryPage />} />
-            <Route path="/fact-sheets/:id" element={<FactSheetDetail />} />
-            <Route path="/reports/portfolio" element={<PortfolioReport />} />
-            <Route path="/reports/capability-map" element={<CapabilityMapReport />} />
-            <Route path="/reports/lifecycle" element={<LifecycleReport />} />
-            <Route path="/reports/dependencies" element={<DependencyReport />} />
-            <Route path="/reports/cost" element={<CostReport />} />
-            <Route path="/reports/matrix" element={<MatrixReport />} />
-            <Route path="/reports/data-quality" element={<DataQualityReport />} />
-            <Route path="/reports/eol" element={<EolReport />} />
-            <Route path="/diagrams" element={<DiagramsPage />} />
-            <Route path="/diagrams/:id" element={<DiagramEditor />} />
-            <Route path="/ea-delivery" element={<EADeliveryPage />} />
-            <Route path="/ea-delivery/soaw/new" element={<SoAWEditor />} />
-            <Route path="/ea-delivery/soaw/:id/preview" element={<SoAWPreview />} />
-            <Route path="/ea-delivery/soaw/:id" element={<SoAWEditor />} />
-            <Route path="/todos" element={<TodosPage />} />
-            <Route path="/surveys" element={<MySurveys />} />
-            <Route path="/surveys/:surveyId/respond/:factSheetId" element={<SurveyRespond />} />
-            <Route path="/admin/metamodel" element={<MetamodelAdmin />} />
-            <Route path="/admin/tags" element={<TagsAdmin />} />
-            <Route path="/admin/users" element={<UsersAdmin />} />
-            <Route path="/admin/settings" element={<SettingsAdmin />} />
-            <Route path="/admin/eol" element={<EolAdmin />} />
-            <Route path="/admin/surveys" element={<SurveysAdmin />} />
-            <Route path="/admin/surveys/new" element={<SurveyBuilder />} />
-            <Route path="/admin/surveys/:id/results" element={<SurveyResults />} />
-            <Route path="/admin/surveys/:id" element={<SurveyBuilder />} />
-            <Route path="*" element={<Navigate to="/" />} />
-          </Routes>
-        </AppLayout>
+        <AppRoutes />
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/frontend/src/features/admin/WebPortalsAdmin.tsx
+++ b/frontend/src/features/admin/WebPortalsAdmin.tsx
@@ -1,0 +1,482 @@
+import { useState, useEffect } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
+import Alert from "@mui/material/Alert";
+import Tooltip from "@mui/material/Tooltip";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import { useMetamodel } from "@/hooks/useMetamodel";
+import type { WebPortal } from "@/types";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export default function WebPortalsAdmin() {
+  const { types } = useMetamodel();
+  const [portals, setPortals] = useState<WebPortal[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPortal, setEditingPortal] = useState<WebPortal | null>(null);
+  const [error, setError] = useState("");
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+
+  // Form fields
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugManual, setSlugManual] = useState(false);
+  const [description, setDescription] = useState("");
+  const [factSheetType, setFactSheetType] = useState("");
+  const [isPublished, setIsPublished] = useState(false);
+  const [displayFields, setDisplayFields] = useState<string[]>([]);
+  const [filterSubtypes, setFilterSubtypes] = useState<string[]>([]);
+
+  const visibleTypes = types.filter((t) => !t.is_hidden);
+
+  const load = async () => {
+    try {
+      const data = await api.get<WebPortal[]>("/web-portals");
+      setPortals(data);
+    } catch {
+      // ignore
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const resetForm = () => {
+    setName("");
+    setSlug("");
+    setSlugManual(false);
+    setDescription("");
+    setFactSheetType("");
+    setIsPublished(false);
+    setDisplayFields([]);
+    setFilterSubtypes([]);
+    setError("");
+    setEditingPortal(null);
+  };
+
+  const openCreate = () => {
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const openEdit = (portal: WebPortal) => {
+    setEditingPortal(portal);
+    setName(portal.name);
+    setSlug(portal.slug);
+    setSlugManual(true);
+    setDescription(portal.description || "");
+    setFactSheetType(portal.fact_sheet_type);
+    setIsPublished(portal.is_published);
+    setDisplayFields(portal.display_fields || []);
+    setFilterSubtypes(
+      ((portal.filters as Record<string, unknown>)?.subtypes as string[]) || []
+    );
+    setError("");
+    setDialogOpen(true);
+  };
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!slugManual) {
+      setSlug(slugify(value));
+    }
+  };
+
+  const selectedType = visibleTypes.find((t) => t.key === factSheetType);
+  const allFields =
+    selectedType?.fields_schema?.flatMap((s) => s.fields) || [];
+
+  const handleSave = async () => {
+    setError("");
+    const body = {
+      name,
+      slug,
+      description: description || null,
+      fact_sheet_type: factSheetType,
+      is_published: isPublished,
+      display_fields: displayFields.length > 0 ? displayFields : null,
+      filters:
+        filterSubtypes.length > 0 ? { subtypes: filterSubtypes } : null,
+      card_config: null,
+    };
+    try {
+      if (editingPortal) {
+        await api.patch(`/web-portals/${editingPortal.id}`, body);
+      } else {
+        await api.post("/web-portals", body);
+      }
+      setDialogOpen(false);
+      resetForm();
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save portal");
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.delete(`/web-portals/${id}`);
+      setDeleteConfirm(null);
+      load();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleTogglePublish = async (portal: WebPortal) => {
+    try {
+      await api.patch(`/web-portals/${portal.id}`, {
+        is_published: !portal.is_published,
+      });
+      load();
+    } catch {
+      // ignore
+    }
+  };
+
+  const getTypeLabel = (key: string) => {
+    const t = types.find((t) => t.key === key);
+    return t?.label || key;
+  };
+
+  const getTypeColor = (key: string) => {
+    const t = types.find((t) => t.key === key);
+    return t?.color || "#666";
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 3 }}>
+        <MaterialSymbol icon="language" size={28} color="#1976d2" />
+        <Typography variant="h5" fontWeight={600}>
+          Web Portals
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="contained"
+          startIcon={<MaterialSymbol icon="add" size={18} />}
+          onClick={openCreate}
+        >
+          Create Portal
+        </Button>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Web portals are public-facing pages that display fact sheets to end
+        users without requiring authentication. Configure which fact sheet type
+        to display, apply filters, and customize the card layout.
+      </Typography>
+
+      {portals.length === 0 && (
+        <Card>
+          <CardContent
+            sx={{
+              textAlign: "center",
+              py: 6,
+            }}
+          >
+            <MaterialSymbol
+              icon="language"
+              size={48}
+              color="#ccc"
+            />
+            <Typography variant="h6" color="text.secondary" sx={{ mt: 1 }}>
+              No web portals yet
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Create your first portal to share fact sheet data with end users.
+            </Typography>
+            <Button variant="outlined" onClick={openCreate}>
+              Create Portal
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {portals.map((portal) => (
+        <Card key={portal.id} sx={{ mb: 2 }}>
+          <CardContent
+            sx={{ display: "flex", alignItems: "center", gap: 2, py: 2 }}
+          >
+            <MaterialSymbol
+              icon="language"
+              size={24}
+              color={getTypeColor(portal.fact_sheet_type)}
+            />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  {portal.name}
+                </Typography>
+                <Chip
+                  label={portal.is_published ? "Published" : "Draft"}
+                  size="small"
+                  color={portal.is_published ? "success" : "default"}
+                  sx={{ height: 22, fontSize: "0.7rem" }}
+                />
+              </Box>
+              <Box
+                sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}
+              >
+                <Chip
+                  label={getTypeLabel(portal.fact_sheet_type)}
+                  size="small"
+                  sx={{
+                    height: 20,
+                    fontSize: "0.65rem",
+                    bgcolor: `${getTypeColor(portal.fact_sheet_type)}18`,
+                    color: getTypeColor(portal.fact_sheet_type),
+                    fontWeight: 600,
+                  }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  /portal/{portal.slug}
+                </Typography>
+              </Box>
+              {portal.description && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 0.5 }}
+                >
+                  {portal.description}
+                </Typography>
+              )}
+            </Box>
+            <Tooltip
+              title={portal.is_published ? "Unpublish" : "Publish"}
+            >
+              <IconButton
+                size="small"
+                onClick={() => handleTogglePublish(portal)}
+                color={portal.is_published ? "success" : "default"}
+              >
+                <MaterialSymbol
+                  icon={portal.is_published ? "visibility" : "visibility_off"}
+                  size={20}
+                />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Copy portal URL">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  navigator.clipboard.writeText(
+                    `${window.location.origin}/portal/${portal.slug}`
+                  );
+                }}
+              >
+                <MaterialSymbol icon="content_copy" size={20} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Edit">
+              <IconButton size="small" onClick={() => openEdit(portal)}>
+                <MaterialSymbol icon="edit" size={20} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete">
+              <IconButton
+                size="small"
+                color="error"
+                onClick={() => setDeleteConfirm(portal.id)}
+              >
+                <MaterialSymbol icon="delete" size={20} />
+              </IconButton>
+            </Tooltip>
+          </CardContent>
+        </Card>
+      ))}
+
+      {/* Create / Edit dialog */}
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>
+          {editingPortal ? "Edit Portal" : "Create Web Portal"}
+        </DialogTitle>
+        <DialogContent>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+          <TextField
+            fullWidth
+            label="Portal Name"
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+            sx={{ mt: 1 }}
+            placeholder="e.g. Application Catalog"
+          />
+          <TextField
+            fullWidth
+            label="URL Slug"
+            value={slug}
+            onChange={(e) => {
+              setSlug(e.target.value);
+              setSlugManual(true);
+            }}
+            sx={{ mt: 2 }}
+            helperText={`Portal will be accessible at /portal/${slug || "..."}`}
+            placeholder="e.g. application-catalog"
+          />
+          <TextField
+            fullWidth
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            sx={{ mt: 2 }}
+            multiline
+            rows={2}
+            placeholder="Optional description displayed at the top of the portal"
+          />
+          <TextField
+            fullWidth
+            select
+            label="Fact Sheet Type"
+            value={factSheetType}
+            onChange={(e) => {
+              setFactSheetType(e.target.value);
+              setDisplayFields([]);
+              setFilterSubtypes([]);
+            }}
+            sx={{ mt: 2 }}
+            helperText="Which type of fact sheets to display in this portal"
+          >
+            {visibleTypes.map((t) => (
+              <MenuItem key={t.key} value={t.key}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <MaterialSymbol
+                    icon={t.icon}
+                    size={18}
+                    color={t.color}
+                  />
+                  {t.label}
+                </Box>
+              </MenuItem>
+            ))}
+          </TextField>
+
+          {selectedType?.subtypes && selectedType.subtypes.length > 0 && (
+            <TextField
+              fullWidth
+              select
+              label="Filter by Subtypes (optional)"
+              value={filterSubtypes}
+              onChange={(e) =>
+                setFilterSubtypes(
+                  typeof e.target.value === "string"
+                    ? e.target.value.split(",")
+                    : (e.target.value as string[])
+                )
+              }
+              sx={{ mt: 2 }}
+              SelectProps={{ multiple: true }}
+              helperText="Only show fact sheets of these subtypes"
+            >
+              {selectedType.subtypes.map((st) => (
+                <MenuItem key={st.key} value={st.key}>
+                  {st.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+
+          {allFields.length > 0 && (
+            <TextField
+              fullWidth
+              select
+              label="Display Fields on Cards (optional)"
+              value={displayFields}
+              onChange={(e) =>
+                setDisplayFields(
+                  typeof e.target.value === "string"
+                    ? e.target.value.split(",")
+                    : (e.target.value as string[])
+                )
+              }
+              sx={{ mt: 2 }}
+              SelectProps={{ multiple: true }}
+              helperText="Select which fields to show on fact sheet cards. Leave empty to show all."
+            >
+              {allFields.map((f) => (
+                <MenuItem key={f.key} value={f.key}>
+                  {f.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={isPublished}
+                onChange={(e) => setIsPublished(e.target.checked)}
+              />
+            }
+            label="Published (publicly accessible)"
+            sx={{ mt: 2 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!name.trim() || !slug.trim() || !factSheetType}
+          >
+            {editingPortal ? "Save Changes" : "Create"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <Dialog
+        open={!!deleteConfirm}
+        onClose={() => setDeleteConfirm(null)}
+        maxWidth="xs"
+      >
+        <DialogTitle>Delete Portal</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete this portal? This action cannot be
+            undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirm(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => deleteConfirm && handleDelete(deleteConfirm)}
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -71,6 +71,7 @@ const ADMIN_ITEMS: NavItem[] = [
   { label: "Surveys", icon: "assignment", path: "/admin/surveys" },
   { label: "Settings", icon: "settings", path: "/admin/settings" },
   { label: "EOL Search", icon: "update", path: "/admin/eol" },
+  { label: "Web Portals", icon: "language", path: "/admin/web-portals" },
 ];
 
 interface Props {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -460,3 +460,87 @@ export interface DiagramSummary {
   created_at?: string;
   updated_at?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Web Portals
+// ---------------------------------------------------------------------------
+
+export interface WebPortal {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  fact_sheet_type: string;
+  filters?: Record<string, unknown>;
+  display_fields?: string[];
+  card_config?: Record<string, unknown>;
+  is_published: boolean;
+  created_by?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface PortalTypeInfo {
+  key: string;
+  label: string;
+  icon: string;
+  color: string;
+  fields_schema: SectionDef[];
+  subtypes?: SubtypeDef[];
+}
+
+export interface PortalRelationType {
+  key: string;
+  label: string;
+  reverse_label?: string;
+  source_type_key: string;
+  target_type_key: string;
+}
+
+export interface PortalTagGroup {
+  id: string;
+  name: string;
+  tags: { id: string; name: string; color?: string }[];
+}
+
+export interface PublicPortal {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  fact_sheet_type: string;
+  filters?: Record<string, unknown>;
+  display_fields?: string[];
+  card_config?: Record<string, unknown>;
+  type_info: PortalTypeInfo | null;
+  relation_types: PortalRelationType[];
+  tag_groups: PortalTagGroup[];
+}
+
+export interface PortalFactSheet {
+  id: string;
+  name: string;
+  type: string;
+  subtype?: string;
+  description?: string;
+  lifecycle?: Record<string, string>;
+  attributes?: Record<string, unknown>;
+  quality_seal: string;
+  completion: number;
+  tags: { id: string; name: string; color?: string; group_name?: string }[];
+  relations: {
+    type: string;
+    related_id: string;
+    related_name: string;
+    related_type: string;
+    direction: string;
+  }[];
+  updated_at?: string;
+}
+
+export interface PortalFactSheetListResponse {
+  items: PortalFactSheet[];
+  total: number;
+  page: number;
+  page_size: number;
+}


### PR DESCRIPTION
## Summary
This PR introduces a new web portals feature that allows administrators to create public-facing pages for sharing fact sheets without requiring authentication. Users can browse, search, filter, and view detailed information about fact sheets through a clean, responsive interface.

## Key Changes

### Backend
- **New Web Portals API** (`backend/app/api/v1/web_portals.py`):
  - Admin endpoints for CRUD operations on web portals (create, read, update, delete)
  - Public endpoints for accessing published portals and their fact sheets
  - Support for filtering by search, subtype, tags, and related fact sheets
  - Pagination and sorting capabilities
  - Portal-level preset filters that are applied to all queries

- **Database Model** (`backend/app/models/web_portal.py`):
  - New `WebPortal` model with fields for name, slug, description, fact sheet type, filters, display fields, and card configuration
  - Timestamps and creator tracking

- **Database Migration** (`backend/alembic/versions/013_add_web_portals.py`):
  - Creates `web_portals` table with appropriate indexes and constraints

- **Schema Updates** (`backend/app/schemas/common.py`):
  - `WebPortalCreate` and `WebPortalUpdate` schemas for request validation

### Frontend
- **Portal Viewer Component** (`frontend/src/features/web-portals/PortalViewer.tsx`):
  - Public-facing portal page displaying fact sheets in a responsive grid layout
  - Search functionality with debouncing
  - Advanced filtering by subtype and tags
  - Multiple sort options (name, date, completion)
  - Expandable filter panel for mobile responsiveness
  - Detailed fact sheet cards with:
    - Key field display
    - Lifecycle phase visualization
    - Tag chips with colors
    - Completion progress bar
    - Quality seal indicator
  - Modal dialog for viewing full fact sheet details with all attributes
  - Responsive design using Material-UI breakpoints

- **Admin Management Component** (`frontend/src/features/admin/WebPortalsAdmin.tsx`):
  - Portal listing with publish/draft status
  - Create, edit, and delete operations
  - Slug auto-generation from portal name
  - Display field selection for card customization
  - Subtype filtering configuration
  - Copy portal URL functionality
  - Publish/unpublish toggle

- **Type Definitions** (`frontend/src/types/index.ts`):
  - `WebPortal`, `PublicPortal`, `PortalFactSheet` interfaces
  - Supporting types for portal metadata, tag groups, and relation types

- **Routing Updates** (`frontend/src/App.tsx`):
  - New public route `/portal/:slug` accessible without authentication
  - Separated authenticated and public route handling

- **Navigation Updates** (`frontend/src/layouts/AppLayout.tsx`):
  - Added Web Portals link to admin navigation menu

## Notable Implementation Details

- **Public Access**: Portal viewer is accessible without authentication, while admin management requires admin role
- **Slug Validation**: Slugs are validated to contain only lowercase letters, numbers, and hyphens
- **Responsive Design**: Portal viewer adapts to mobile, tablet, and desktop viewports
- **Field Customization**: Admins can select which fields to display on fact sheet cards
- **Lifecycle Visualization**: Interactive timeline showing product lifecycle phases with current phase highlighting
- **Performance**: Pagination (24 items per page) and debounced search to optimize API calls
- **Material Symbols**: Uses Material Design icons for consistent UI

https://claude.ai/code/session_011rvvF7N78QtNuvMdy6AjD9