### PR TITLE
Fix Process House grid to fill full screen width

### DIFF
--- a/frontend/src/features/bpm/ProcessNavigator.tsx
+++ b/frontend/src/features/bpm/ProcessNavigator.tsx
@@ -1987,22 +1987,21 @@ export default function ProcessNavigator() {
                     ) : (
                       <Box
                         sx={{
-                          display: "flex",
-                          flexWrap: "wrap",
+                          display: "grid",
+                          gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
                           gap: 1.5,
                         }}
                       >
                         {nodes.map((node) => (
-                          <Box key={node.id} sx={{ flex: "1 1 260px", maxWidth: 400 }}>
-                            <HouseCard
-                              node={node}
-                              displayLevel={displayLevel}
-                              overlay={overlay}
-                              search={search}
-                              onOpen={handleOpenDrawer}
-                              onDrill={handleDrill}
-                            />
-                          </Box>
+                          <HouseCard
+                            key={node.id}
+                            node={node}
+                            displayLevel={displayLevel}
+                            overlay={overlay}
+                            search={search}
+                            onOpen={handleOpenDrawer}
+                            onDrill={handleDrill}
+                          />
                         ))}
                       </Box>
                     )}


### PR DESCRIPTION
Switch from flexbox (flex: 1 1 260px / maxWidth: 400) back to CSS grid with repeat(auto-fill, minmax(260px, 1fr)). Now that the container has no maxWidth cap, auto-fill correctly creates as many columns as the viewport allows and cards stretch equally to fill each row.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7