### PR TITLE
Add drill-down button on container card headers

### DIFF
--- a/frontend/src/features/bpm/ProcessNavigator.tsx
+++ b/frontend/src/features/bpm/ProcessNavigator.tsx
@@ -586,6 +586,21 @@ function HouseCard({
             ml: 0.5,
           }}
         />
+        <Tooltip title="Drill down into this process">
+          <IconButton
+            size="small"
+            onClick={(e) => { e.stopPropagation(); onDrill(node.id); }}
+            sx={{
+              p: 0.25,
+              ml: 0.25,
+              color: "#fff",
+              opacity: 0.7,
+              "&:hover": { opacity: 1, bgcolor: "rgba(255,255,255,0.2)" },
+            }}
+          >
+            <MaterialSymbol icon="zoom_in" size={18} />
+          </IconButton>
+        </Tooltip>
       </Box>
       <Box sx={{ p: 0.75, display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 0.75, bgcolor: "rgba(0,0,0,0.02)" }}>
         {node.children.map((ch) => (


### PR DESCRIPTION
Adds a zoom_in icon next to the child count chip on container cards. Clicking it drills into that process, showing its children as the new top-level view with breadcrumb navigation. Works recursively at every level of the hierarchy.

https://claude.ai/code/session_01TrxdFbr2Q98kqRY4MwgKG7