### PR TITLE
Fix migration 022 crash: SQLAlchemy text() misparses ::jsonb cast

### DIFF
--- a/backend/alembic/versions/022_add_rbac_tables.py
+++ b/backend/alembic/versions/022_add_rbac_tables.py
@@ -189,7 +189,7 @@ def upgrade() -> None:
             conn.execute(sa.text(
                 "INSERT INTO subscription_role_definitions "
                 "(fact_sheet_type_key, key, label, permissions, sort_order) "
-                "VALUES (:type_key, :key, :label, :perms::jsonb, :sort_order) "
+                "VALUES (:type_key, :key, :label, CAST(:perms AS jsonb), :sort_order) "
                 "ON CONFLICT (fact_sheet_type_key, key) DO NOTHING"
             ), {
                 "type_key": type_key,


### PR DESCRIPTION
SQLAlchemy's text() treats :: as an escape sequence, causing :perms::jsonb to create bind param "perm" instead of "perms". Replace with CAST(:perms AS jsonb) which parses correctly.

https://claude.ai/code/session_01WgjdxNoGQZJM8Azabv5U4k