### PR TITLE
Add draft preview, editable elements table with TCode, and fix naviga…

### DIFF
--- a/frontend/src/features/bpm/ProcessFlowEditorPage.tsx
+++ b/frontend/src/features/bpm/ProcessFlowEditorPage.tsx
@@ -3,6 +3,7 @@
  * Route: /bpm/processes/:id/flow
  *
  * Reads ?versionId= query param to edit a specific draft version.
+ * Reads ?returnSubTab= to know which sub-tab to return to on back/save.
  */
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import BpmnModeler from "./BpmnModeler";
@@ -12,6 +13,7 @@ export default function ProcessFlowEditorPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const versionId = searchParams.get("versionId") || undefined;
+  const returnSubTab = searchParams.get("returnSubTab") || "1"; // default to drafts tab
 
   if (!id) return null;
 
@@ -19,7 +21,7 @@ export default function ProcessFlowEditorPage() {
     <BpmnModeler
       processId={id}
       versionId={versionId}
-      onBack={() => navigate(`/fact-sheets/${id}`)}
+      onBack={() => navigate(`/fact-sheets/${id}?tab=1&subtab=${returnSubTab}`)}
       onSaved={() => {}}
     />
   );


### PR DESCRIPTION
…tion return

- Draft tab: click to expand inline BPMN preview for each draft (collapsible)
- Elements table: click-to-edit Application, Data Object, IT Component via autocomplete
- Elements table: add TCode column (stored in custom_fields, manually maintained)
- Elements table: Automated column now shows "No" instead of em-dash, with tooltip explaining auto-detection
- Navigation: editor returns to correct sub-tab (published/drafts/archived) via URL params
- FactSheetDetail reads ?tab= and ?subtab= search params for deep linking

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw