### PR TITLE
Pass SEED_BPM env var through to backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       RESET_DB: ${RESET_DB:-false}
       SEED_DEMO: ${SEED_DEMO:-false}
+      SEED_BPM: ${SEED_BPM:-false}
       SECRET_KEY: ${SECRET_KEY:-dev-secret-key-change-in-production}
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-1440}
     ports:


### PR DESCRIPTION
The SEED_BPM variable was missing from the docker-compose environment block, so it was never reaching the container even when set on the host.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7