### PR TITLE
Fix draft editor save, element extraction on publish, and restore ele…

### DIFF
--- a/backend/app/services/bpmn_parser.py
+++ b/backend/app/services/bpmn_parser.py
@@ -51,7 +51,8 @@ def parse_bpmn_xml(bpmn_xml: str) -> list[ExtractedElement]:
     lane_map: dict[str, str] = {}  # element_id → lane_name
     for lane in root.iter(f"{{{BPMN_NS}}}lane"):
         lane_name = lane.get("name", "")
-        for flow_node_ref in lane.iter(f"{{{BPMN_NS}}}flowNodeRef"):
+        # Use findall for direct children only (iter would recurse into nested laneSets)
+        for flow_node_ref in lane.findall(f"{{{BPMN_NS}}}flowNodeRef"):
             if flow_node_ref.text:
                 lane_map[flow_node_ref.text.strip()] = lane_name
 

--- a/frontend/src/features/bpm/ProcessFlowEditorPage.tsx
+++ b/frontend/src/features/bpm/ProcessFlowEditorPage.tsx
@@ -1,23 +1,26 @@
 /**
  * ProcessFlowEditorPage — Full-page BPMN editor route.
  * Route: /bpm/processes/:id/flow
+ *
+ * Reads ?versionId= query param to edit a specific draft version.
  */
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import BpmnModeler from "./BpmnModeler";
 
 export default function ProcessFlowEditorPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const versionId = searchParams.get("versionId") || undefined;
 
   if (!id) return null;
 
   return (
     <BpmnModeler
       processId={id}
+      versionId={versionId}
       onBack={() => navigate(`/fact-sheets/${id}`)}
-      onSaved={(version) => {
-        console.log(`Diagram saved: v${version}`);
-      }}
+      onSaved={() => {}}
     />
   );
 }


### PR DESCRIPTION
…ments table

- BpmnModeler now loads/saves to draft version endpoint when versionId is provided
- ProcessFlowEditorPage reads ?versionId= query param for draft editing
- Approve endpoint extracts BPMN elements into ProcessElement table (upsert with EA link preservation)
- Fix lane parsing to use findall() for direct children instead of recursive iter()
- Restore Process Steps & Elements table below published BPMN viewer with lanes, automation, and EA links

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw