### PR TITLE
Fix 500 error on workflow submit and migrate existing process flows t…

### DIFF
--- a/backend/alembic/versions/017_migrate_existing_diagrams_to_versions.py
+++ b/backend/alembic/versions/017_migrate_existing_diagrams_to_versions.py
@@ -1,0 +1,53 @@
+"""migrate existing process_diagrams into process_flow_versions as drafts
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-02-15
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "017"
+down_revision: Union[str, None] = "016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    from sqlalchemy import inspect as sa_inspect
+
+    conn = op.get_bind()
+    inspector = sa_inspect(conn)
+
+    if not inspector.has_table("process_diagrams"):
+        return
+    if not inspector.has_table("process_flow_versions"):
+        return
+
+    # Copy process_diagrams that don't already have a matching
+    # process_flow_version (by process_id) so this is idempotent.
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO process_flow_versions
+                (id, process_id, status, revision, bpmn_xml,
+                 svg_thumbnail, created_by, created_at, updated_at)
+            SELECT
+                gen_random_uuid(), pd.process_id, 'draft', pd.version, pd.bpmn_xml,
+                pd.svg_thumbnail, pd.created_by, pd.created_at, pd.updated_at
+            FROM process_diagrams pd
+            WHERE NOT EXISTS (
+                SELECT 1 FROM process_flow_versions pfv
+                WHERE pfv.process_id = pd.process_id
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Data migration only — nothing to structurally undo.
+    pass


### PR DESCRIPTION
…o drafts

- Fix notification_service calls: use correct method name (create_notification) and parameter name (notif_type) in submit/approve/reject endpoints
- Add actor_id to notification calls for proper self-notification filtering
- Move notification_service import to module level following existing patterns
- Add migration 017 to copy existing process_diagrams into process_flow_versions as drafts (idempotent, skips processes that already have versions)
- Update migration 016 with same data migration for fresh installs

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw