### PR TITLE
Switch relation editor from popover to centered dialog

### DIFF
--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -146,9 +146,10 @@ export default function InventoryPage() {
   const [massEditError, setMassEditError] = useState("");
   const [massEditLoading, setMassEditLoading] = useState(false);
 
-  // Relation cell popover state
-  const [relEditAnchor, setRelEditAnchor] = useState<HTMLElement | null>(null);
+  // Relation cell dialog state
+  const [relEditOpen, setRelEditOpen] = useState(false);
   const [relEditFsId, setRelEditFsId] = useState("");
+  const [relEditFsName, setRelEditFsName] = useState("");
   const [relEditRelType, setRelEditRelType] = useState<RelationType | null>(null);
 
   // React to ?create=true search param
@@ -581,8 +582,9 @@ export default function InventoryPage() {
                 onClick={(e: React.MouseEvent<HTMLDivElement>) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  setRelEditAnchor(e.currentTarget as HTMLElement);
+                  setRelEditOpen(true);
                   setRelEditFsId(p.data.id);
+                  setRelEditFsName(p.data.name);
                   setRelEditRelType(relTypeRef);
                 }}
                 sx={{
@@ -971,9 +973,10 @@ export default function InventoryPage() {
 
       {relEditRelType && (
         <RelationCellPopover
-          anchorEl={relEditAnchor}
-          onClose={() => { setRelEditAnchor(null); setRelEditFsId(""); setRelEditRelType(null); }}
+          open={relEditOpen}
+          onClose={() => { setRelEditOpen(false); setRelEditFsId(""); setRelEditFsName(""); setRelEditRelType(null); }}
           factSheetId={relEditFsId}
+          factSheetName={relEditFsName}
           relationType={relEditRelType}
           selectedType={selectedType}
           onRelationsChanged={fetchRelations}


### PR DESCRIPTION
Replace the Popover (which had positioning issues due to AG Grid cell virtualization) with a full-width Dialog (maxWidth="sm"). The dialog shows the fact sheet name in the title, has labeled sections for current relations and adding new ones, and uses normal-sized chips for better readability.

https://claude.ai/code/session_01LdSUCz9EMUdbm2A2D1Yip4