### PR TITLE
Add BPM feature toggle, bpm_admin role, and process flow approval wor…

### DIFF
--- a/backend/alembic/versions/016_add_process_flow_versions.py
+++ b/backend/alembic/versions/016_add_process_flow_versions.py
@@ -1,0 +1,82 @@
+"""add process_flow_versions table for draft/published/archived workflow
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-02-15
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    from sqlalchemy import inspect as sa_inspect
+
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+
+    if not inspector.has_table("process_flow_versions"):
+        op.create_table(
+            "process_flow_versions",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "process_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("fact_sheets.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("status", sa.String(20), nullable=False, default="draft"),
+            sa.Column("revision", sa.Integer(), default=1),
+            sa.Column("bpmn_xml", sa.Text(), nullable=False),
+            sa.Column("svg_thumbnail", sa.Text(), nullable=True),
+            sa.Column(
+                "created_by",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id"),
+                nullable=True,
+            ),
+            sa.Column(
+                "submitted_by",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id"),
+                nullable=True,
+            ),
+            sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "approved_by",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id"),
+                nullable=True,
+            ),
+            sa.Column("approved_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "based_on_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("process_flow_versions.id"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("process_flow_versions")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -37,3 +37,15 @@ async def get_optional_user(request: Request, db: AsyncSession = Depends(get_db)
         return await get_current_user(request, db)
     except HTTPException:
         return None
+
+
+def require_admin(user: User) -> None:
+    """Raise 403 unless user is a site admin."""
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin only")
+
+
+def require_bpm_admin(user: User) -> None:
+    """Raise 403 unless user is admin or bpm_admin."""
+    if user.role not in ("admin", "bpm_admin"):
+        raise HTTPException(status_code=403, detail="Admin or BPM Admin required")

--- a/backend/app/api/v1/bpm.py
+++ b/backend/app/api/v1/bpm.py
@@ -193,9 +193,9 @@ async def delete_diagram(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Delete all diagram versions and extracted elements for a process (admin only)."""
-    if current_user.role != "admin":
-        raise HTTPException(403, "Admin only")
+    """Delete all diagram versions and extracted elements for a process (admin or bpm_admin)."""
+    if current_user.role not in ("admin", "bpm_admin"):
+        raise HTTPException(403, "Admin or BPM Admin required")
 
     pid = uuid.UUID(process_id)
     process = await _get_process_or_404(db, pid)

