### PR TITLE
Improve admin portal dialog layout and add logo to portal viewer

### DIFF
--- a/frontend/src/features/admin/WebPortalsAdmin.tsx
+++ b/frontend/src/features/admin/WebPortalsAdmin.tsx
@@ -17,6 +17,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import Alert from "@mui/material/Alert";
 import Tooltip from "@mui/material/Tooltip";
+import Divider from "@mui/material/Divider";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableBody from "@mui/material/TableBody";
@@ -406,26 +407,34 @@ export default function WebPortalsAdmin() {
               {error}
             </Alert>
           )}
-          <TextField
-            fullWidth
-            label="Portal Name"
-            value={name}
-            onChange={(e) => handleNameChange(e.target.value)}
-            sx={{ mt: 1 }}
-            placeholder="e.g. Application Catalog"
-          />
-          <TextField
-            fullWidth
-            label="URL Slug"
-            value={slug}
-            onChange={(e) => {
-              setSlug(e.target.value);
-              setSlugManual(true);
-            }}
-            sx={{ mt: 2 }}
-            helperText={`Portal will be accessible at /portal/${slug || "..."}`}
-            placeholder="e.g. application-catalog"
-          />
+
+          {/* ── Section: General ── */}
+          <Typography
+            variant="overline"
+            sx={{ display: "block", mt: 1, mb: 1.5, fontWeight: 700, color: "text.secondary", letterSpacing: 1 }}
+          >
+            General
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <TextField
+              fullWidth
+              label="Portal Name"
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              placeholder="e.g. Application Catalog"
+            />
+            <TextField
+              fullWidth
+              label="URL Slug"
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setSlugManual(true);
+              }}
+              helperText={`/portal/${slug || "..."}`}
+              placeholder="e.g. application-catalog"
+            />
+          </Box>
           <TextField
             fullWidth
             label="Description"
@@ -436,6 +445,16 @@ export default function WebPortalsAdmin() {
             rows={2}
             placeholder="Optional description displayed at the top of the portal"
           />
+
+          <Divider sx={{ my: 3 }} />
+
+          {/* ── Section: Data Source ── */}
+          <Typography
+            variant="overline"
+            sx={{ display: "block", mb: 1.5, fontWeight: 700, color: "text.secondary", letterSpacing: 1 }}
+          >
+            Data Source
+          </Typography>
           <TextField
             fullWidth
             select
@@ -446,7 +465,6 @@ export default function WebPortalsAdmin() {
               setToggles({});
               setFilterSubtypes([]);
             }}
-            sx={{ mt: 2 }}
             helperText="Which type of fact sheets to display in this portal"
           >
             {visibleTypes.map((t) => (
@@ -489,14 +507,21 @@ export default function WebPortalsAdmin() {
           )}
 
           {factSheetType && (
-            <Box sx={{ mt: 3 }}>
-              <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 0.5 }}>
-                Property Visibility
-              </Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
-                Control which properties appear on the summary card and in the
-                expanded detail view. Unconfigured properties use defaults.
-              </Typography>
+            <>
+            <Divider sx={{ my: 3 }} />
+
+            {/* ── Section: Display Configuration ── */}
+            <Typography
+              variant="overline"
+              sx={{ display: "block", mb: 0.5, fontWeight: 700, color: "text.secondary", letterSpacing: 1 }}
+            >
+              Display Configuration
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1.5 }}>
+              Choose which properties appear on the summary card and the expanded
+              detail view. Visible select fields and relation types also become
+              filter dropdowns on the portal automatically.
+            </Typography>
               <Table size="small" sx={{ "& td, & th": { py: 0.5, px: 1 } }}>
                 <TableHead>
                   <TableRow>
@@ -691,9 +716,12 @@ export default function WebPortalsAdmin() {
                   })}
                 </TableBody>
               </Table>
-            </Box>
+            </>
           )}
 
