### PR TITLE
Fix BPM export auth and hide bpmn.io watermark

### DIFF
--- a/frontend/src/features/bpm/BpmnModeler.tsx
+++ b/frontend/src/features/bpm/BpmnModeler.tsx
@@ -306,7 +306,7 @@ export default function BpmnModeler({ processId, initialXml, onSaved, onBack }: 
       </Box>
 
       {/* Canvas */}
-      <Box ref={containerRef} sx={{ flex: 1, bgcolor: "#fafafa" }} />
+      <Box ref={containerRef} sx={{ flex: 1, bgcolor: "#fafafa", "& .bjs-powered-by": { display: "none" } }} />
 
       {/* Snackbar */}
       <Snackbar

--- a/frontend/src/features/bpm/BpmnViewer.tsx
+++ b/frontend/src/features/bpm/BpmnViewer.tsx
@@ -116,7 +116,7 @@ export default function BpmnViewer({ bpmnXml, elements, onElementClick, height =
     <Box sx={{ position: "relative" }}>
       <Box
         ref={containerRef}
-        sx={{ height, border: 1, borderColor: "divider", borderRadius: 1, bgcolor: "#fafafa" }}
+        sx={{ height, border: 1, borderColor: "divider", borderRadius: 1, bgcolor: "#fafafa", "& .bjs-powered-by": { display: "none" } }}
       />
 
       <Popover

--- a/frontend/src/features/bpm/ProcessFlowTab.tsx
+++ b/frontend/src/features/bpm/ProcessFlowTab.tsx
@@ -126,7 +126,16 @@ export default function ProcessFlowTab({ processId }: Props) {
           variant="outlined"
           size="small"
           startIcon={<MaterialSymbol icon="download" />}
-          onClick={() => window.open(`/api/v1/bpm/processes/${processId}/diagram/export/bpmn`)}
+          onClick={async () => {
+            const res = await api.getRaw(`/bpm/processes/${processId}/diagram/export/bpmn`);
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `process-${processId}.bpmn`;
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
         >
           Export BPMN
         </Button>
@@ -134,7 +143,16 @@ export default function ProcessFlowTab({ processId }: Props) {
           variant="outlined"
           size="small"
           startIcon={<MaterialSymbol icon="image" />}
-          onClick={() => window.open(`/api/v1/bpm/processes/${processId}/diagram/export/svg`)}
+          onClick={async () => {
+            const res = await api.getRaw(`/bpm/processes/${processId}/diagram/export/svg`);
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `process-${processId}.svg`;
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
         >
           Export SVG
         </Button>


### PR DESCRIPTION
- ProcessFlowTab export buttons used window.open() which opened a new tab without JWT token, causing 401 errors. Now uses api.getRaw() with proper auth headers and triggers blob downloads.
- Added getRaw() method to API client for non-JSON responses.
- Hide the bpmn.io "powered by" logo in both BpmnModeler and BpmnViewer.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7