### PR TITLE
Fix migration 013: guard against table already existing

### DIFF
--- a/backend/alembic/versions/013_add_web_portals.py
+++ b/backend/alembic/versions/013_add_web_portals.py
@@ -18,34 +18,40 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "web_portals",
-        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column("name", sa.String(200), nullable=False),
-        sa.Column("slug", sa.String(200), nullable=False, unique=True, index=True),
-        sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("fact_sheet_type", sa.String(100), nullable=False),
-        sa.Column("filters", postgresql.JSONB(), nullable=True),
-        sa.Column("display_fields", postgresql.JSONB(), nullable=True),
-        sa.Column("card_config", postgresql.JSONB(), nullable=True),
-        sa.Column("is_published", sa.Boolean(), server_default="false"),
-        sa.Column(
-            "created_by",
-            postgresql.UUID(as_uuid=True),
-            sa.ForeignKey("users.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-        ),
-    )
+    from sqlalchemy import inspect as sa_inspect
+
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+
+    if not inspector.has_table("web_portals"):
+        op.create_table(
+            "web_portals",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column("name", sa.String(200), nullable=False),
+            sa.Column("slug", sa.String(200), nullable=False, unique=True, index=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("fact_sheet_type", sa.String(100), nullable=False),
+            sa.Column("filters", postgresql.JSONB(), nullable=True),
+            sa.Column("display_fields", postgresql.JSONB(), nullable=True),
+            sa.Column("card_config", postgresql.JSONB(), nullable=True),
+            sa.Column("is_published", sa.Boolean(), server_default="false"),
+            sa.Column(
+                "created_by",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
The app's startup runs create_all before Alembic migrations, so the web_portals table may already exist when the migration runs. Use inspector.has_table() guard, matching the pattern in migration 009.

https://claude.ai/code/session_011rvvF7N78QtNuvMdy6AjD9