### PR TITLE
Add workflow self-notifications, approval todos, full-screen viewer, …

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -46,7 +46,13 @@ async def create_notification(
 
     # Don't notify the actor about their own action, except for types where
     # the actor is performing a batch/admin action (surveys, todo assignments).
-    allow_self_types = {"survey_request", "todo_assigned"}
+    allow_self_types = {
+        "survey_request",
+        "todo_assigned",
+        "process_flow_approval_requested",
+        "process_flow_approved",
+        "process_flow_rejected",
+    }
     if actor_id and actor_id == user_id and notif_type not in allow_self_types:
         return None
 

--- a/frontend/src/features/bpm/ProcessFlowTab.tsx
+++ b/frontend/src/features/bpm/ProcessFlowTab.tsx
@@ -6,7 +6,7 @@
  *   Drafts    — Work-in-progress flows visible to member/bpm_admin/admin/process_owner/responsible/observer.
  *   Archived  — Previously published versions (read-only list with revision + archival date).
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -26,6 +26,9 @@ import ListItemText from "@mui/material/ListItemText";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import Paper from "@mui/material/Paper";
 import Tooltip from "@mui/material/Tooltip";
+import AppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import IconButton from "@mui/material/IconButton";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import BpmnViewer from "./BpmnViewer";
 import BpmnTemplateChooser from "./BpmnTemplateChooser";
@@ -34,6 +37,7 @@ import type { ProcessFlowVersion, ProcessFlowPermissions } from "@/types";
 
 interface Props {
   processId: string;
+  processName?: string;
 }
 
 const STATUS_COLORS: Record<string, "success" | "warning" | "info" | "default" | "error"> = {
@@ -43,7 +47,7 @@ const STATUS_COLORS: Record<string, "success" | "warning" | "info" | "default" |
   archived: "info",
 };
 
-export default function ProcessFlowTab({ processId }: Props) {
+export default function ProcessFlowTab({ processId, processName }: Props) {
   const navigate = useNavigate();
   const [subTab, setSubTab] = useState(0);
 
@@ -69,11 +73,15 @@ export default function ProcessFlowTab({ processId }: Props) {
   // Dialog states
   const [showTemplateChooser, setShowTemplateChooser] = useState(false);
   const [viewingVersion, setViewingVersion] = useState<ProcessFlowVersion | null>(null);
+  const [fullScreenOpen, setFullScreenOpen] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: "submit" | "approve" | "reject" | "delete";
     version: ProcessFlowVersion;
   } | null>(null);
   const [actionError, setActionError] = useState("");
+
+  // Ref for the full-screen BPMN container (used for SVG extraction in print)
+  const fullScreenBpmnRef = useRef<HTMLDivElement>(null);
 
   // Load permissions and published version
   const loadInitial = useCallback(async () => {
@@ -212,13 +220,21 @@ export default function ProcessFlowTab({ processId }: Props) {
         `/bpm/processes/${processId}/flow/versions/${versionId}`
       );
       setViewingVersion(data);
+      setFullScreenOpen(true);
     } catch (err) {
       console.error("Failed to load version:", err);
     }
   };
 
+  const openPublishedFullScreen = () => {
+    if (published) {
+      setViewingVersion(published);
+      setFullScreenOpen(true);
+    }
+  };
+
   const formatDate = (iso?: string) => {
-    if (!iso) return "—";
+    if (!iso) return "\u2014";
     return new Date(iso).toLocaleDateString(undefined, {
       year: "numeric",
       month: "short",
@@ -226,6 +242,86 @@ export default function ProcessFlowTab({ processId }: Props) {
       hour: "2-digit",
       minute: "2-digit",
     });
+  };
+
+  // ── Print / PDF ────────────────────────────────────────────────────
+
+  const handlePrint = async (version: ProcessFlowVersion) => {
+    if (!version.bpmn_xml) return;
+
+    // Extract SVG from the bpmn-js viewer off-screen
+    let svgContent = "";
+    try {
+      const NavigatedViewer = (await import("bpmn-js/lib/NavigatedViewer")).default;
+      const el = document.createElement("div");
+      el.style.cssText = "position:absolute;left:-9999px;width:1400px;height:900px";
+      document.body.appendChild(el);
+      const viewer = new NavigatedViewer({ container: el });
+      await viewer.importXML(version.bpmn_xml);
+      const result = await (viewer as any).saveSVG();
+      svgContent = result.svg;
+      viewer.destroy();
+      document.body.removeChild(el);
+    } catch {
+      // Fallback: try svg_thumbnail
+      svgContent = version.svg_thumbnail || "";
+    }
+
+    if (!svgContent) return;
+
+    const title = processName || "Process Flow";
+    const watermarkText = version.approved_by_name
+      ? `Revision ${version.revision} \u2014 Approved by ${version.approved_by_name} on ${formatDate(version.approved_at)}`
+      : `Revision ${version.revision}`;
+
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+
+    printWindow.document.write(`<!DOCTYPE html>
+<html>
+<head>
+  <title>${title} - Rev ${version.revision}</title>
+  <style>
+    @page { size: landscape; margin: 15mm; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .header { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; border-bottom: 2px solid #4caf50; margin-bottom: 16px; }
+    .header h1 { font-size: 18px; color: #333; }
+    .watermark { display: inline-flex; align-items: center; gap: 6px; background: rgba(76,175,80,0.1); border: 1px solid #4caf50; border-radius: 4px; padding: 4px 12px; }
+    .watermark svg { width: 16px; height: 16px; fill: #4caf50; }
+    .watermark span { color: #4caf50; font-weight: 600; font-size: 12px; }
+    .diagram { width: 100%; text-align: center; }
+    .diagram svg { max-width: 100%; height: auto; }
+    .footer { margin-top: 16px; padding-top: 8px; border-top: 1px solid #ddd; display: flex; justify-content: space-between; font-size: 11px; color: #888; }
+    @media print {
+      .no-print { display: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <div class="no-print" style="padding:12px;text-align:center;background:#f5f5f5;border-bottom:1px solid #ddd">
+    <button onclick="window.print()" style="padding:8px 24px;font-size:14px;cursor:pointer;background:#1976d2;color:#fff;border:none;border-radius:4px">
+      Print / Save as PDF
+    </button>
+    <button onclick="window.close()" style="padding:8px 24px;font-size:14px;cursor:pointer;background:#fff;color:#333;border:1px solid #ccc;border-radius:4px;margin-left:8px">
+      Close
+    </button>
+  </div>
+  <div class="header">
+    <h1>${title}</h1>
+    <div class="watermark">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm-2 16l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"/></svg>
+      <span>${watermarkText}</span>
+    </div>
+  </div>
+  <div class="diagram">${svgContent}</div>
+  <div class="footer">
+    <span>Printed on ${new Date().toLocaleDateString()}</span>
+    <span>${watermarkText}</span>
+  </div>
+</body>
+</html>`);
+    printWindow.document.close();
   };
 
   // ── Published Tab ────────────────────────────────────────────────────
@@ -281,7 +377,7 @@ export default function ProcessFlowTab({ processId }: Props) {
           icon={<MaterialSymbol icon="verified" size={20} />}
           sx={{ mb: 2 }}
         >
-          <strong>Approved</strong> by {published.approved_by_name || "—"} on{" "}
+          <strong>Approved</strong> by {published.approved_by_name || "\u2014"} on{" "}
           {formatDate(published.approved_at)} &mdash; Revision {published.revision}
         </Alert>
 
@@ -298,6 +394,22 @@ export default function ProcessFlowTab({ processId }: Props) {
             </Button>
           )}
           <Box sx={{ flex: 1 }} />
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<MaterialSymbol icon="fullscreen" />}
+            onClick={openPublishedFullScreen}
+          >
+            View Full Size
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<MaterialSymbol icon="print" />}
+            onClick={() => handlePrint(published)}
+          >
+            Print / PDF
+          </Button>
           <Chip
             label={`Revision ${published.revision}`}
             size="small"
@@ -336,7 +448,9 @@ export default function ProcessFlowTab({ processId }: Props) {
                 variant="caption"
                 sx={{ color: "#4caf50", fontWeight: 600 }}
               >
-                APPROVED
+                Rev {published.revision} &middot; Approved by{" "}
+                {published.approved_by_name || "\u2014"} on{" "}
+                {formatDate(published.approved_at)}
               </Typography>
             </Box>
           </Box>
@@ -410,7 +524,7 @@ export default function ProcessFlowTab({ processId }: Props) {
                     }
                     secondary={
                       <>
-                        Created by {d.created_by_name || "—"} on{" "}
+                        Created by {d.created_by_name || "\u2014"} on{" "}
                         {formatDate(d.created_at)}
                         {d.status === "pending" && d.submitted_by_name && (
                           <> &mdash; Submitted by {d.submitted_by_name}</>
@@ -543,7 +657,7 @@ export default function ProcessFlowTab({ processId }: Props) {
                 }
                 secondary={
                   <>
-                    Approved by {a.approved_by_name || "—"} on{" "}
+                    Approved by {a.approved_by_name || "\u2014"} on{" "}
                     {formatDate(a.approved_at)} &mdash; Archived on{" "}
                     {formatDate(a.archived_at)}
                   </>
@@ -556,57 +670,130 @@ export default function ProcessFlowTab({ processId }: Props) {
     );
   };
 
-  // ── Version detail viewer dialog ─────────────────────────────────────
+  // ── Full-screen version viewer dialog ──────────────────────────────
 
-  const renderVersionDialog = () => (
+  const buildWatermarkText = (v: ProcessFlowVersion) => {
+    if (v.status === "published" || v.status === "archived") {
+      return `Rev ${v.revision} \u2014 Approved by ${v.approved_by_name || "\u2014"} on ${formatDate(v.approved_at)}`;
+    }
+    if (v.status === "pending") {
+      return `Rev ${v.revision} \u2014 Pending approval (submitted by ${v.submitted_by_name || "\u2014"})`;
+    }
+    return `Rev ${v.revision} \u2014 Draft`;
+  };
+
+  const renderFullScreenDialog = () => (
     <Dialog
-      open={!!viewingVersion}
-      onClose={() => setViewingVersion(null)}
-      maxWidth="lg"
-      fullWidth
+      open={fullScreenOpen}
+      onClose={() => { setFullScreenOpen(false); setViewingVersion(null); }}
+      fullScreen
     >
       {viewingVersion && (
         <>
-          <DialogTitle>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              Revision {viewingVersion.revision}
+          <AppBar sx={{ position: "relative" }} color="default" elevation={1}>
+            <Toolbar>
+              <IconButton
+                edge="start"
+                onClick={() => { setFullScreenOpen(false); setViewingVersion(null); }}
+                aria-label="close"
+              >
+                <MaterialSymbol icon="close" />
+              </IconButton>
+              <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+                {processName || "Process Flow"} &mdash; Revision {viewingVersion.revision}
+              </Typography>
               <Chip
                 label={viewingVersion.status}
                 size="small"
                 color={STATUS_COLORS[viewingVersion.status] || "default"}
+                sx={{ mr: 2 }}
               />
-            </Box>
-          </DialogTitle>
-          <DialogContent>
-            {viewingVersion.status === "published" && viewingVersion.approved_by_name && (
+              {(viewingVersion.status === "published" || viewingVersion.status === "archived") && (
+                <Button
+                  color="inherit"
+                  startIcon={<MaterialSymbol icon="print" />}
+                  onClick={() => handlePrint(viewingVersion)}
+                >
+                  Print / PDF
+                </Button>
+              )}
+            </Toolbar>
+          </AppBar>
+          <DialogContent sx={{ p: 0, display: "flex", flexDirection: "column" }}>
+            {/* Watermark banner */}
+            {viewingVersion.status === "published" && (
               <Alert
                 severity="success"
                 icon={<MaterialSymbol icon="verified" size={20} />}
-                sx={{ mb: 2 }}
+                sx={{ borderRadius: 0 }}
               >
-                <strong>Approved</strong> by {viewingVersion.approved_by_name} on{" "}
-                {formatDate(viewingVersion.approved_at)}
+                <strong>Approved</strong> by {viewingVersion.approved_by_name || "\u2014"} on{" "}
+                {formatDate(viewingVersion.approved_at)} &mdash; Revision {viewingVersion.revision}
               </Alert>
             )}
             {viewingVersion.status === "archived" && (
-              <Alert severity="info" sx={{ mb: 2 }}>
-                This version was archived on {formatDate(viewingVersion.archived_at)}.
-                Originally approved by {viewingVersion.approved_by_name || "—"} on{" "}
-                {formatDate(viewingVersion.approved_at)}.
+              <Alert severity="info" sx={{ borderRadius: 0 }}>
+                <strong>Archived</strong> on {formatDate(viewingVersion.archived_at)}.
+                Originally approved by {viewingVersion.approved_by_name || "\u2014"} on{" "}
+                {formatDate(viewingVersion.approved_at)} &mdash; Revision {viewingVersion.revision}
               </Alert>
             )}
+            {viewingVersion.status === "pending" && (
+              <Alert severity="warning" sx={{ borderRadius: 0 }}>
+                <strong>Pending Approval</strong> &mdash; Submitted by{" "}
+                {viewingVersion.submitted_by_name || "\u2014"} on{" "}
+                {formatDate(viewingVersion.submitted_at)} &mdash; Revision {viewingVersion.revision}
+              </Alert>
+            )}
+
+            {/* BPMN Viewer with watermark overlay */}
             {viewingVersion.bpmn_xml && (
-              <BpmnViewer
-                bpmnXml={viewingVersion.bpmn_xml}
-                elements={[]}
-                onElementClick={() => {}}
-                height={500}
-              />
+              <Box sx={{ flex: 1, position: "relative", minHeight: 0 }} ref={fullScreenBpmnRef}>
+                <BpmnViewer
+                  bpmnXml={viewingVersion.bpmn_xml}
+                  elements={[]}
+                  onElementClick={() => {}}
+                  height="100%"
+                />
+                {/* Corner watermark */}
+                {(viewingVersion.status === "published" || viewingVersion.status === "archived") && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 12,
+                      right: 12,
+                      bgcolor: viewingVersion.status === "published"
+                        ? "rgba(76,175,80,0.1)"
+                        : "rgba(33,150,243,0.1)",
+                      border: `1px solid ${viewingVersion.status === "published" ? "#4caf50" : "#2196f3"}`,
+                      borderRadius: 1,
+                      px: 2,
+                      py: 0.75,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.75,
+                      pointerEvents: "none",
+                    }}
+                  >
+                    <MaterialSymbol
+                      icon="verified"
+                      size={18}
+                      color={viewingVersion.status === "published" ? "#4caf50" : "#2196f3"}
+                    />
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        color: viewingVersion.status === "published" ? "#4caf50" : "#2196f3",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {buildWatermarkText(viewingVersion)}
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
             )}
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setViewingVersion(null)}>Close</Button>
-          </DialogActions>
         </>
       )}
     </Dialog>
@@ -693,7 +880,7 @@ export default function ProcessFlowTab({ processId }: Props) {
       {subTab === 1 && perms.can_view_drafts && renderDrafts()}
       {subTab === 2 && perms.can_view_drafts && renderArchived()}
 
-      {renderVersionDialog()}
+      {renderFullScreenDialog()}
       {renderConfirmDialog()}
     </Box>
   );

--- a/frontend/src/features/fact-sheets/FactSheetDetail.tsx
+++ b/frontend/src/features/fact-sheets/FactSheetDetail.tsx
@@ -1891,7 +1891,7 @@ export default function FactSheetDetail() {
               <RelationsSection fsId={fs.id} fsType={fs.type} refreshKey={relRefresh} />
             </Box>
           )}
-          {tab === 1 && <Card><CardContent><ProcessFlowTab processId={fs.id} /></CardContent></Card>}
+          {tab === 1 && <Card><CardContent><ProcessFlowTab processId={fs.id} processName={fs.name} /></CardContent></Card>}
           {tab === 2 && <Card><CardContent><ProcessAssessmentPanel processId={fs.id} /></CardContent></Card>}
           {tab === 3 && <Card><CardContent><CommentsTab fsId={fs.id} /></CardContent></Card>}
           {tab === 4 && <Card><CardContent><TodosTab fsId={fs.id} /></CardContent></Card>}


### PR DESCRIPTION
…and PDF print

Backend:
- Allow self-notifications for process flow workflow actions (submit/approve/reject) so users get notified even when they are both submitter and process owner
- Create system todo for process owners on submit for approval, auto-complete the todo when the version is approved or rejected
- Import Todo model in bpm_workflow for todo creation

Frontend:
- Replace small version dialog with full-screen dialog showing BPMN viewer at full viewport height with watermark overlay (revision, approver, date)
- Published tab: add "View Full Size" and "Print / PDF" buttons
- Full-screen dialog: AppBar with close, title, status chip, and Print button
- Watermark overlay shows revision number, approver name, and approval date for both published (green) and archived (blue) versions
- Print/PDF: opens new window with SVG export + watermark header/footer, landscape layout, and browser print dialog (Save as PDF)
- Pass processName prop from FactSheetDetail to ProcessFlowTab for print titles

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw