### PR TITLE
Add draft element pre-linking, improve click-to-link UX, and handle s…

### DIFF
--- a/backend/alembic/versions/018_add_draft_element_links.py
+++ b/backend/alembic/versions/018_add_draft_element_links.py
@@ -1,0 +1,28 @@
+"""add draft_element_links JSONB to process_flow_versions
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-02-15
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "018"
+down_revision: Union[str, None] = "017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "process_flow_versions",
+        sa.Column("draft_element_links", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("process_flow_versions", "draft_element_links")

--- a/backend/app/models/process_flow_version.py
+++ b/backend/app/models/process_flow_version.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDMixin
@@ -64,6 +64,12 @@ class ProcessFlowVersion(Base, UUIDMixin, TimestampMixin):
     based_on_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("process_flow_versions.id"), nullable=True
     )
+
+    # Draft-stage element links: pre-linked EA references before publishing.
+    # Dict keyed by bpmn_element_id:
+    #   {"Task_1": {"application_id": "uuid", "data_object_id": "uuid",
+    #               "it_component_id": "uuid", "custom_fields": {"tcode": "SE16"}}}
+    draft_element_links: Mapped[dict | None] = mapped_column(JSONB, default=dict)
 
     process = relationship("FactSheet", lazy="selectin")
     creator = relationship("User", foreign_keys=[created_by], lazy="selectin")

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -640,6 +640,12 @@ export interface ProcessFlowVersion {
   approved_at?: string;
   archived_at?: string;
   based_on_id?: string;
+  draft_element_links?: Record<string, {
+    application_id?: string;
+    data_object_id?: string;
+    it_component_id?: string;
+    custom_fields?: Record<string, unknown>;
+  }>;
 }
 
 export interface ProcessFlowPermissions {


### PR DESCRIPTION
…tale links on publish

- Backend: add draft_element_links JSONB field to ProcessFlowVersion for storing pre-linked EA references before publishing
- Backend: new endpoints GET/PUT draft-elements for parsing BPMN XML and managing draft element links with resolved fact sheet names
- Backend: approve_version now applies draft links to ProcessElement records, validates linked fact sheets still exist, and warns about stale/deleted links in the approval notification
- Frontend: improve inline editing aesthetic — replace italic "Click to link" with icon+label, use dashed border hover, consistent 32px cell height
- Frontend: show element table below expanded draft preview for pre-linking applications, data objects, IT components, and TCodes before publish
- Migration 018: add draft_element_links column

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw