### PR TITLE
Add interactive filtering to BPM dashboard charts

### DIFF
--- a/frontend/src/features/bpm/BpmDashboard.tsx
+++ b/frontend/src/features/bpm/BpmDashboard.tsx
@@ -138,7 +138,20 @@ function BpmDashboardContent() {
               <Typography variant="subtitle2" gutterBottom>By Process Type</Typography>
               <ResponsiveContainer width="100%" height={220}>
                 <PieChart>
-                  <Pie data={typeData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+                  <Pie
+                    data={typeData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    label
+                    style={{ cursor: "pointer" }}
+                    onClick={(_data, idx) => {
+                      const name = typeData[idx]?.name;
+                      if (name) navigate(`/inventory?type=BusinessProcess&attr_processType=${encodeURIComponent(name)}`);
+                    }}
+                  >
                     {typeData.map((_, i) => (
                       <Cell key={i} fill={COLORS[i % COLORS.length]} />
                     ))}
@@ -162,7 +175,15 @@ function BpmDashboardContent() {
                   <XAxis dataKey="name" />
                   <YAxis />
                   <Tooltip />
-                  <Bar dataKey="value" name="Processes">
+                  <Bar
+                    dataKey="value"
+                    name="Processes"
+                    style={{ cursor: "pointer" }}
+                    onClick={(_data, idx) => {
+                      const name = maturityData[idx]?.name;
+                      if (name) navigate(`/inventory?type=BusinessProcess&attr_maturity=${encodeURIComponent(name)}`);
+                    }}
+                  >
                     {maturityData.map((entry, i) => (
                       <Cell key={i} fill={MATURITY_COLORS[entry.name] || "#9e9e9e"} />
                     ))}
@@ -184,7 +205,16 @@ function BpmDashboardContent() {
                   <XAxis dataKey="name" />
                   <YAxis />
                   <Tooltip />
-                  <Bar dataKey="value" name="Processes" fill="#1976d2" />
+                  <Bar
+                    dataKey="value"
+                    name="Processes"
+                    fill="#1976d2"
+                    style={{ cursor: "pointer" }}
+                    onClick={(_data, idx) => {
+                      const name = automationData[idx]?.name;
+                      if (name) navigate(`/inventory?type=BusinessProcess&attr_automationLevel=${encodeURIComponent(name)}`);
+                    }}
+                  />
                 </BarChart>
               </ResponsiveContainer>
             </CardContent>

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -120,12 +120,21 @@ export default function InventoryPage() {
   // Sidebar state
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
-  const [filters, setFilters] = useState<Filters>({
-    types: searchParams.get("type") ? [searchParams.get("type")!] : [],
-    search: searchParams.get("search") || "",
-    qualitySeals: searchParams.get("quality_seal") ? [searchParams.get("quality_seal")!] : [],
-    attributes: {},
-    relations: {},
+  const [filters, setFilters] = useState<Filters>(() => {
+    // Parse attr_* URL params into initial attribute filters
+    const attributes: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      if (key.startsWith("attr_")) {
+        attributes[key.slice(5)] = value;
+      }
+    });
+    return {
+      types: searchParams.get("type") ? [searchParams.get("type")!] : [],
+      search: searchParams.get("search") || "",
+      qualitySeals: searchParams.get("quality_seal") ? [searchParams.get("quality_seal")!] : [],
+      attributes,
+      relations: {},
+    };
   });
 
   const [data, setData] = useState<FactSheet[]>([]);


### PR DESCRIPTION
## Summary
This PR adds interactive click-to-filter functionality to the BPM Dashboard charts, allowing users to click on chart segments to navigate to the Inventory page with pre-applied filters based on the selected data.

## Key Changes
- **BpmDashboard.tsx**: Added click handlers to three charts (Process Type pie chart, Maturity bar chart, and Automation Level bar chart) that navigate to the Inventory page with appropriate attribute filters
  - Process Type chart: Filters by `attr_processType`
  - Maturity chart: Filters by `attr_maturity`
  - Automation Level chart: Filters by `attr_automationLevel`
  - Added cursor pointer styling to indicate interactivity

- **InventoryPage.tsx**: Enhanced URL parameter parsing to support dynamic attribute filters
  - Changed initial filter state to use a function initializer
  - Added logic to parse `attr_*` URL parameters and populate the attributes filter object
  - Enables seamless navigation from dashboard charts with pre-applied filters

## Implementation Details
- Chart click handlers extract the data name from the clicked segment and navigate with URL-encoded parameters
- The inventory page now automatically initializes filters from any `attr_*` query parameters, supporting extensibility for future attributes
- All three chart types follow the same pattern for consistency

https://claude.ai/code/session_01EKtX9SAsWsnRADX6c1GoTc