### PR TITLE
SVG preview fix, drag-and-drop reorder, row reorder, wider cards, rem…

### DIFF
--- a/frontend/src/features/bpm/ProcessFlowTab.tsx
+++ b/frontend/src/features/bpm/ProcessFlowTab.tsx
@@ -70,8 +70,26 @@ export default function ProcessFlowTab({ processId }: Props) {
 
   const handleTemplateSelected = async (bpmnXml: string) => {
     try {
+      // Generate SVG thumbnail using a hidden bpmn-js viewer
+      let svgThumbnail: string | undefined;
+      try {
+        const NavigatedViewer = (await import("bpmn-js/lib/NavigatedViewer")).default;
+        const el = document.createElement("div");
+        el.style.cssText = "position:absolute;left:-9999px;width:1200px;height:800px";
+        document.body.appendChild(el);
+        const viewer = new NavigatedViewer({ container: el });
+        await viewer.importXML(bpmnXml);
+        const result = await (viewer as any).saveSVG();
+        svgThumbnail = result.svg;
+        viewer.destroy();
+        document.body.removeChild(el);
+      } catch {
+        // SVG generation optional
+      }
+
       await api.put(`/bpm/processes/${processId}/diagram`, {
         bpmn_xml: bpmnXml,
+        svg_thumbnail: svgThumbnail,
       });
       setShowTemplateChooser(false);
       loadData();


### PR DESCRIPTION
…ove cost

1. SVG preview for template-created diagrams:
   - ProcessFlowTab now generates SVG thumbnail using a hidden bpmn-js NavigatedViewer before saving template, so preview is immediately available in the drawer Flow tab

2. Leaf card improvements:
   - Width increased to minmax(320px, 1fr)
   - Fixed header height (minHeight: 38px) with 2-line clamp for consistent card heights regardless of name length
   - Removed noWrap — long names show up to 2 lines

3. Drag-and-drop reorder (admin only):
   - Cards are draggable with HTML5 drag API (admin users see grab cursor and drag indicator on container cards)
   - Drop target highlights with colored outline
   - On drop, ALL siblings get sequential sortOrder values assigned, fixing the previous reliability issue where only 2 items were swapped
   - Works for both leaf and container cards within same process type row

4. Vertical row reordering (admin only):
   - Up/down arrows on each row header (Management/Core/Support)
   - Row order persisted to backend via new /settings/bpm-row-order endpoint (stored in app_settings.general_settings.bpmRowOrder)
   - Visible to all users, only admins can change

5. Removed Cost KPI from drawer side panel (and fmtCost prop chain)

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7