### PR TITLE
Add relationship-based filters to portal viewer

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -495,6 +495,8 @@ export interface PortalRelationType {
   reverse_label?: string;
   source_type_key: string;
   target_type_key: string;
+  other_type_key: string;
+  other_type_label: string;
 }
 
 export interface PortalTagGroup {


### PR DESCRIPTION
Portal visitors can now filter fact sheets by related items. For example, an Application portal shows dropdowns for Business Capability, Organization, IT Component, etc. — populated with actual fact sheets of each related type.

Backend:
- Enriched portal relation_types response with other_type_key/label so the frontend knows which type each relation connects to
- Added GET /public/{slug}/relation-options endpoint returning {id, name} pairs for a given type (dropdown population)
- Added relation_filters JSON query param to the fact-sheets endpoint supporting multiple simultaneous relation filters (AND logic)

Frontend:
- Added relationFilters state and relationOptions cache
- Fetches fact sheet options per related type on portal load
- Renders one dropdown per relation type, labeled with the related type name, populated with its fact sheets
- Clear Filters resets relation filters along with other filters

https://claude.ai/code/session_014Td7rfgLXZHLaehfyHgEkL