### PR TITLE
Improve BPM reports: embed Process Map, redesign Value Stream Matrix

### DIFF
--- a/backend/app/api/v1/bpm_reports.py
+++ b/backend/app/api/v1/bpm_reports.py
@@ -594,11 +594,13 @@ async def value_stream_matrix(db: AsyncSession = Depends(get_db)):
         }
 
     def _ctx_dict(c):
+        attrs = c.attributes or {}
         return {
             "id": str(c.id),
             "name": c.name,
             "subtype": c.subtype,
             "parent_id": str(c.parent_id) if c.parent_id else None,
+            "sort_order": attrs.get("sortOrder"),
         }
 
     return {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,6 @@ import PortalViewer from "@/features/web-portals/PortalViewer";
 import BpmDashboard from "@/features/bpm/BpmDashboard";
 import ProcessFlowEditorPage from "@/features/bpm/ProcessFlowEditorPage";
 import BpmReportPage from "@/features/bpm/BpmReportPage";
-import ProcessMapReport from "@/features/reports/ProcessMapReport";
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 
@@ -98,7 +97,6 @@ function AppRoutes() {
               <Route path="/reports/data-quality" element={<DataQualityReport />} />
               <Route path="/reports/eol" element={<EolReport />} />
               <Route path="/reports/bpm" element={<BpmReportPage />} />
-              <Route path="/reports/process-map" element={<ProcessMapReport />} />
               <Route path="/bpm" element={<BpmDashboard />} />
               <Route path="/bpm/processes/:id/flow" element={<ProcessFlowEditorPage />} />
               <Route path="/diagrams" element={<DiagramsPage />} />

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -50,7 +50,6 @@ const NAV_ITEMS: NavItem[] = [
     children: [
       { label: "Portfolio", icon: "bubble_chart", path: "/reports/portfolio" },
       { label: "Capability Map", icon: "grid_view", path: "/reports/capability-map" },
-      { label: "Process Map", icon: "account_tree", path: "/reports/process-map" },
       { label: "Lifecycle", icon: "timeline", path: "/reports/lifecycle" },
       { label: "Dependencies", icon: "hub", path: "/reports/dependencies" },
       { label: "Cost", icon: "payments", path: "/reports/cost" },


### PR DESCRIPTION
Process Map:
- Removed from main Reports nav and standalone route
- Now rendered directly as a tab inside BPM Reports page

Value Stream Matrix redesign:
- Columns grouped by Business Context subtype (Value Streams, Customer Journeys, etc.) with colored spanning header row
- Each group has a distinct color band for clear visual separation
- Process cells use rounded card-style blocks instead of small chips
- Hover effects with elevation and lift animation
- Rich tooltips showing process name, color-by value, and subtype
- Admin reorder: left/right arrows on column headers (admin only) that persist ordering via sortOrder attribute on fact sheets
- Summary stats bar below the matrix
- Removed the confusing context type dropdown filter in favor of always showing all groups with visual separation

Backend: value-stream-matrix endpoint now includes sort_order field from context attributes for column ordering.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7