### PR TITLE
Merge Surveys into Todos page as a tabbed "My Tasks" view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ turbo-ea/
 │   │   │   ├── diagrams/             # DrawIO editor + sync panel + shapes
 │   │   │   ├── reports/              # 8 report types (see Reports section)
 │   │   │   ├── ea-delivery/          # SoAW editor + preview + DOCX export
-│   │   │   ├── todos/TodosPage.tsx
-│   │   │   ├── surveys/              # MySurveys + SurveyRespond pages
+│   │   │   ├── todos/TodosPage.tsx    # Combined Todos + Surveys page (tabbed)
+│   │   │   ├── surveys/              # SurveyRespond page
 │   │   │   ├── web-portals/          # PortalViewer (public portal rendering)
 │   │   │   └── admin/               # MetamodelAdmin, TagsAdmin, UsersAdmin,
 │   │   │                            # SettingsAdmin, EolAdmin, SurveysAdmin,
@@ -434,14 +434,13 @@ Base path: `/api/v1`. All endpoints except auth require `Authorization: Bearer <
 | `/ea-delivery/soaw/new` | `SoAWEditor` | Create new SoAW |
 | `/ea-delivery/soaw/:id` | `SoAWEditor` | Edit SoAW |
 | `/ea-delivery/soaw/:id/preview` | `SoAWPreview` | Read-only SoAW preview |
-| `/todos` | `TodosPage` | Global todo list |
-| `/surveys` | `MySurveys` | List surveys assigned to current user |
+| `/todos` | `TodosPage` | Todos + Surveys combined page with tab switcher (`?tab=surveys`) |
 | `/surveys/:surveyId/respond/:factSheetId` | `SurveyRespond` | Respond to a survey for a specific fact sheet |
 | `/portal/:slug` | `PortalViewer` | Public portal view (no auth required) |
 | `/admin/metamodel` | `MetamodelAdmin` | Manage fact sheet types + relation types |
 | `/admin/tags` | `TagsAdmin` | Manage tag groups + tags |
 | `/admin/users` | `UsersAdmin` | Manage users (admin only) |
-| `/admin/settings` | `SettingsAdmin` | Logo, currency, SMTP email, logo visibility toggle |
+| `/admin/settings` | `SettingsAdmin` | Logo, currency, SMTP email configuration |
 | `/admin/eol` | `EolAdmin` | Mass search + link IT components to EOL products |
 | `/admin/surveys` | `SurveysAdmin` | Admin survey list |
 | `/admin/surveys/new` | `SurveyBuilder` | Create new data-maintenance survey |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,6 @@ import SurveysAdmin from "@/features/admin/SurveysAdmin";
 import SurveyBuilder from "@/features/admin/SurveyBuilder";
 import SurveyResults from "@/features/admin/SurveyResults";
 import EolAdmin from "@/features/admin/EolAdmin";
-import MySurveys from "@/features/surveys/MySurveys";
 import SurveyRespond from "@/features/surveys/SurveyRespond";
 import WebPortalsAdmin from "@/features/admin/WebPortalsAdmin";
 import PortalViewer from "@/features/web-portals/PortalViewer";
@@ -101,7 +100,7 @@ function AppRoutes() {
               <Route path="/ea-delivery/soaw/:id/preview" element={<SoAWPreview />} />
               <Route path="/ea-delivery/soaw/:id" element={<SoAWEditor />} />
               <Route path="/todos" element={<TodosPage />} />
-              <Route path="/surveys" element={<MySurveys />} />
+              <Route path="/surveys" element={<Navigate to="/todos?tab=surveys" />} />
               <Route path="/surveys/:surveyId/respond/:factSheetId" element={<SurveyRespond />} />
               <Route path="/admin/metamodel" element={<MetamodelAdmin />} />
               <Route path="/admin/tags" element={<TagsAdmin />} />

--- a/frontend/src/features/todos/TodosPage.tsx
+++ b/frontend/src/features/todos/TodosPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
@@ -11,11 +12,16 @@ import Chip from "@mui/material/Chip";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Tooltip from "@mui/material/Tooltip";
+import Badge from "@mui/material/Badge";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
-import type { Todo } from "@/types";
+import type { Todo, MySurveyItem } from "@/types";
 
-export default function TodosPage() {
+/* ── Todos sub-panel ─────────────────────────────────────────────────── */
+
+function TodosPanel() {
   const navigate = useNavigate();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [tab, setTab] = useState(0);
@@ -32,25 +38,19 @@ export default function TodosPage() {
   };
 
   const handleTodoAction = (todo: Todo) => {
-    // System todos (e.g. sign requests) navigate to linked page
     if (todo.is_system && todo.link) {
       navigate(todo.link);
       return;
     }
-    // Regular fact-sheet todos navigate to the fact sheet
     if (todo.fact_sheet_id) {
       navigate(`/fact-sheets/${todo.fact_sheet_id}`);
       return;
     }
-    // Otherwise toggle status
     toggleStatus(todo);
   };
 
   return (
-    <Box>
-      <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
-        My Todos
-      </Typography>
+    <>
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Open" />
         <Tab label="Done" />
@@ -138,6 +138,144 @@ export default function TodosPage() {
           </Typography>
         )}
       </List>
+    </>
+  );
+}
+
+/* ── Surveys sub-panel ───────────────────────────────────────────────── */
+
+function SurveysPanel() {
+  const navigate = useNavigate();
+  const [surveys, setSurveys] = useState<MySurveyItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    api
+      .get<MySurveyItem[]>("/surveys/my")
+      .then(setSurveys)
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load surveys"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
+          {error}
+        </Alert>
+      )}
+
+      {surveys.length === 0 && (
+        <Alert severity="info">
+          No pending surveys. You're all caught up!
+        </Alert>
+      )}
+
+      {surveys.map((s) => (
+        <Card key={s.survey_id} sx={{ mb: 2 }}>
+          <Box sx={{ p: 2 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+              <MaterialSymbol icon="assignment" size={22} color="#1976d2" />
+              <Typography sx={{ fontWeight: 600, flex: 1 }}>{s.survey_name}</Typography>
+              <Chip
+                label={`${s.pending_count} pending`}
+                size="small"
+                color="warning"
+              />
+            </Box>
+
+            {s.survey_message && (
+              <Card variant="outlined" sx={{ p: 1.5, mb: 2, bgcolor: "grey.50" }}>
+                <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                  {s.survey_message}
+                </Typography>
+              </Card>
+            )}
+
+            {s.items.map((item) => (
+              <Card key={item.response_id} variant="outlined" sx={{ mb: 1 }}>
+                <CardActionArea
+                  onClick={() => navigate(`/surveys/${s.survey_id}/respond/${item.fact_sheet_id}`)}
+                  sx={{ p: 1.5, display: "flex", justifyContent: "flex-start" }}
+                >
+                  <MaterialSymbol icon="edit_note" size={20} color="#ed6c02" />
+                  <Typography sx={{ ml: 1, fontSize: "0.9rem", flex: 1 }}>
+                    {item.fact_sheet_name}
+                  </Typography>
+                  <Chip label="Respond" size="small" color="primary" variant="outlined" />
+                </CardActionArea>
+              </Card>
+            ))}
+          </Box>
+        </Card>
+      ))}
+    </>
+  );
+}
+
+/* ── Main page ───────────────────────────────────────────────────────── */
+
+export default function TodosPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const section = searchParams.get("tab") === "surveys" ? 1 : 0;
+
+  const [badgeCounts, setBadgeCounts] = useState({ open_todos: 0, pending_surveys: 0 });
+
+  useEffect(() => {
+    api
+      .get<{ open_todos: number; pending_surveys: number }>("/notifications/badge-counts")
+      .then(setBadgeCounts)
+      .catch(() => {});
+  }, []);
+
+  const handleSectionChange = (_: unknown, v: number) => {
+    setSearchParams(v === 1 ? { tab: "surveys" } : {});
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
+        My Tasks
+      </Typography>
+
+      <Tabs value={section} onChange={handleSectionChange} sx={{ mb: 2 }}>
+        <Tab
+          label={
+            <Badge
+              badgeContent={badgeCounts.open_todos}
+              color="error"
+              max={99}
+              sx={{ "& .MuiBadge-badge": { right: -12, top: 2 } }}
+            >
+              Todos
+            </Badge>
+          }
+        />
+        <Tab
+          label={
+            <Badge
+              badgeContent={badgeCounts.pending_surveys}
+              color="warning"
+              max={99}
+              sx={{ "& .MuiBadge-badge": { right: -12, top: 2 } }}
+            >
+              Surveys
+            </Badge>
+          }
+        />
+      </Tabs>
+
+      {section === 0 && <TodosPanel />}
+      {section === 1 && <SurveysPanel />}
     </Box>
   );
 }

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -61,7 +61,6 @@ const NAV_ITEMS: NavItem[] = [
   { label: "Diagrams", icon: "schema", path: "/diagrams" },
   { label: "Delivery", icon: "architecture", path: "/ea-delivery" },
   { label: "Todos", icon: "checklist", path: "/todos" },
-  { label: "Surveys", icon: "assignment", path: "/surveys" },
 ];
 
 const ADMIN_ITEMS: NavItem[] = [
@@ -231,8 +230,7 @@ export default function AppLayout({ children, user, onLogout }: Props) {
   };
 
   const hasBadge = (label: string) =>
-    (label === "Todos" && badgeCounts.open_todos > 0) ||
-    (label === "Surveys" && badgeCounts.pending_surveys > 0);
+    label === "Todos" && (badgeCounts.open_todos > 0 || badgeCounts.pending_surveys > 0);
 
   // ── Mobile drawer ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Free up navbar space by removing the standalone Surveys button. The /todos page now has two top-level tabs: "Todos" and "Surveys", each showing a badge count. The Surveys tab embeds the MySurveys content inline. /surveys redirects to /todos?tab=surveys for backwards compatibility.

- TodosPage: split into TodosPanel + SurveysPanel sub-components, top-level tab switcher driven by ?tab= search param, badge counts fetched from /notifications/badge-counts
- AppLayout: remove "Surveys" from NAV_ITEMS, update hasBadge to trigger on Todos when either open_todos or pending_surveys > 0
- App.tsx: replace /surveys route with redirect to /todos?tab=surveys, remove unused MySurveys import
- CLAUDE.md: update routing table and project structure

https://claude.ai/code/session_012nJQp7dgmTDmQSz6vTsp4G