### PR TITLE
Fix Process Navigator: drawer close, SVG URL, layout, spacing, and mo…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,6 @@ import PortalViewer from "@/features/web-portals/PortalViewer";
 import BpmDashboard from "@/features/bpm/BpmDashboard";
 import ProcessFlowEditorPage from "@/features/bpm/ProcessFlowEditorPage";
 import BpmReportPage from "@/features/bpm/BpmReportPage";
-import ProcessNavigator from "@/features/bpm/ProcessNavigator";
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 
@@ -98,7 +97,6 @@ function AppRoutes() {
               <Route path="/reports/data-quality" element={<DataQualityReport />} />
               <Route path="/reports/eol" element={<EolReport />} />
               <Route path="/reports/bpm" element={<BpmReportPage />} />
-              <Route path="/process-navigator" element={<ProcessNavigator />} />
               <Route path="/bpm" element={<BpmDashboard />} />
               <Route path="/bpm/processes/:id/flow" element={<ProcessFlowEditorPage />} />
               <Route path="/diagrams" element={<DiagramsPage />} />

--- a/frontend/src/features/bpm/BpmDashboard.tsx
+++ b/frontend/src/features/bpm/BpmDashboard.tsx
@@ -1,9 +1,10 @@
 /**
- * BpmDashboard — Landing page for BPM module.
- * Shows KPIs, charts, and quick links to processes.
+ * BpmDashboard — Tabbed landing page for BPM module.
+ * Tab 0: Process Navigator (Process House)
+ * Tab 1: Dashboard KPIs, charts, and quick links to processes.
  */
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -16,6 +17,8 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Chip from "@mui/material/Chip";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
 import LinearProgress from "@mui/material/LinearProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
@@ -24,6 +27,7 @@ import {
   Tooltip, Legend, ResponsiveContainer,
 } from "recharts";
 import type { BpmDashboardData } from "@/types";
+import ProcessNavigator from "./ProcessNavigator";
 
 const COLORS = ["#1976d2", "#607d8b", "#9c27b0", "#4caf50", "#ff9800", "#f44336"];
 
@@ -42,7 +46,8 @@ const RISK_COLORS: Record<string, string> = {
   critical: "#b71c1c",
 };
 
-export default function BpmDashboard() {
+/* ── Dashboard content (tab 1) ── */
+function BpmDashboardContent() {
   const navigate = useNavigate();
   const [data, setData] = useState<BpmDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -69,11 +74,7 @@ export default function BpmDashboard() {
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 } }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3, alignItems: "center" }}>
-        <Typography variant="h5">
-          <MaterialSymbol icon="route" style={{ marginRight: 8, verticalAlign: "middle" }} />
-          Business Process Management
-        </Typography>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
         <Button
           variant="outlined"
           onClick={() => navigate("/inventory?type=BusinessProcess")}
@@ -233,6 +234,57 @@ export default function BpmDashboard() {
           </CardContent>
         </Card>
       )}
