### PR TITLE
Rework user invitation: unified Invite User flow with optional password

### DIFF
--- a/backend/alembic/versions/019_add_sso_support.py
+++ b/backend/alembic/versions/019_add_sso_support.py
@@ -38,6 +38,12 @@ def upgrade() -> None:
             sa.Column("sso_subject_id", sa.String(256), nullable=True, unique=True),
         )
 
+    if "password_setup_token" not in existing_columns:
+        op.add_column(
+            "users",
+            sa.Column("password_setup_token", sa.String(128), nullable=True, unique=True),
+        )
+
     # Make password_hash nullable (SSO users don't have passwords)
     op.alter_column("users", "password_hash", existing_type=sa.String(200), nullable=True)
 
@@ -69,6 +75,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("sso_invitations")
+    op.drop_column("users", "password_setup_token")
     op.drop_column("users", "sso_subject_id")
     op.drop_column("users", "auth_provider")
     op.alter_column("users", "password_hash", existing_type=sa.String(200), nullable=False)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -38,6 +38,9 @@ class User(Base, UUIDMixin, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     auth_provider: Mapped[str] = mapped_column(String(20), default="local")  # local/sso
     sso_subject_id: Mapped[str | None] = mapped_column(String(256), nullable=True, unique=True)
+    password_setup_token: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, unique=True
+    )
     notification_preferences: Mapped[dict | None] = mapped_column(
         JSONB, default=lambda: DEFAULT_NOTIFICATION_PREFERENCES.copy()
     )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import SurveyRespond from "@/features/surveys/SurveyRespond";
 import WebPortalsAdmin from "@/features/admin/WebPortalsAdmin";
 import PortalViewer from "@/features/web-portals/PortalViewer";
 import SsoCallback from "@/features/auth/SsoCallback";
+import SetPasswordPage from "@/features/auth/SetPasswordPage";
 import BpmDashboard from "@/features/bpm/BpmDashboard";
 import ProcessFlowEditorPage from "@/features/bpm/ProcessFlowEditorPage";
 
@@ -55,7 +56,7 @@ const theme = createTheme({
 
 /** Inner component that handles authenticated vs public routes. */
 function AppRoutes() {
-  const { user, loading, login, register, ssoCallback, logout } = useAuth();
+  const { user, loading, login, register, ssoCallback, setPassword, logout } = useAuth();
 
   if (loading) {
     return (
@@ -72,6 +73,8 @@ function AppRoutes() {
         <Route path="/portal/:slug" element={<PortalViewer />} />
         {/* SSO callback route */}
         <Route path="/auth/callback" element={<SsoCallback onSsoCallback={ssoCallback} />} />
+        {/* Password setup route (for invited users) */}
+        <Route path="/auth/set-password" element={<SetPasswordPage onSetPassword={setPassword} />} />
         {/* Everything else redirects to login */}
         <Route path="*" element={<LoginPage onLogin={login} onRegister={register} />} />
       </Routes>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,4 +92,6 @@ export const auth = {
     }>("/auth/sso/config"),
   ssoCallback: (code: string, redirect_uri: string) =>
     api.post<{ access_token: string }>("/auth/sso/callback", { code, redirect_uri }),
+  setPassword: (token: string, password: string) =>
+    api.post<{ access_token: string }>("/auth/set-password", { token, password }),
 };

--- a/frontend/src/features/auth/SetPasswordPage.tsx
+++ b/frontend/src/features/auth/SetPasswordPage.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+
+interface Props {
+  onSetPassword: (token: string, password: string) => Promise<void>;
+}
+
+export default function SetPasswordPage({ onSetPassword }: Props) {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") || "";
+
+  const [validating, setValidating] = useState(true);
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [invalid, setInvalid] = useState(false);
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setInvalid(true);
+      setValidating(false);
+      return;
+    }
+    api
+      .get<{ email: string; display_name: string }>(
+        `/auth/validate-setup-token?token=${encodeURIComponent(token)}`
+      )
+      .then((data) => {
+        setEmail(data.email);
+        setDisplayName(data.display_name);
+        setValidating(false);
+      })
+      .catch(() => {
+        setInvalid(true);
+        setValidating(false);
+      });
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await onSetPassword(token, password);
+      navigate("/", { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to set password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (validating) {
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          bgcolor: "#1a1a2e",
+        }}
+      >
+        <CircularProgress sx={{ color: "#64b5f6" }} />
+      </Box>
+    );
+  }
+
+  if (invalid) {
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          bgcolor: "#1a1a2e",
+        }}
+      >
+        <Card sx={{ p: 4, width: 400, maxWidth: "90vw", textAlign: "center" }}>
+          <MaterialSymbol icon="error" size={48} color="#d32f2f" />
+          <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>
+            Invalid Setup Link
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            This password setup link is invalid or has already been used.
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={() => navigate("/", { replace: true })}
+          >
+            Go to Login
+          </Button>
+        </Card>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor: "#1a1a2e",
+      }}
+    >
+      <Card sx={{ p: 4, width: 400, maxWidth: "90vw" }}>
+        <Box sx={{ textAlign: "center", mb: 3 }}>
+          <MaterialSymbol icon="hub" size={48} color="#1976d2" />
+          <Typography variant="h5" fontWeight={700} sx={{ mt: 1 }}>
+            Set Your Password
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Welcome{displayName ? `, ${displayName}` : ""}! Set a password for{" "}
+            <strong>{email}</strong>.
+          </Typography>
+        </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <TextField
+            fullWidth
+            label="New Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            sx={{ mb: 2 }}
+            autoFocus
+          />
+          <TextField
+            fullWidth
+            label="Confirm Password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            sx={{ mb: 3 }}
+          />
+          <Button
+            fullWidth
+            variant="contained"
+            type="submit"
+            disabled={loading}
+            size="large"
+          >
+            {loading ? "Setting password..." : "Set Password & Sign In"}
+          </Button>
+        </form>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -44,10 +44,16 @@ export function useAuth() {
     await loadUser();
   };
 
+  const setPassword = async (token: string, password: string) => {
+    const { access_token } = await auth.setPassword(token, password);
+    localStorage.setItem("token", access_token);
+    await loadUser();
+  };
+
   const logout = () => {
     localStorage.removeItem("token");
     setUser(null);
   };
 
-  return { user, loading, login, register, ssoCallback, logout };
+  return { user, loading, login, register, ssoCallback, setPassword, logout };
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,6 +5,8 @@ export interface User {
   role: string;
   is_active: boolean;
   auth_provider?: string;
+  has_password?: boolean;
+  pending_setup?: boolean;
   created_at?: string;
 }
 


### PR DESCRIPTION
- Replace separate "Create User" + "Invite via SSO" with single "Invite User" button
- Password is now optional when inviting: if omitted, a setup token is generated
- When SSO disabled + no password: user gets email with password setup link
- When SSO enabled + no password: user must sign in with Microsoft
- When password is set: user can login with password (even when SSO enabled)
- Add password_setup_token to User model and migration
- Add POST /auth/set-password + GET /auth/validate-setup-token endpoints
- Create SetPasswordPage frontend component for token-based password setup
- SSO account linking no longer clears existing passwords
- Login gives specific error when user has no password set yet
- Auth column in UsersAdmin shows SSO/Local/Pending Setup/SSO+Password states

https://claude.ai/code/session_01S6q5cB751fcv2f3jLkMBzz