### PR TITLE
Fix BPMN templates, default to full mode, fix lane extraction

### DIFF
--- a/backend/app/api/v1/bpm.py
+++ b/backend/app/api/v1/bpm.py
@@ -380,7 +380,7 @@ async def get_template(
     # Return BPMN XML from bundled templates
     import pathlib
 
-    template_dir = pathlib.Path(__file__).resolve().parent.parent.parent / "bpmn_templates"
+    template_dir = pathlib.Path(__file__).resolve().parent.parent.parent.parent / "bpmn_templates"
     template_file = template_dir / f"{template_key}.bpmn"
     if template_file.exists():
         bpmn_xml = template_file.read_text()

--- a/frontend/src/features/bpm/BpmnModeler.tsx
+++ b/frontend/src/features/bpm/BpmnModeler.tsx
@@ -42,7 +42,7 @@ export default function BpmnModeler({ processId, initialXml, onSaved, onBack }: 
   const [saving, setSaving] = useState(false);
   const [version, setVersion] = useState<number | null>(null);
   const [snack, setSnack] = useState<{ msg: string; severity: "success" | "error" } | null>(null);
-  const [mode, setMode] = useState<"simple" | "full">("simple");
+  const [mode, setMode] = useState<"simple" | "full">("full");
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load bpmn-js dynamically (it's a CommonJS module)
@@ -356,15 +356,50 @@ function defaultBlankXml(): string {
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
                   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
                   xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
-                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_1" targetNamespace="http://turbo-ea.io/bpmn">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" name="Process" processRef="Process_1" />
+  </bpmn:collaboration>
   <bpmn:process id="Process_1" isExecutable="false">
-    <bpmn:startEvent id="StartEvent_1" name="Start" />
+    <bpmn:laneSet id="LaneSet_1">
+      <bpmn:lane id="Lane_1" name="Lane 1">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
-        <dc:Bounds x="180" y="160" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="60" width="600" height="200" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1_di" bpmnElement="Lane_1" isHorizontal="true">
+        <dc:Bounds x="190" y="60" width="570" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="252" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258" y="185" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="612" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="620" y="185" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="288" y="160" />
+        <di:waypoint x="612" y="160" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>`;


### PR DESCRIPTION
Three connected issues:

1. Templates broken: path resolved to backend/app/bpmn_templates (wrong) instead of backend/bpmn_templates. Every template fell back to _blank_bpmn() which is just a bare start event. Fix: add one more .parent to the path resolution.

2. Lanes not populated: because templates were broken, users always got the minimal blank XML with no collaboration/pool/laneSet. The parser is correct but there were no lanes to extract. Fix: update the frontend defaultBlankXml() fallback to include a proper BPMN structure with collaboration, participant, laneSet, and a named lane.

3. Default to Full BPMN: change editor default from "simple" to "full" so pools, lanes, sub-processes, data objects, intermediate events are all available in the palette by default.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7