+    </Box>
+  );
+}
+
+/* ── Tabbed shell ── */
+const BPM_TAB_PARAM = "tab";
+
+export default function BpmDashboard() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get(BPM_TAB_PARAM);
+  const tabIndex = tabParam === "dashboard" ? 1 : 0;
+
+  const handleTabChange = (_: unknown, newValue: number) => {
+    const params = new URLSearchParams(searchParams);
+    if (newValue === 0) {
+      params.delete(BPM_TAB_PARAM);
+    } else {
+      params.set(BPM_TAB_PARAM, "dashboard");
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  return (
+    <Box>
+      {/* Header + tabs */}
+      <Box sx={{ px: { xs: 2, md: 3 }, pt: { xs: 2, md: 2.5 }, borderBottom: 1, borderColor: "divider" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+          <MaterialSymbol icon="route" size={28} color="#1976d2" />
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>
+            Business Process Management
+          </Typography>
+        </Box>
+        <Tabs value={tabIndex} onChange={handleTabChange}>
+          <Tab
+            label="Process Navigator"
+            icon={<MaterialSymbol icon="account_tree" size={18} />}
+            iconPosition="start"
+            sx={{ minHeight: 42, textTransform: "none" }}
+          />
+          <Tab
+            label="Dashboard"
+            icon={<MaterialSymbol icon="dashboard" size={18} />}
+            iconPosition="start"
+            sx={{ minHeight: 42, textTransform: "none" }}
+          />
+        </Tabs>
+      </Box>
+
+      {/* Tab content */}
+      {tabIndex === 0 && <ProcessNavigator />}
+      {tabIndex === 1 && <BpmDashboardContent />}
     </Box>
   );
 }

--- a/frontend/src/features/bpm/ProcessNavigator.tsx
+++ b/frontend/src/features/bpm/ProcessNavigator.tsx
@@ -27,7 +27,6 @@ import LinearProgress from "@mui/material/LinearProgress";
 import CircularProgress from "@mui/material/CircularProgress";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
-import Badge from "@mui/material/Badge";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -367,7 +366,7 @@ function HouseCard({
             color: "#fff",
             display: "flex",
             alignItems: "center",
-            gap: 0.5,
+            gap: 1,
           }}
         >
           <Typography
@@ -378,7 +377,7 @@ function HouseCard({
             {node.name}
           </Typography>
           {subtypeLabel && (
-            <Typography variant="caption" sx={{ opacity: 0.85, fontSize: "0.6rem", flexShrink: 0 }}>
+            <Typography variant="caption" sx={{ opacity: 0.85, fontSize: "0.6rem", flexShrink: 0, ml: 0.5 }}>
               {subtypeLabel}
             </Typography>
           )}
@@ -391,7 +390,7 @@ function HouseCard({
             py: 0.5,
             display: "flex",
             alignItems: "center",
-            gap: 0.5,
+            gap: 0.75,
             bgcolor: "#fafafa",
             borderTop: "1px solid #f0f0f0",
           }}
@@ -470,7 +469,7 @@ function HouseCard({
           color: "#fff",
           display: "flex",
           alignItems: "center",
-          gap: 0.5,
+          gap: 1,
           cursor: "pointer",
           "&:hover": { opacity: 0.9 },
         }}
@@ -488,27 +487,26 @@ function HouseCard({
           {node.name}
         </Typography>
         {subtypeLabel && (
-          <Typography variant="caption" sx={{ opacity: 0.85, fontSize: "0.6rem", flexShrink: 0 }}>
+          <Typography variant="caption" sx={{ opacity: 0.85, fontSize: "0.6rem", flexShrink: 0, ml: 0.5 }}>
             {subtypeLabel}
           </Typography>
         )}
-        <Badge badgeContent={childCount} color="default" max={99}
+        <Chip
+          size="small"
+          label={childCount}
           sx={{
-            "& .MuiBadge-badge": {
-              bgcolor: "rgba(255,255,255,0.25)",
-              color: "#fff",
-              fontSize: "0.6rem",
-              height: 18,
-              minWidth: 18,
-            },
+            height: 20,
+            fontSize: "0.65rem",
+            fontWeight: 600,
+            bgcolor: "rgba(255,255,255,0.25)",
+            color: "#fff",
+            ml: 0.5,
           }}
-        >
-          <Box sx={{ width: 4 }} />
-        </Badge>
+        />
       </Box>
-      <Box sx={{ p: 0.75, display: "flex", flexWrap: "wrap", gap: 0.75, bgcolor: "rgba(0,0,0,0.02)" }}>
+      <Box sx={{ p: 0.75, display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 0.75, bgcolor: "rgba(0,0,0,0.02)" }}>
         {node.children.map((ch) => (
-          <Box key={ch.id} sx={{ flex: "1 1 160px", minWidth: 140, maxWidth: 320 }}>
+          <Box key={ch.id}>
             <HouseCard
               node={ch}
               displayLevel={displayLevel}
@@ -996,7 +994,7 @@ function DrawerFlow({
 
     // Fetch SVG thumbnail
     const token = localStorage.getItem("token");
-    fetch(`/api/v1/bpm/processes/${processId}/diagram/svg`, {
+    fetch(`/api/v1/bpm/processes/${processId}/diagram/export/svg`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
       .then((r) => {
@@ -1630,13 +1628,15 @@ export default function ProcessNavigator() {
     };
   }, [fullTree, zoomNodeId]);
 
-  // ── Open drawer from URL param ──
+  // ── Open drawer from URL param (initial mount only) ──
+  const initialDrawerApplied = useRef(false);
   useEffect(() => {
-    if (drawerParam && fullTree.length > 0 && !drawerNode) {
+    if (!initialDrawerApplied.current && drawerParam && fullTree.length > 0) {
       const node = findNode(fullTree, drawerParam);
       if (node) setDrawerNode(node);
+      initialDrawerApplied.current = true;
     }
-  }, [drawerParam, fullTree, drawerNode]);
+  }, [drawerParam, fullTree]);
 
   // ── Sync state → URL ──
   useEffect(() => {
@@ -1752,15 +1752,10 @@ export default function ProcessNavigator() {
     );
 
   return (
-    <Box ref={containerRef} sx={{ p: { xs: 2, md: 3 }, maxWidth: 1400, mx: "auto" }}>
-      {/* ── Title Row ── */}
+    <Box ref={containerRef} sx={{ p: { xs: 2, md: 3 } }}>
+      {/* ── View mode toggle ── */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2, flexWrap: "wrap" }}>
-        <MaterialSymbol icon="account_tree" size={28} color="#e65100" />
-        <Typography variant="h5" sx={{ fontWeight: 700, flex: 1, minWidth: 0 }} noWrap>
-          Process Navigator
-        </Typography>
-
-        {/* View mode toggle */}
+        <Box sx={{ flex: 1 }} />
         <ToggleButtonGroup
           value={viewMode}
           exclusive
@@ -1972,15 +1967,8 @@ export default function ProcessNavigator() {
                           display: "grid",
                           gridTemplateColumns: {
                             xs: "1fr",
-                            sm: "1fr 1fr",
-                            md:
-                              rowType === "core"
-                                ? "1fr 1fr 1fr"
-                                : "1fr 1fr 1fr 1fr",
-                            lg:
-                              rowType === "core"
-                                ? "1fr 1fr 1fr 1fr"
-                                : "1fr 1fr 1fr 1fr 1fr",
+                            sm: "repeat(2, 1fr)",
+                            md: "repeat(auto-fill, minmax(220px, 1fr))",
                           },
                           gap: 1.5,
                         }}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -60,7 +60,6 @@ const NAV_ITEMS: NavItem[] = [
     ],
   },
   { label: "BPM", icon: "route", path: "/bpm" },
-  { label: "Processes", icon: "account_tree", path: "/process-navigator" },
   { label: "Diagrams", icon: "schema", path: "/diagrams" },
   { label: "Delivery", icon: "architecture", path: "/ea-delivery" },
   { label: "Todos", icon: "checklist", path: "/todos" },


### PR DESCRIPTION
…ve under BPM tabs

- Fix drawer can't close: race condition between URL sync and drawer-open effect — restrict URL-based opening to initial mount only via ref guard
- Fix SVG 404: correct endpoint from /diagram/svg to /diagram/export/svg
- Full page width: remove maxWidth:1400, use auto-fill grid for cards
- Better spacing: increase gap in card headers (0.5→1) and footers (0.5→0.75), add margin between labels and pills
- Replace Badge with Chip for child count in container card headers
- Move Process Navigator under BPM as first tab (Process Navigator | Dashboard), remove separate /process-navigator route and nav item
- Remove redundant title from ProcessNavigator since BPM shell has header

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7