### PR TITLE
Fix BPM toggle to actually hide BusinessProcess type and relation types

### DIFF
--- a/frontend/src/features/admin/SettingsAdmin.tsx
+++ b/frontend/src/features/admin/SettingsAdmin.tsx
@@ -15,6 +15,7 @@ import Chip from "@mui/material/Chip";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import { useCurrency } from "@/hooks/useCurrency";
+import { useMetamodel } from "@/hooks/useMetamodel";
 
 const CURRENCIES = [
   { code: "USD", label: "US Dollar ($)" },
@@ -67,6 +68,9 @@ export default function SettingsAdmin() {
   const [logoVersion, setLogoVersion] = useState(0);
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Metamodel cache (invalidated when BPM toggle changes type visibility)
+  const { invalidateCache: invalidateMetamodel } = useMetamodel();
 
   // Currency state
   const { currency: currentCurrency, invalidate: invalidateCurrency } = useCurrency();
@@ -198,6 +202,7 @@ export default function SettingsAdmin() {
     try {
       await api.patch("/settings/bpm-enabled", { enabled });
       setBpmEnabled(enabled);
+      invalidateMetamodel();
       setSnack(enabled ? "BPM module enabled" : "BPM module disabled");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to update BPM setting");


### PR DESCRIPTION
The toggle previously only hid the nav button but left the fact sheet type, fact sheets, and relations fully visible. Now when BPM is disabled, the backend also sets is_hidden=true on the BusinessProcess FactSheetType and all RelationTypes connected to BusinessProcess. This leverages the existing is_hidden filtering in metamodel, fact sheets, and relations endpoints. The frontend also invalidates the metamodel cache after toggle so the type list updates without a page refresh.

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw