### PR TITLE
Fix filter dropdowns jumping on value selection

### DIFF
--- a/frontend/src/features/web-portals/PortalViewer.tsx
+++ b/frontend/src/features/web-portals/PortalViewer.tsx
@@ -535,7 +535,8 @@ export default function PortalViewer() {
               setSortDir(sd);
               setPage(1);
             }}
-            sx={{ minWidth: 180, "& .MuiSelect-select": { pr: "32px !important" } }}
+            InputLabelProps={{ shrink: true }}
+            sx={{ width: 180 }}
           >
             <MenuItem value="name-asc">Name A-Z</MenuItem>
             <MenuItem value="name-desc">Name Z-A</MenuItem>
@@ -553,6 +554,7 @@ export default function PortalViewer() {
               display: "flex",
               gap: 1.5,
               flexWrap: "wrap",
+              alignItems: "center",
               mt: 1.5,
               pb: 0.5,
             }}
@@ -568,7 +570,8 @@ export default function PortalViewer() {
                     setSubtype(e.target.value);
                     setPage(1);
                   }}
-                  sx={{ minWidth: 180, "& .MuiSelect-select": { pr: "32px !important" } }}
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ width: 180 }}
                 >
                   <MenuItem value="">All Subtypes</MenuItem>
                   {portal.type_info.subtypes.map((st) => (
@@ -593,7 +596,8 @@ export default function PortalViewer() {
                   }));
                   setPage(1);
                 }}
-                sx={{ minWidth: 180, "& .MuiSelect-select": { pr: "32px !important" } }}
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 180 }}
               >
                 <MenuItem value="">All</MenuItem>
                 {field.options!.map((opt) => (
@@ -621,7 +625,8 @@ export default function PortalViewer() {
                     }));
                     setPage(1);
                   }}
-                  sx={{ minWidth: 200, "& .MuiSelect-select": { pr: "32px !important" } }}
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ width: 200 }}
                 >
                   <MenuItem value="">
                     All {rt.other_type_label}s
@@ -645,7 +650,6 @@ export default function PortalViewer() {
                   setRelationFilters({});
                   setPage(1);
                 }}
-                sx={{ alignSelf: "center" }}
               />
             )}
           </Box>


### PR DESCRIPTION
- Set InputLabelProps={{ shrink: true }} on all filter TextFields so labels stay in the shrunk (above-input) position permanently instead of animating between inside/above states on selection
- Changed minWidth to fixed width on all filter dropdowns so they don't resize when a value is selected
- Added alignItems: center to the filter row for consistent alignment
- Applied same fix to the sort dropdown

https://claude.ai/code/session_014Td7rfgLXZHLaehfyHgEkL