--- a/backend/app/api/v1/bpm_workflow.py
+++ b/backend/app/api/v1/bpm_workflow.py
@@ -1,0 +1,580 @@
+"""BPM Workflow — draft / published / archived process flow management with approval."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.models.fact_sheet import FactSheet
+from app.models.process_flow_version import ProcessFlowVersion
+from app.models.subscription import Subscription
+from app.models.user import User
+from app.schemas.bpm import ProcessFlowVersionCreate, ProcessFlowVersionUpdate
+from app.services.event_bus import event_bus
+
+router = APIRouter(prefix="/bpm", tags=["bpm-workflow"])
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+async def _get_process_or_404(db: AsyncSession, process_id: uuid.UUID) -> FactSheet:
+    result = await db.execute(
+        select(FactSheet).where(
+            FactSheet.id == process_id,
+            FactSheet.type == "BusinessProcess",
+            FactSheet.status == "ACTIVE",
+        )
+    )
+    fs = result.scalar_one_or_none()
+    if not fs:
+        raise HTTPException(404, "Business process not found")
+    return fs
+
+
+async def _user_subscription_roles(
+    db: AsyncSession, process_id: uuid.UUID, user_id: uuid.UUID
+) -> set[str]:
+    """Return the set of subscription roles a user holds on a fact sheet."""
+    result = await db.execute(
+        select(Subscription.role).where(
+            Subscription.fact_sheet_id == process_id,
+            Subscription.user_id == user_id,
+        )
+    )
+    return {r for (r,) in result.all()}
+
+
+def _can_view_drafts(user: User, sub_roles: set[str]) -> bool:
+    """Check if a user can see draft / archived tabs.
+
+    Allowed for: admin, bpm_admin, member, and fact-sheet subscribers
+    with roles responsible, process_owner, or observer.
+    """
+    if user.role in ("admin", "bpm_admin", "member"):
+        return True
+    privileged = {"responsible", "process_owner", "observer"}
+    return bool(sub_roles & privileged)
+
+
+def _can_edit_draft(user: User, sub_roles: set[str]) -> bool:
+    """Check if a user can create / edit drafts."""
+    if user.role in ("admin", "bpm_admin", "member"):
+        return True
+    privileged = {"responsible", "process_owner"}
+    return bool(sub_roles & privileged)
+
+
+def _is_process_owner(user: User, sub_roles: set[str]) -> bool:
+    """Check if user is a process owner (can approve)."""
+    if user.role in ("admin", "bpm_admin"):
+        return True
+    return "process_owner" in sub_roles
+
+
+def _version_response(v: ProcessFlowVersion) -> dict:
+    return {
+        "id": str(v.id),
+        "process_id": str(v.process_id),
+        "status": v.status,
+        "revision": v.revision,
+        "bpmn_xml": v.bpmn_xml,
+        "svg_thumbnail": v.svg_thumbnail,
+        "created_by": str(v.created_by) if v.created_by else None,
+        "created_by_name": v.creator.display_name if v.creator else None,
+        "created_at": v.created_at.isoformat() if v.created_at else None,
+        "submitted_by": str(v.submitted_by) if v.submitted_by else None,
+        "submitted_by_name": v.submitter.display_name if v.submitter else None,
+        "submitted_at": v.submitted_at.isoformat() if v.submitted_at else None,
+        "approved_by": str(v.approved_by) if v.approved_by else None,
+        "approved_by_name": v.approver.display_name if v.approver else None,
+        "approved_at": v.approved_at.isoformat() if v.approved_at else None,
+        "archived_at": v.archived_at.isoformat() if v.archived_at else None,
+        "based_on_id": str(v.based_on_id) if v.based_on_id else None,
+    }
+
+
+def _version_summary(v: ProcessFlowVersion) -> dict:
+    """Lightweight version info without bpmn_xml for list endpoints."""
+    resp = _version_response(v)
+    resp.pop("bpmn_xml", None)
+    return resp
+
+
+# ── Published (latest) ──────────────────────────────────────────────────
+
+
+@router.get("/processes/{process_id}/flow/published")
+async def get_published_flow(
+    process_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Get the currently published process flow (visible to all authenticated users)."""
+    pid = uuid.UUID(process_id)
+    await _get_process_or_404(db, pid)
+    result = await db.execute(
+        select(ProcessFlowVersion)
+        .where(
+            ProcessFlowVersion.process_id == pid,
+            ProcessFlowVersion.status == "published",
+        )
+        .order_by(ProcessFlowVersion.revision.desc())
+        .limit(1)
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        return None
+    return _version_response(version)
+
+
+# ── Drafts ──────────────────────────────────────────────────────────────
+
+
+@router.get("/processes/{process_id}/flow/drafts")
+async def list_drafts(
+    process_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """List draft (and pending) flow versions for a process."""
+    pid = uuid.UUID(process_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_view_drafts(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions to view drafts")
+
+    result = await db.execute(
+        select(ProcessFlowVersion)
+        .where(
+            ProcessFlowVersion.process_id == pid,
+            ProcessFlowVersion.status.in_(["draft", "pending"]),
+        )
+        .order_by(ProcessFlowVersion.created_at.desc())
+    )
+    return [_version_summary(v) for v in result.scalars().all()]
+
+
+@router.post("/processes/{process_id}/flow/drafts", status_code=201)
+async def create_draft(
+    process_id: str,
+    body: ProcessFlowVersionCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Create a new draft process flow, optionally cloned from an existing version."""
+    pid = uuid.UUID(process_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_edit_draft(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions to create drafts")
+
+    bpmn_xml = body.bpmn_xml
+    svg_thumbnail = body.svg_thumbnail
+    based_on_id = None
+
+    if body.based_on_id:
+        based_on_id = uuid.UUID(body.based_on_id)
+        base = await db.execute(
+            select(ProcessFlowVersion).where(
+                ProcessFlowVersion.id == based_on_id,
+                ProcessFlowVersion.process_id == pid,
+            )
+        )
+        base_version = base.scalar_one_or_none()
+        if not base_version:
+            raise HTTPException(404, "Base version not found")
+        # Clone XML if not provided
+        if not bpmn_xml:
+            bpmn_xml = base_version.bpmn_xml
+            svg_thumbnail = svg_thumbnail or base_version.svg_thumbnail
+
+    # Determine next revision number
+    latest = await db.execute(
+        select(ProcessFlowVersion.revision)
+        .where(ProcessFlowVersion.process_id == pid)
+        .order_by(ProcessFlowVersion.revision.desc())
+        .limit(1)
+    )
+    latest_rev = latest.scalar_one_or_none()
+    next_rev = (latest_rev or 0) + 1
+
+    version = ProcessFlowVersion(
+        process_id=pid,
+        status="draft",
+        revision=next_rev,
+        bpmn_xml=bpmn_xml,
+        svg_thumbnail=svg_thumbnail,
+        created_by=user.id,
+        based_on_id=based_on_id,
+    )
+    db.add(version)
+    await db.commit()
+    await db.refresh(version)
+    return _version_response(version)
+
+
+@router.get("/processes/{process_id}/flow/versions/{version_id}")
+async def get_version(
+    process_id: str,
+    version_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Get a specific process flow version by ID."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    await _get_process_or_404(db, pid)
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+
+    # Published versions are visible to all; drafts/pending/archived need perms
+    if version.status in ("draft", "pending", "archived"):
+        sub_roles = await _user_subscription_roles(db, pid, user.id)
+        if not _can_view_drafts(user, sub_roles):
+            raise HTTPException(403, "Insufficient permissions")
+
+    return _version_response(version)
+
+
+@router.patch("/processes/{process_id}/flow/versions/{version_id}")
+async def update_draft(
+    process_id: str,
+    version_id: str,
+    body: ProcessFlowVersionUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Update a draft process flow. Only drafts can be edited."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_edit_draft(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions")
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+    if version.status != "draft":
+        raise HTTPException(400, "Only draft versions can be edited")
+
+    if body.bpmn_xml is not None:
+        version.bpmn_xml = body.bpmn_xml
+    if body.svg_thumbnail is not None:
+        version.svg_thumbnail = body.svg_thumbnail
+
+    await db.commit()
+    await db.refresh(version)
+    return _version_response(version)
+
+
+@router.delete("/processes/{process_id}/flow/versions/{version_id}", status_code=204)
+async def delete_draft(
+    process_id: str,
+    version_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Delete a draft process flow. Only drafts can be deleted."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_edit_draft(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions")
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+    if version.status != "draft":
+        raise HTTPException(400, "Only draft versions can be deleted")
+
+    await db.delete(version)
+    await db.commit()
+
+
+# ── Submit for approval ─────────────────────────────────────────────────
+
+
+@router.post("/processes/{process_id}/flow/versions/{version_id}/submit")
+async def submit_for_approval(
+    process_id: str,
+    version_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Submit a draft for approval by the business process owner."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    process = await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_edit_draft(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions")
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+    if version.status != "draft":
+        raise HTTPException(400, "Only draft versions can be submitted for approval")
+
+    version.status = "pending"
+    version.submitted_by = user.id
+    version.submitted_at = datetime.now(timezone.utc)
+
+    # Notify process owners
+    from app.services.notification_service import notification_service
+
+    owner_subs = await db.execute(
+        select(Subscription).where(
+            Subscription.fact_sheet_id == pid,
+            Subscription.role == "process_owner",
+        )
+    )
+    for sub in owner_subs.scalars().all():
+        await notification_service.create(
+            db,
+            user_id=sub.user_id,
+            notification_type="process_flow_approval_requested",
+            title=f"Process flow approval requested for {process.name}",
+            message=f"{user.display_name} submitted revision {version.revision} for approval.",
+            link=f"/fact-sheets/{process_id}?tab=process-flow&subtab=drafts",
+            fact_sheet_id=pid,
+        )
+
+    await event_bus.publish(
+        "process_flow.submitted",
+        {
+            "process_name": process.name,
+            "revision": version.revision,
+            "submitted_by": user.display_name,
+        },
+        db=db,
+        fact_sheet_id=pid,
+        user_id=user.id,
+    )
+
+    await db.commit()
+    await db.refresh(version)
+    return _version_response(version)
+
+
+# ── Approve / Reject ────────────────────────────────────────────────────
+
+
+@router.post("/processes/{process_id}/flow/versions/{version_id}/approve")
+async def approve_version(
+    process_id: str,
+    version_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Approve a pending process flow. The approved version becomes published;
+    the previous published version becomes archived."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    process = await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _is_process_owner(user, sub_roles):
+        raise HTTPException(403, "Only process owners, admins, or BPM admins can approve")
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+    if version.status != "pending":
+        raise HTTPException(400, "Only pending versions can be approved")
+
+    now = datetime.now(timezone.utc)
+
+    # Archive the current published version
+    current_published = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.process_id == pid,
+            ProcessFlowVersion.status == "published",
+        )
+    )
+    for pub in current_published.scalars().all():
+        pub.status = "archived"
+        pub.archived_at = now
+
+    # Publish the approved version
+    version.status = "published"
+    version.approved_by = user.id
+    version.approved_at = now
+
+    # Notify the submitter
+    if version.submitted_by:
+        from app.services.notification_service import notification_service
+
+        await notification_service.create(
+            db,
+            user_id=version.submitted_by,
+            notification_type="process_flow_approved",
+            title=f"Process flow approved for {process.name}",
+            message=f"{user.display_name} approved revision {version.revision}.",
+            link=f"/fact-sheets/{process_id}?tab=process-flow&subtab=published",
+            fact_sheet_id=pid,
+        )
+
+    await event_bus.publish(
+        "process_flow.approved",
+        {
+            "process_name": process.name,
+            "revision": version.revision,
+            "approved_by": user.display_name,
+        },
+        db=db,
+        fact_sheet_id=pid,
+        user_id=user.id,
+    )
+
+    await db.commit()
+    await db.refresh(version)
+    return _version_response(version)
+
+
+@router.post("/processes/{process_id}/flow/versions/{version_id}/reject")
+async def reject_version(
+    process_id: str,
+    version_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Reject a pending process flow, returning it to draft status."""
+    pid = uuid.UUID(process_id)
+    vid = uuid.UUID(version_id)
+    process = await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _is_process_owner(user, sub_roles):
+        raise HTTPException(403, "Only process owners, admins, or BPM admins can reject")
+
+    result = await db.execute(
+        select(ProcessFlowVersion).where(
+            ProcessFlowVersion.id == vid,
+            ProcessFlowVersion.process_id == pid,
+        )
+    )
+    version = result.scalar_one_or_none()
+    if not version:
+        raise HTTPException(404, "Version not found")
+    if version.status != "pending":
+        raise HTTPException(400, "Only pending versions can be rejected")
+
+    version.status = "draft"
+    version.submitted_by = None
+    version.submitted_at = None
+
+    # Notify the original creator
+    if version.created_by:
+        from app.services.notification_service import notification_service
+
+        await notification_service.create(
+            db,
+            user_id=version.created_by,
+            notification_type="process_flow_rejected",
+            title=f"Process flow rejected for {process.name}",
+            message=f"{user.display_name} rejected revision {version.revision}. Please revise.",
+            link=f"/fact-sheets/{process_id}?tab=process-flow&subtab=drafts",
+            fact_sheet_id=pid,
+        )
+
+    await event_bus.publish(
+        "process_flow.rejected",
+        {
+            "process_name": process.name,
+            "revision": version.revision,
+            "rejected_by": user.display_name,
+        },
+        db=db,
+        fact_sheet_id=pid,
+        user_id=user.id,
+    )
+
+    await db.commit()
+    await db.refresh(version)
+    return _version_response(version)
+
+
+# ── Archived ────────────────────────────────────────────────────────────
+
+
+@router.get("/processes/{process_id}/flow/archived")
+async def list_archived(
+    process_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """List archived process flow versions (most recent first)."""
+    pid = uuid.UUID(process_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    if not _can_view_drafts(user, sub_roles):
+        raise HTTPException(403, "Insufficient permissions to view archives")
+
+    result = await db.execute(
+        select(ProcessFlowVersion)
+        .where(
+            ProcessFlowVersion.process_id == pid,
+            ProcessFlowVersion.status == "archived",
+        )
+        .order_by(ProcessFlowVersion.revision.desc())
+    )
+    return [_version_summary(v) for v in result.scalars().all()]
+
+
+# ── Permission check endpoint (for frontend) ───────────────────────────
+
+
+@router.get("/processes/{process_id}/flow/permissions")
+async def get_flow_permissions(
+    process_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """Return the current user's permissions on the process flow."""
+    pid = uuid.UUID(process_id)
+    await _get_process_or_404(db, pid)
+    sub_roles = await _user_subscription_roles(db, pid, user.id)
+    return {
+        "can_view_drafts": _can_view_drafts(user, sub_roles),
+        "can_edit_draft": _can_edit_draft(user, sub_roles),
+        "can_approve": _is_process_owner(user, sub_roles),
+    }

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,6 +6,7 @@ from app.api.v1 import (
     bpm,
     bpm_assessments,
     bpm_reports,
+    bpm_workflow,
     comments,
     diagrams,
     documents,
@@ -50,3 +51,4 @@ api_router.include_router(web_portals.router)
 api_router.include_router(bpm.router)
 api_router.include_router(bpm_assessments.router)
 api_router.include_router(bpm_reports.router)
+api_router.include_router(bpm_workflow.router)

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -69,8 +69,8 @@ async def create_user(
     if current_user.role != "admin":
         raise HTTPException(403, "Admin only")
 
-    if body.role not in ("admin", "member", "viewer"):
-        raise HTTPException(400, "Role must be admin, member, or viewer")
+    if body.role not in ("admin", "bpm_admin", "member", "viewer"):
+        raise HTTPException(400, "Role must be admin, bpm_admin, member, or viewer")
 
     existing = await db.execute(select(User).where(User.email == body.email))
     if existing.scalar_one_or_none():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.notification import Notification
 from app.models.process_assessment import ProcessAssessment
 from app.models.process_diagram import ProcessDiagram
 from app.models.process_element import ProcessElement
+from app.models.process_flow_version import ProcessFlowVersion
 from app.models.relation import Relation
 from app.models.relation_type import RelationType
 from app.models.soaw import SoAW
@@ -46,5 +47,6 @@ __all__ = [
     "ProcessDiagram",
     "ProcessElement",
     "ProcessAssessment",
+    "ProcessFlowVersion",
     "WebPortal",
 ]

--- a/backend/app/models/process_flow_version.py
+++ b/backend/app/models/process_flow_version.py
@@ -1,0 +1,71 @@
+"""Process Flow Version — draft / published / archived workflow for BPMN diagrams."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDMixin
+
+
+class ProcessFlowVersion(Base, UUIDMixin, TimestampMixin):
+    """A versioned process flow with approval workflow.
+
+    States:
+        draft      — editable, only visible to privileged users
+        pending    — submitted for approval, awaiting process_owner sign-off
+        published  — approved and read-only, the current live version
+        archived   — previously-published version, read-only
+    """
+
+    __tablename__ = "process_flow_versions"
+
+    process_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("fact_sheets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="draft"
+    )  # draft / pending / published / archived
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+
+    bpmn_xml: Mapped[str] = mapped_column(Text, nullable=False)
+    svg_thumbnail: Mapped[str | None] = mapped_column(Text)
+
+    # Who created the draft
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id")
+    )
+    # Who submitted for approval
+    submitted_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id")
+    )
+    submitted_at: Mapped[str | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Approval details
+    approved_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id")
+    )
+    approved_at: Mapped[str | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Archival timestamp (set when a newer version is published)
+    archived_at: Mapped[str | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Base version this draft was created from (null = from scratch)
+    based_on_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("process_flow_versions.id"), nullable=True
+    )
+
+    process = relationship("FactSheet", lazy="selectin")
+    creator = relationship("User", foreign_keys=[created_by], lazy="selectin")
+    submitter = relationship("User", foreign_keys=[submitted_by], lazy="selectin")
+    approver = relationship("User", foreign_keys=[approved_by], lazy="selectin")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -34,7 +34,7 @@ class User(Base, UUIDMixin, TimestampMixin):
     email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False)
     display_name: Mapped[str] = mapped_column(String(200), nullable=False)
     password_hash: Mapped[str] = mapped_column(String(200), nullable=False)
-    role: Mapped[str] = mapped_column(String(20), default="member")  # admin/member/viewer
+    role: Mapped[str] = mapped_column(String(20), default="member")  # admin/bpm_admin/member/viewer
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     notification_preferences: Mapped[dict | None] = mapped_column(
         JSONB, default=lambda: DEFAULT_NOTIFICATION_PREFERENCES.copy()

--- a/backend/app/schemas/bpm.py
+++ b/backend/app/schemas/bpm.py
@@ -38,3 +38,21 @@ class ProcessAssessmentUpdate(BaseModel):
     automation: int | None = None
     notes: str | None = None
     action_items: list[dict] | None = None
+
+
+# ── Process flow version (draft/published/archived workflow) ──────
+
+
+class ProcessFlowVersionCreate(BaseModel):
+    """Create a new draft process flow."""
+
+    bpmn_xml: str
+    svg_thumbnail: str | None = None
+    based_on_id: str | None = None  # UUID of version to clone from
+
+
+class ProcessFlowVersionUpdate(BaseModel):
+    """Update an existing draft process flow."""
+
+    bpmn_xml: str | None = None
+    svg_thumbnail: str | None = None

--- a/frontend/src/features/admin/UsersAdmin.tsx
+++ b/frontend/src/features/admin/UsersAdmin.tsx
@@ -27,7 +27,7 @@ import { api } from "@/api/client";
 import type { User } from "@/types";
 import MaterialSymbol from "@/components/MaterialSymbol";
 
-type Role = "admin" | "member" | "viewer";
+type Role = "admin" | "bpm_admin" | "member" | "viewer";
 
 interface UserFormState {
   email: string;
@@ -234,6 +234,7 @@ export default function UsersAdmin() {
           onChange={(e) => updateField("role", e.target.value)}
         >
           <MenuItem value="admin">Admin</MenuItem>
+          <MenuItem value="bpm_admin">BPM Admin</MenuItem>
           <MenuItem value="member">Member</MenuItem>
           <MenuItem value="viewer">Viewer</MenuItem>
         </Select>

--- a/frontend/src/features/bpm/ProcessFlowTab.tsx
+++ b/frontend/src/features/bpm/ProcessFlowTab.tsx
@@ -1,6 +1,10 @@
 /**
  * ProcessFlowTab — Rendered inside FactSheetDetail for BusinessProcess.
- * Shows: BPMN viewer (read-only) + element table + link buttons.
+ *
+ * Three sub-tabs:
+ *   Published — The current approved process flow (read-only, watermark + seal).
+ *   Drafts    — Work-in-progress flows visible to member/bpm_admin/admin/process_owner/responsible/observer.
+ *   Archived  — Previously published versions (read-only list with revision + archival date).
  */
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -12,65 +16,125 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import Typography from "@mui/material/Typography";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
 import Chip from "@mui/material/Chip";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
+import Alert from "@mui/material/Alert";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemIcon from "@mui/material/ListItemIcon";
 import Paper from "@mui/material/Paper";
+import Tooltip from "@mui/material/Tooltip";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import BpmnViewer from "./BpmnViewer";
-import ElementLinker from "./ElementLinker";
 import BpmnTemplateChooser from "./BpmnTemplateChooser";
 import { api } from "@/api/client";
-import { useAuth } from "@/hooks/useAuth";
-import type { ProcessDiagramData, ProcessElement } from "@/types";
+import type { ProcessFlowVersion, ProcessFlowPermissions } from "@/types";
 
 interface Props {
   processId: string;
 }
 
+const STATUS_COLORS: Record<string, "success" | "warning" | "info" | "default" | "error"> = {
+  published: "success",
+  draft: "default",
+  pending: "warning",
+  archived: "info",
+};
+
 export default function ProcessFlowTab({ processId }: Props) {
   const navigate = useNavigate();
-  const { user } = useAuth();
-  const isAdmin = user?.role === "admin";
-  const [diagram, setDiagram] = useState<ProcessDiagramData | null>(null);
-  const [elements, setElements] = useState<ProcessElement[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [linkElement, setLinkElement] = useState<ProcessElement | null>(null);
-  const [showTemplateChooser, setShowTemplateChooser] = useState(false);
-  const [selectedBpmnId, setSelectedBpmnId] = useState<string | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [subTab, setSubTab] = useState(0);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
+  // Permissions
+  const [perms, setPerms] = useState<ProcessFlowPermissions>({
+    can_view_drafts: false,
+    can_edit_draft: false,
+    can_approve: false,
+  });
+
+  // Published
+  const [published, setPublished] = useState<ProcessFlowVersion | null>(null);
+  const [loadingPub, setLoadingPub] = useState(true);
+
+  // Drafts
+  const [drafts, setDrafts] = useState<ProcessFlowVersion[]>([]);
+  const [loadingDrafts, setLoadingDrafts] = useState(false);
+
+  // Archived
+  const [archived, setArchived] = useState<ProcessFlowVersion[]>([]);
+  const [loadingArchived, setLoadingArchived] = useState(false);
+
+  // Dialog states
+  const [showTemplateChooser, setShowTemplateChooser] = useState(false);
+  const [viewingVersion, setViewingVersion] = useState<ProcessFlowVersion | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{
+    type: "submit" | "approve" | "reject" | "delete";
+    version: ProcessFlowVersion;
+  } | null>(null);
+  const [actionError, setActionError] = useState("");
+
+  // Load permissions and published version
+  const loadInitial = useCallback(async () => {
+    setLoadingPub(true);
     try {
-      const [diagData, elemsData] = await Promise.all([
-        api.get<ProcessDiagramData | null>(`/bpm/processes/${processId}/diagram`),
-        api.get<ProcessElement[]>(`/bpm/processes/${processId}/elements`),
+      const [permsData, pubData] = await Promise.all([
+        api.get<ProcessFlowPermissions>(`/bpm/processes/${processId}/flow/permissions`),
+        api.get<ProcessFlowVersion | null>(`/bpm/processes/${processId}/flow/published`),
       ]);
-      setDiagram(diagData);
-      setElements(elemsData || []);
+      setPerms(permsData);
+      setPublished(pubData);
     } catch {
-      // No diagram yet
-      setDiagram(null);
-      setElements([]);
+      setPublished(null);
     } finally {
-      setLoading(false);
+      setLoadingPub(false);
     }
   }, [processId]);
 
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  const handleTemplateSelected = async (bpmnXml: string) => {
+  const loadDrafts = useCallback(async () => {
+    if (!perms.can_view_drafts) return;
+    setLoadingDrafts(true);
     try {
-      // Generate SVG thumbnail using a hidden bpmn-js viewer
+      const data = await api.get<ProcessFlowVersion[]>(
+        `/bpm/processes/${processId}/flow/drafts`
+      );
+      setDrafts(data);
+    } catch {
+      setDrafts([]);
+    } finally {
+      setLoadingDrafts(false);
+    }
+  }, [processId, perms.can_view_drafts]);
+
+  const loadArchived = useCallback(async () => {
+    if (!perms.can_view_drafts) return;
+    setLoadingArchived(true);
+    try {
+      const data = await api.get<ProcessFlowVersion[]>(
+        `/bpm/processes/${processId}/flow/archived`
+      );
+      setArchived(data);
+    } catch {
+      setArchived([]);
+    } finally {
+      setLoadingArchived(false);
+    }
+  }, [processId, perms.can_view_drafts]);
+
+  useEffect(() => {
+    loadInitial();
+  }, [loadInitial]);
+
+  useEffect(() => {
+    if (subTab === 1) loadDrafts();
+    if (subTab === 2) loadArchived();
+  }, [subTab, loadDrafts, loadArchived]);
+
+  // ── Actions ──────────────────────────────────────────────────────────
+
+  const handleCreateDraftFromScratch = async (bpmnXml: string) => {
+    try {
       let svgThumbnail: string | undefined;
       try {
         const NavigatedViewer = (await import("bpmn-js/lib/NavigatedViewer")).default;
@@ -86,229 +150,551 @@ export default function ProcessFlowTab({ processId }: Props) {
       } catch {
         // SVG generation optional
       }
-
-      await api.put(`/bpm/processes/${processId}/diagram`, {
+      await api.post(`/bpm/processes/${processId}/flow/drafts`, {
         bpmn_xml: bpmnXml,
         svg_thumbnail: svgThumbnail,
       });
       setShowTemplateChooser(false);
-      loadData();
+      setSubTab(1);
+      loadDrafts();
     } catch (err) {
-      console.error("Failed to save template:", err);
+      console.error("Failed to create draft:", err);
     }
   };
 
-  if (loading) {
-    return <Typography color="text.secondary">Loading process flow...</Typography>;
-  }
+  const handleCreateDraftFromVersion = async (versionId: string) => {
+    try {
+      await api.post(`/bpm/processes/${processId}/flow/drafts`, {
+        bpmn_xml: "",
+        based_on_id: versionId,
+      });
+      setSubTab(1);
+      loadDrafts();
+    } catch (err) {
+      console.error("Failed to clone version:", err);
+    }
+  };
 
-  if (!diagram) {
-    return (
-      <Box sx={{ textAlign: "center", py: 4 }}>
-        <MaterialSymbol icon="route" size={48} color="#666" />
-        <Typography variant="h6" gutterBottom>
-          No process flow diagram yet
-        </Typography>
-        <Typography color="text.secondary" sx={{ mb: 2 }}>
-          Create a BPMN 2.0 diagram to document this process flow.
-        </Typography>
-        <Box sx={{ display: "flex", gap: 1, justifyContent: "center" }}>
-          <Button
-            variant="contained"
-            startIcon={<MaterialSymbol icon="add" />}
-            onClick={() => setShowTemplateChooser(true)}
-          >
-            Start from Template
-          </Button>
-          <Button
-            variant="outlined"
-            startIcon={<MaterialSymbol icon="edit" />}
-            onClick={() => navigate(`/bpm/processes/${processId}/flow`)}
-          >
-            Open Editor
-          </Button>
+  const handleAction = async () => {
+    if (!confirmAction) return;
+    setActionError("");
+    const { type, version } = confirmAction;
+    try {
+      if (type === "submit") {
+        await api.post(
+          `/bpm/processes/${processId}/flow/versions/${version.id}/submit`
+        );
+      } else if (type === "approve") {
+        await api.post(
+          `/bpm/processes/${processId}/flow/versions/${version.id}/approve`
+        );
+      } else if (type === "reject") {
+        await api.post(
+          `/bpm/processes/${processId}/flow/versions/${version.id}/reject`
+        );
+      } else if (type === "delete") {
+        await api.delete(
+          `/bpm/processes/${processId}/flow/versions/${version.id}`
+        );
+      }
+      setConfirmAction(null);
+      loadInitial();
+      loadDrafts();
+      loadArchived();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed");
+    }
+  };
+
+  const loadVersionDetail = async (versionId: string) => {
+    try {
+      const data = await api.get<ProcessFlowVersion>(
+        `/bpm/processes/${processId}/flow/versions/${versionId}`
+      );
+      setViewingVersion(data);
+    } catch (err) {
+      console.error("Failed to load version:", err);
+    }
+  };
+
+  const formatDate = (iso?: string) => {
+    if (!iso) return "—";
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  // ── Published Tab ────────────────────────────────────────────────────
+
+  const renderPublished = () => {
+    if (loadingPub) {
+      return (
+        <Typography color="text.secondary">Loading published flow...</Typography>
+      );
+    }
+    if (!published) {
+      return (
+        <Box sx={{ textAlign: "center", py: 4 }}>
+          <MaterialSymbol icon="route" size={48} color="#666" />
+          <Typography variant="h6" gutterBottom>
+            No published process flow yet
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 2 }}>
+            Create a draft, then submit it for approval to publish.
+          </Typography>
+          {perms.can_edit_draft && (
+            <Box sx={{ display: "flex", gap: 1, justifyContent: "center" }}>
+              <Button
+                variant="contained"
+                startIcon={<MaterialSymbol icon="add" />}
+                onClick={() => setShowTemplateChooser(true)}
+              >
+                New Draft from Template
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<MaterialSymbol icon="edit" />}
+                onClick={() => navigate(`/bpm/processes/${processId}/flow`)}
+              >
+                Open Editor
+              </Button>
+            </Box>
+          )}
+          <BpmnTemplateChooser
+            open={showTemplateChooser}
+            onClose={() => setShowTemplateChooser(false)}
+            onSelect={handleCreateDraftFromScratch}
+          />
         </Box>
+      );
+    }
+
+    return (
+      <Box>
+        {/* Approval watermark */}
+        <Alert
+          severity="success"
+          icon={<MaterialSymbol icon="verified" size={20} />}
+          sx={{ mb: 2 }}
+        >
+          <strong>Approved</strong> by {published.approved_by_name || "—"} on{" "}
+          {formatDate(published.approved_at)} &mdash; Revision {published.revision}
+        </Alert>
+
+        {/* Actions */}
+        <Box sx={{ display: "flex", gap: 1, mb: 2, flexWrap: "wrap" }}>
+          {perms.can_edit_draft && (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<MaterialSymbol icon="content_copy" />}
+              onClick={() => handleCreateDraftFromVersion(published.id)}
+            >
+              Create New Draft from This
+            </Button>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <Chip
+            label={`Revision ${published.revision}`}
+            size="small"
+            variant="outlined"
+          />
+        </Box>
+
+        {/* Read-only BPMN viewer */}
+        {published.bpmn_xml && (
+          <Box sx={{ position: "relative" }}>
+            <BpmnViewer
+              bpmnXml={published.bpmn_xml}
+              elements={[]}
+              onElementClick={() => {}}
+              height={400}
+            />
+            {/* Watermark overlay */}
+            <Box
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                bgcolor: "rgba(76,175,80,0.1)",
+                border: "1px solid #4caf50",
+                borderRadius: 1,
+                px: 1.5,
+                py: 0.5,
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                pointerEvents: "none",
+              }}
+            >
+              <MaterialSymbol icon="verified" size={16} color="#4caf50" />
+              <Typography
+                variant="caption"
+                sx={{ color: "#4caf50", fontWeight: 600 }}
+              >
+                APPROVED
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  // ── Drafts Tab ───────────────────────────────────────────────────────
+
+  const renderDrafts = () => {
+    if (loadingDrafts) {
+      return (
+        <Typography color="text.secondary">Loading drafts...</Typography>
+      );
+    }
+
+    return (
+      <Box>
+        {perms.can_edit_draft && (
+          <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<MaterialSymbol icon="add" />}
+              onClick={() => setShowTemplateChooser(true)}
+            >
+              New Draft from Template
+            </Button>
+            {published && (
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<MaterialSymbol icon="content_copy" />}
+                onClick={() => handleCreateDraftFromVersion(published.id)}
+              >
+                Clone Published Version
+              </Button>
+            )}
+          </Box>
+        )}
+
+        {drafts.length === 0 ? (
+          <Box sx={{ textAlign: "center", py: 3 }}>
+            <Typography color="text.secondary">No draft process flows.</Typography>
+          </Box>
+        ) : (
+          <List>
+            {drafts.map((d) => (
+              <Paper key={d.id} variant="outlined" sx={{ mb: 1 }}>
+                <ListItemButton onClick={() => loadVersionDetail(d.id)}>
+                  <ListItemIcon>
+                    <MaterialSymbol
+                      icon={d.status === "pending" ? "hourglass_top" : "edit_note"}
+                      size={24}
+                      color={d.status === "pending" ? "#ed6c02" : "#666"}
+                    />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        <Typography variant="body1" fontWeight={500}>
+                          Revision {d.revision}
+                        </Typography>
+                        <Chip
+                          label={d.status}
+                          size="small"
+                          color={STATUS_COLORS[d.status] || "default"}
+                        />
+                      </Box>
+                    }
+                    secondary={
+                      <>
+                        Created by {d.created_by_name || "—"} on{" "}
+                        {formatDate(d.created_at)}
+                        {d.status === "pending" && d.submitted_by_name && (
+                          <> &mdash; Submitted by {d.submitted_by_name}</>
+                        )}
+                      </>
+                    }
+                  />
+                  <Box
+                    sx={{ display: "flex", gap: 0.5 }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {d.status === "draft" && perms.can_edit_draft && (
+                      <>
+                        <Tooltip title="Edit in BPMN editor">
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={() =>
+                              navigate(
+                                `/bpm/processes/${processId}/flow?versionId=${d.id}`
+                              )
+                            }
+                          >
+                            Edit
+                          </Button>
+                        </Tooltip>
+                        <Tooltip title="Submit for approval">
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="primary"
+                            onClick={() =>
+                              setConfirmAction({ type: "submit", version: d })
+                            }
+                          >
+                            Submit
+                          </Button>
+                        </Tooltip>
+                        <Tooltip title="Delete draft">
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            onClick={() =>
+                              setConfirmAction({ type: "delete", version: d })
+                            }
+                          >
+                            Delete
+                          </Button>
+                        </Tooltip>
+                      </>
+                    )}
+                    {d.status === "pending" && perms.can_approve && (
+                      <>
+                        <Tooltip title="Approve and publish">
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="success"
+                            onClick={() =>
+                              setConfirmAction({ type: "approve", version: d })
+                            }
+                          >
+                            Approve
+                          </Button>
+                        </Tooltip>
+                        <Tooltip title="Reject and return to draft">
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            onClick={() =>
+                              setConfirmAction({ type: "reject", version: d })
+                            }
+                          >
+                            Reject
+                          </Button>
+                        </Tooltip>
+                      </>
+                    )}
+                  </Box>
+                </ListItemButton>
+              </Paper>
+            ))}
+          </List>
+        )}
+
         <BpmnTemplateChooser
           open={showTemplateChooser}
           onClose={() => setShowTemplateChooser(false)}
-          onSelect={handleTemplateSelected}
+          onSelect={handleCreateDraftFromScratch}
         />
       </Box>
     );
-  }
+  };
 
-  return (
-    <Box>
-      {/* Actions bar */}
-      <Box sx={{ display: "flex", gap: 1, mb: 2, flexWrap: "wrap" }}>
-        <Button
-          variant="contained"
-          size="small"
-          startIcon={<MaterialSymbol icon="edit" />}
-          onClick={() => navigate(`/bpm/processes/${processId}/flow`)}
-        >
-          Open Editor
-        </Button>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<MaterialSymbol icon="download" />}
-          onClick={async () => {
-            const res = await api.getRaw(`/bpm/processes/${processId}/diagram/export/bpmn`);
-            const blob = await res.blob();
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `process-${processId}.bpmn`;
-            a.click();
-            URL.revokeObjectURL(url);
-          }}
-        >
-          Export BPMN
-        </Button>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<MaterialSymbol icon="image" />}
-          onClick={async () => {
-            const res = await api.getRaw(`/bpm/processes/${processId}/diagram/export/svg`);
-            const blob = await res.blob();
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `process-${processId}.svg`;
-            a.click();
-            URL.revokeObjectURL(url);
-          }}
-        >
-          Export SVG
-        </Button>
-        <Box sx={{ flex: 1 }} />
-        <Chip label={`v${diagram.version}`} size="small" variant="outlined" />
-        {isAdmin && (
-          <Button
-            variant="outlined"
-            size="small"
-            color="error"
-            startIcon={<MaterialSymbol icon="delete" />}
-            onClick={() => setConfirmDelete(true)}
-          >
-            Delete Diagram
-          </Button>
-        )}
-      </Box>
+  // ── Archived Tab ─────────────────────────────────────────────────────
 
-      {/* Delete confirmation dialog */}
-      <Dialog open={confirmDelete} onClose={() => setConfirmDelete(false)}>
-        <DialogTitle>Delete Process Diagram?</DialogTitle>
+  const renderArchived = () => {
+    if (loadingArchived) {
+      return (
+        <Typography color="text.secondary">Loading archived flows...</Typography>
+      );
+    }
+
+    if (archived.length === 0) {
+      return (
+        <Box sx={{ textAlign: "center", py: 3 }}>
+          <Typography color="text.secondary">No archived process flows.</Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <List>
+        {archived.map((a) => (
+          <Paper key={a.id} variant="outlined" sx={{ mb: 1 }}>
+            <ListItemButton onClick={() => loadVersionDetail(a.id)}>
+              <ListItemIcon>
+                <MaterialSymbol icon="inventory_2" size={24} color="#999" />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <Typography variant="body1" fontWeight={500}>
+                      Revision {a.revision}
+                    </Typography>
+                    <Chip label="Archived" size="small" color="info" />
+                  </Box>
+                }
+                secondary={
+                  <>
+                    Approved by {a.approved_by_name || "—"} on{" "}
+                    {formatDate(a.approved_at)} &mdash; Archived on{" "}
+                    {formatDate(a.archived_at)}
+                  </>
+                }
+              />
+            </ListItemButton>
+          </Paper>
+        ))}
+      </List>
+    );
+  };
+
+  // ── Version detail viewer dialog ─────────────────────────────────────
+
+  const renderVersionDialog = () => (
+    <Dialog
+      open={!!viewingVersion}
+      onClose={() => setViewingVersion(null)}
+      maxWidth="lg"
+      fullWidth
+    >
+      {viewingVersion && (
+        <>
+          <DialogTitle>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              Revision {viewingVersion.revision}
+              <Chip
+                label={viewingVersion.status}
+                size="small"
+                color={STATUS_COLORS[viewingVersion.status] || "default"}
+              />
+            </Box>
+          </DialogTitle>
+          <DialogContent>
+            {viewingVersion.status === "published" && viewingVersion.approved_by_name && (
+              <Alert
+                severity="success"
+                icon={<MaterialSymbol icon="verified" size={20} />}
+                sx={{ mb: 2 }}
+              >
+                <strong>Approved</strong> by {viewingVersion.approved_by_name} on{" "}
+                {formatDate(viewingVersion.approved_at)}
+              </Alert>
+            )}
+            {viewingVersion.status === "archived" && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                This version was archived on {formatDate(viewingVersion.archived_at)}.
+                Originally approved by {viewingVersion.approved_by_name || "—"} on{" "}
+                {formatDate(viewingVersion.approved_at)}.
+              </Alert>
+            )}
+            {viewingVersion.bpmn_xml && (
+              <BpmnViewer
+                bpmnXml={viewingVersion.bpmn_xml}
+                elements={[]}
+                onElementClick={() => {}}
+                height={500}
+              />
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setViewingVersion(null)}>Close</Button>
+          </DialogActions>
+        </>
+      )}
+    </Dialog>
+  );
+
+  // ── Confirm action dialog ────────────────────────────────────────────
+
+  const actionLabels: Record<string, { title: string; description: string; button: string; color: "primary" | "success" | "error" }> = {
+    submit: {
+      title: "Submit for Approval?",
+      description:
+        "This draft will be sent to the business process owner for approval. You will not be able to edit it while it is pending.",
+      button: "Submit",
+      color: "primary",
+    },
+    approve: {
+      title: "Approve and Publish?",
+      description:
+        "This will publish the process flow. The current published version (if any) will be archived. This action cannot be undone.",
+      button: "Approve & Publish",
+      color: "success",
+    },
+    reject: {
+      title: "Reject Draft?",
+      description:
+        "This will return the draft to the author for revision. They will be notified.",
+      button: "Reject",
+      color: "error",
+    },
+    delete: {
+      title: "Delete Draft?",
+      description: "This will permanently delete the draft. This cannot be undone.",
+      button: "Delete",
+      color: "error",
+    },
+  };
+
+  const renderConfirmDialog = () => {
+    if (!confirmAction) return null;
+    const labels = actionLabels[confirmAction.type];
+    return (
+      <Dialog open onClose={() => setConfirmAction(null)}>
+        <DialogTitle>{labels.title}</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            This will permanently delete all diagram versions and extracted process elements.
-            You will be able to start fresh from a template.
-          </DialogContentText>
+          <DialogContentText>{labels.description}</DialogContentText>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            Revision: {confirmAction.version.revision}
+          </Typography>
+          {actionError && (
+            <Alert severity="error" sx={{ mt: 1 }}>
+              {actionError}
+            </Alert>
+          )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setConfirmDelete(false)}>Cancel</Button>
+          <Button onClick={() => setConfirmAction(null)}>Cancel</Button>
           <Button
-            color="error"
             variant="contained"
-            onClick={async () => {
-              try {
-                await api.delete(`/bpm/processes/${processId}/diagram`);
-                setConfirmDelete(false);
-                setDiagram(null);
-                setElements([]);
-              } catch (err) {
-                console.error("Failed to delete diagram:", err);
-              }
-            }}
+            color={labels.color}
+            onClick={handleAction}
           >
-            Delete
+            {labels.button}
           </Button>
         </DialogActions>
       </Dialog>
+    );
+  };
 
-      {/* BPMN Diagram (read-only) */}
-      <BpmnViewer
-        bpmnXml={diagram.bpmn_xml}
-        elements={elements}
-        onElementClick={setSelectedBpmnId}
-        height={400}
-      />
+  // ── Main render ──────────────────────────────────────────────────────
 
-      {/* Elements Table */}
-      {elements.length > 0 && (
-        <Box sx={{ mt: 3 }}>
-          <Typography variant="subtitle1" gutterBottom>
-            Process Elements ({elements.length})
-          </Typography>
-          <TableContainer component={Paper} variant="outlined">
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Name</TableCell>
-                  <TableCell>Type</TableCell>
-                  <TableCell>Lane</TableCell>
-                  <TableCell>Application</TableCell>
-                  <TableCell>Data Object</TableCell>
-                  <TableCell>IT Component</TableCell>
-                  <TableCell align="right">Actions</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {elements.map((el) => (
-                  <TableRow
-                    key={el.id}
-                    hover
-                    selected={el.bpmn_element_id === selectedBpmnId}
-                    sx={{ cursor: "pointer" }}
-                    onClick={() => setSelectedBpmnId(el.bpmn_element_id)}
-                  >
-                    <TableCell>
-                      {el.name || <em style={{ color: "#999" }}>unnamed</em>}
-                      {el.is_automated && (
-                        <Chip label="Auto" size="small" color="success" sx={{ ml: 0.5 }} />
-                      )}
-                    </TableCell>
-                    <TableCell>{el.element_type}</TableCell>
-                    <TableCell>{el.lane_name || "—"}</TableCell>
-                    <TableCell>
-                      {el.application_name ? (
-                        <Chip label={el.application_name} size="small" color="primary" variant="outlined" />
-                      ) : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {el.data_object_name ? (
-                        <Chip label={el.data_object_name} size="small" color="secondary" variant="outlined" />
-                      ) : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {el.it_component_name ? (
-                        <Chip label={el.it_component_name} size="small" variant="outlined" />
-                      ) : "—"}
-                    </TableCell>
-                    <TableCell align="right">
-                      <Tooltip title="Link to EA">
-                        <IconButton size="small" onClick={(e) => { e.stopPropagation(); setLinkElement(el); }}>
-                          <MaterialSymbol icon="link" />
-                        </IconButton>
-                      </Tooltip>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </Box>
-      )}
+  return (
+    <Box>
+      <Tabs
+        value={subTab}
+        onChange={(_, v) => setSubTab(v)}
+        sx={{ borderBottom: 1, borderColor: "divider", mb: 2 }}
+      >
+        <Tab label="Published" />
+        {perms.can_view_drafts && <Tab label="Drafts" />}
+        {perms.can_view_drafts && <Tab label="Archived" />}
+      </Tabs>
 
-      <ElementLinker
-        open={!!linkElement}
-        onClose={() => setLinkElement(null)}
-        element={linkElement}
-        processId={processId}
-        onSaved={loadData}
-      />
+      {subTab === 0 && renderPublished()}
+      {subTab === 1 && perms.can_view_drafts && renderDrafts()}
+      {subTab === 2 && perms.can_view_drafts && renderArchived()}
+
+      {renderVersionDialog()}
+      {renderConfirmDialog()}
     </Box>
   );
 }

--- a/frontend/src/hooks/useBpmEnabled.ts
+++ b/frontend/src/hooks/useBpmEnabled.ts
@@ -1,0 +1,48 @@
+/**
+ * useBpmEnabled — module-level singleton that caches whether the BPM feature
+ * is enabled. Similar pattern to useCurrency.
+ */
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/api/client";
+
+let _cached: boolean | null = null;
+let _listeners: Array<(v: boolean) => void> = [];
+
+function _notify(v: boolean) {
+  _cached = v;
+  _listeners.forEach((fn) => fn(v));
+}
+
+async function _fetch() {
+  try {
+    const res = await api.get<{ enabled: boolean }>("/settings/bpm-enabled");
+    _notify(res.enabled);
+  } catch {
+    // default to true if fetch fails
+    if (_cached === null) _notify(true);
+  }
+}
+
+export function useBpmEnabled() {
+  const [enabled, setEnabled] = useState<boolean>(_cached ?? true);
+
+  useEffect(() => {
+    _listeners.push(setEnabled);
+    if (_cached === null) _fetch();
+    else setEnabled(_cached);
+    return () => {
+      _listeners = _listeners.filter((fn) => fn !== setEnabled);
+    };
+  }, []);
+
+  const invalidate = useCallback((newVal?: boolean) => {
+    if (newVal !== undefined) {
+      _notify(newVal);
+    } else {
+      _cached = null;
+      _fetch();
+    }
+  }, []);
+
+  return { bpmEnabled: enabled, invalidateBpm: invalidate };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -617,3 +617,33 @@ export interface BpmnTemplate {
   category: string;
   bpmn_xml?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Process Flow Versions (draft / published / archived workflow)
+// ---------------------------------------------------------------------------
+
+export interface ProcessFlowVersion {
+  id: string;
+  process_id: string;
+  status: "draft" | "pending" | "published" | "archived";
+  revision: number;
+  bpmn_xml?: string;
+  svg_thumbnail?: string;
+  created_by?: string;
+  created_by_name?: string;
+  created_at?: string;
+  submitted_by?: string;
+  submitted_by_name?: string;
+  submitted_at?: string;
+  approved_by?: string;
+  approved_by_name?: string;
+  approved_at?: string;
+  archived_at?: string;
+  based_on_id?: string;
+}
+
+export interface ProcessFlowPermissions {
+  can_view_drafts: boolean;
+  can_edit_draft: boolean;
+  can_approve: boolean;
+}


### PR DESCRIPTION
…kflow

- Add admin toggle to enable/disable the BPM module (hides nav, fact sheets, reports)
- Add bpm_admin site-level role with BPM-scoped admin permissions
- Create ProcessFlowVersion model with draft/pending/published/archived states
- Add workflow API: create drafts, submit for approval, approve/reject, archive
- Rebuild ProcessFlowTab with Published/Drafts/Archived sub-tabs
- Published flows show approval watermark+seal (approved by X on Y), read-only
- Drafts visible to member/bpm_admin/admin/process_owner/responsible/observer
- Process owners can approve pending submissions (auto-archives previous version)
- Archived versions displayed as read-only list, viewable on click
- Add Alembic migration 016 for process_flow_versions table

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw