### PR TITLE
Process Navigator: wider leaf cards + flow indicator on container hea…

### DIFF
--- a/frontend/src/features/bpm/ProcessNavigator.tsx
+++ b/frontend/src/features/bpm/ProcessNavigator.tsx
@@ -576,6 +576,18 @@ function HouseCard({
             {subtypeLabel}
           </Typography>
         )}
+        {(hasDiagram || hasElements) && (
+          <Tooltip title={hasDiagram ? `Has process flow (${node.element_count ?? 0} elements)` : `${node.element_count} BPMN elements`}>
+            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.25, ml: 0.25, opacity: 0.85 }}>
+              <MaterialSymbol icon="schema" size={16} />
+              {hasElements && (
+                <Typography variant="caption" sx={{ fontSize: "0.6rem", color: "#fff", fontWeight: 600, lineHeight: 1 }}>
+                  {node.element_count}
+                </Typography>
+              )}
+            </Box>
+          </Tooltip>
+        )}
         <Chip
           size="small"
           label={childCount}
@@ -2277,7 +2289,7 @@ export default function ProcessNavigator() {
                         <Box
                           sx={{
                             display: "grid",
-                            gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+                            gridTemplateColumns: "repeat(auto-fill, minmax(380px, 1fr))",
                             gap: 1.5,
                           }}
                         >


### PR DESCRIPTION
…ders

1. Increased leaf card minimum width from 320px to 380px to better use available horizontal space.

2. When a node with a process flow becomes a container card (group) at a certain display level, the flow information was lost. Now container card headers show a schema icon + element count when the group node itself has a BPMN diagram or elements, so users can tell at a glance which groups have their own process flows defined.

https://claude.ai/code/session_01WbvBSzBPfqNrNx4a1nN8rw