+          <Divider sx={{ my: 3 }} />
+
+          {/* ── Section: Publishing ── */}
           <FormControlLabel
             control={
               <Switch
@@ -701,8 +729,16 @@ export default function WebPortalsAdmin() {
                 onChange={(e) => setIsPublished(e.target.checked)}
               />
             }
-            label="Published (publicly accessible)"
-            sx={{ mt: 2 }}
+            label={
+              <Box>
+                <Typography variant="body1" fontWeight={500}>
+                  Published
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Make this portal publicly accessible without authentication
+                </Typography>
+              </Box>
+            }
           />
         </DialogContent>
         <DialogActions>

--- a/frontend/src/features/web-portals/PortalViewer.tsx
+++ b/frontend/src/features/web-portals/PortalViewer.tsx
@@ -427,7 +427,7 @@ export default function PortalViewer() {
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "#f0f2f5" }}>
-      {/* Header — matches Turbo EA toolbar */}
+      {/* Header */}
       <Box
         sx={{
           bgcolor: TOOLBAR_COLOR,
@@ -438,41 +438,67 @@ export default function PortalViewer() {
       >
         <Box sx={{ maxWidth: 1200, mx: "auto" }}>
           <Box
-            sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 0.5 }}
+            sx={{
+              display: "flex",
+              alignItems: "flex-start",
+              justifyContent: "space-between",
+              gap: 2,
+            }}
           >
-            <Box
-              sx={{
-                width: 40,
-                height: 40,
-                borderRadius: 1.5,
-                bgcolor: "rgba(255,255,255,0.12)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Icon
-                name={portal.type_info?.icon || "language"}
-                size={24}
-                color="#fff"
-              />
+            {/* Left: icon + title */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box
+                sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 0.5 }}
+              >
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 1.5,
+                    bgcolor: "rgba(255,255,255,0.12)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  <Icon
+                    name={portal.type_info?.icon || "language"}
+                    size={24}
+                    color="#fff"
+                  />
+                </Box>
+                <Typography variant="h4" fontWeight={700} sx={{ letterSpacing: -0.5 }}>
+                  {portal.name}
+                </Typography>
+              </Box>
+              {portal.description && (
+                <Typography
+                  variant="body1"
+                  sx={{ opacity: 0.8, maxWidth: 700, mt: 0.5, lineHeight: 1.6 }}
+                >
+                  {portal.description}
+                </Typography>
+              )}
+              <Typography variant="body2" sx={{ mt: 1.5, opacity: 0.5, fontSize: "0.8rem" }}>
+                {total} {portal.type_info?.label || "item"}
+                {total !== 1 ? "s" : ""}
+              </Typography>
             </Box>
-            <Typography variant="h4" fontWeight={700} sx={{ letterSpacing: -0.5 }}>
-              {portal.name}
-            </Typography>
+
+            {/* Right: app logo */}
+            <img
+              src="/api/v1/settings/logo"
+              alt=""
+              style={{
+                height: 28,
+                objectFit: "contain",
+                opacity: 0.85,
+                flexShrink: 0,
+                marginTop: 4,
+              }}
+            />
           </Box>
-          {portal.description && (
-            <Typography
-              variant="body1"
-              sx={{ opacity: 0.8, maxWidth: 700, mt: 0.5, lineHeight: 1.6 }}
-            >
-              {portal.description}
-            </Typography>
-          )}
-          <Typography variant="body2" sx={{ mt: 1.5, opacity: 0.5, fontSize: "0.8rem" }}>
-            {total} {portal.type_info?.label || "item"}
-            {total !== 1 ? "s" : ""}
-          </Typography>
         </Box>
       </Box>
 


### PR DESCRIPTION
Admin dialog:
- Reorganized into clear sections with dividers and overline headers: General (name + slug side-by-side), Data Source (type + subtypes), Display Configuration (visibility table), Publishing (switch)
- Updated helper text on Display Configuration to explain that visible select fields and relation types automatically become portal filters
- Published switch now has a subtitle explaining what it does

Portal viewer:
- Added the app logo (from /api/v1/settings/logo) to the top-right of the portal header, matching the main app toolbar branding
- Logo uses 28px height with slight opacity for subtlety
- If a custom logo is uploaded in settings, the portal shows it too

https://claude.ai/code/session_014Td7rfgLXZHLaehfyHgEkL