### PR TITLE
Hide Word export when SoAW is signed, add signatures to PDF and print…

### DIFF
--- a/frontend/src/features/ea-delivery/SoAWEditor.tsx
+++ b/frontend/src/features/ea-delivery/SoAWEditor.tsx
@@ -489,7 +489,7 @@ export default function SoAWEditor() {
         {compact ? (
           <Tooltip title="Export PDF">
             <IconButton
-              onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections, revisionNumber)}
+              onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections, revisionNumber, signatories, signedAt)}
             >
               <MaterialSymbol icon="picture_as_pdf" size={20} />
             </IconButton>
@@ -499,12 +499,12 @@ export default function SoAWEditor() {
             size="small"
             startIcon={<MaterialSymbol icon="picture_as_pdf" size={18} />}
             sx={{ textTransform: "none" }}
-            onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections, revisionNumber)}
+            onClick={() => exportToPdf(name, docInfo, versionHistory, sections, customSections, revisionNumber, signatories, signedAt)}
           >
             PDF
           </Button>
         )}
-        {compact ? (
+        {!isSigned && (compact ? (
           <Tooltip title="Export Word">
             <IconButton
               onClick={() => exportToDocx(name, docInfo, versionHistory, sections, customSections)}
@@ -521,7 +521,7 @@ export default function SoAWEditor() {
           >
             Word
           </Button>
-        )}
+        ))}
         {!isSigned && (
           <Button
             variant="contained"

--- a/frontend/src/features/ea-delivery/SoAWPreview.tsx
+++ b/frontend/src/features/ea-delivery/SoAWPreview.tsx
@@ -104,7 +104,7 @@ export default function SoAWPreview() {
   const bodyHtml = buildPreviewBody(soaw.name, docInfo, versionHistory, templateSections, customSections, soaw.revision_number);
 
   const handleExportPdf = () =>
-    exportToPdf(soaw.name, docInfo, versionHistory, templateSections, customSections, soaw.revision_number);
+    exportToPdf(soaw.name, docInfo, versionHistory, templateSections, customSections, soaw.revision_number, soaw.signatories, soaw.signed_at);
 
   return (
     <>


### PR DESCRIPTION
… footer

- Wrap Word export button with !isSigned so it's hidden for signed documents
- Add signatories parameter to buildPreviewBody and exportToPdf
- Render signature block (approved/pending cards) in PDF/print HTML output
- Add fixed print footer showing approver name, approval date, and print date
- Pass signatories data through from SoAWEditor and SoAWPreview callers

https://claude.ai/code/session_01JDMbnByGLWVsGDH657krA7