### PR TITLE
Add list view and filtering to EA Delivery page

### DIFF
--- a/backend/app/api/v1/fact_sheets.py
+++ b/backend/app/api/v1/fact_sheets.py
@@ -213,8 +213,13 @@ async def list_fact_sheets(
         q = q.where(FactSheet.type == type)
         count_q = count_q.where(FactSheet.type == type)
     if status:
-        q = q.where(FactSheet.status == status)
-        count_q = count_q.where(FactSheet.status == status)
+        statuses = [s.strip() for s in status.split(",") if s.strip()]
+        if len(statuses) == 1:
+            q = q.where(FactSheet.status == statuses[0])
+            count_q = count_q.where(FactSheet.status == statuses[0])
+        else:
+            q = q.where(FactSheet.status.in_(statuses))
+            count_q = count_q.where(FactSheet.status.in_(statuses))
     else:
         q = q.where(FactSheet.status == "ACTIVE")
         count_q = count_q.where(FactSheet.status == "ACTIVE")

--- a/frontend/src/features/ea-delivery/EADeliveryPage.tsx
+++ b/frontend/src/features/ea-delivery/EADeliveryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -24,24 +24,52 @@ import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
+import InputAdornment from "@mui/material/InputAdornment";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import LinearProgress from "@mui/material/LinearProgress";
 import MaterialSymbol from "@/components/MaterialSymbol";
+import { useMetamodel } from "@/hooks/useMetamodel";
 import { api } from "@/api/client";
-import type { FactSheet, SoAW, DiagramSummary } from "@/types";
+import type { FactSheet, SoAW, DiagramSummary, Relation } from "@/types";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
-const STATUS_COLORS: Record<string, "default" | "warning" | "success" | "info"> = {
+const SOAW_STATUS_COLORS: Record<string, "default" | "warning" | "success" | "info"> = {
   draft: "default",
   in_review: "warning",
   approved: "success",
   signed: "info",
 };
 
-const STATUS_LABELS: Record<string, string> = {
+const SOAW_STATUS_LABELS: Record<string, string> = {
   draft: "Draft",
   in_review: "In Review",
   approved: "Approved",
   signed: "Signed",
+};
+
+const INITIATIVE_STATUS_COLORS: Record<string, string> = {
+  onTrack: "#4caf50",
+  atRisk: "#ff9800",
+  offTrack: "#d32f2f",
+  onHold: "#9e9e9e",
+  completed: "#1976d2",
+};
+
+const INITIATIVE_STATUS_LABELS: Record<string, string> = {
+  onTrack: "On Track",
+  atRisk: "At Risk",
+  offTrack: "Off Track",
+  onHold: "On Hold",
+  completed: "Completed",
 };
 
 interface InitiativeGroup {
@@ -50,17 +78,28 @@ interface InitiativeGroup {
   soaws: SoAW[];
 }
 
+type ViewMode = "cards" | "list";
+type StatusFilter = "ACTIVE" | "ARCHIVED" | "";
+
 // ─── component ──────────────────────────────────────────────────────────────
 
 export default function EADeliveryPage() {
   const navigate = useNavigate();
+  const { types: metamodelTypes } = useMetamodel();
 
   const [initiatives, setInitiatives] = useState<FactSheet[]>([]);
   const [diagrams, setDiagrams] = useState<DiagramSummary[]>([]);
   const [soaws, setSoaws] = useState<SoAW[]>([]);
+  const [relations, setRelations] = useState<Relation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  // filters
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ACTIVE");
+  const [subtypeFilter, setSubtypeFilter] = useState("");
+  const [viewMode, setViewMode] = useState<ViewMode>("cards");
 
   // create SoAW dialog
   const [createOpen, setCreateOpen] = useState(false);
@@ -80,21 +119,31 @@ export default function EADeliveryPage() {
     soaw: SoAW;
   } | null>(null);
 
+  // get Initiative subtypes from metamodel
+  const initiativeType = useMemo(
+    () => metamodelTypes.find((t) => t.key === "Initiative"),
+    [metamodelTypes],
+  );
+  const subtypes = initiativeType?.subtypes ?? [];
+
   // ── data fetching ───────────────────────────────────────────────────────
 
-  const fetchAll = async () => {
+  const fetchAll = useCallback(async () => {
     setLoading(true);
     setError("");
     try {
+      const statusParam = statusFilter ? `&status=${statusFilter}` : "&status=ACTIVE,ARCHIVED";
       const [initRes, diagRes, soawRes] = await Promise.all([
-        api.get<{ items: FactSheet[] }>("/fact-sheets?type=Initiative&page_size=500"),
+        api.get<{ items: FactSheet[] }>(
+          `/fact-sheets?type=Initiative&page_size=500${statusParam}`,
+        ),
         api.get<DiagramSummary[]>("/diagrams"),
         api.get<SoAW[]>("/soaw"),
       ]);
       setInitiatives(initRes.items);
       setDiagrams(diagRes);
       setSoaws(soawRes);
-      // Auto-expand first initiative
+      // Auto-expand first initiative on initial load
       if (initRes.items.length > 0 && Object.keys(expanded).length === 0) {
         setExpanded({ [initRes.items[0].id]: true });
       }
@@ -103,22 +152,70 @@ export default function EADeliveryPage() {
     } finally {
       setLoading(false);
     }
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
 
   useEffect(() => {
     fetchAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [fetchAll]);
+
+  // Fetch relations for initiatives (for list view)
+  useEffect(() => {
+    if (viewMode !== "list" || initiatives.length === 0) {
+      setRelations([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const allRels: Relation[] = [];
+        // Fetch relations in batches to avoid too many parallel requests
+        const batchSize = 10;
+        for (let i = 0; i < initiatives.length; i += batchSize) {
+          const batch = initiatives.slice(i, i + batchSize);
+          const results = await Promise.all(
+            batch.map((init) =>
+              api.get<Relation[]>(`/relations?fact_sheet_id=${init.id}`),
+            ),
+          );
+          if (cancelled) return;
+          for (const rels of results) allRels.push(...rels);
+        }
+        if (!cancelled) setRelations(allRels);
+      } catch {
+        // non-critical — list view will just show no relations
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [viewMode, initiatives]);
+
+  // ── filter initiatives ────────────────────────────────────────────────
+
+  const filteredInitiatives = useMemo(() => {
+    let list = initiatives;
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (i) =>
+          i.name.toLowerCase().includes(q) ||
+          (i.description ?? "").toLowerCase().includes(q),
+      );
+    }
+    if (subtypeFilter) {
+      list = list.filter((i) => i.subtype === subtypeFilter);
+    }
+    return list;
+  }, [initiatives, search, subtypeFilter]);
 
   // ── group artefacts by initiative ───────────────────────────────────────
 
   const groups: InitiativeGroup[] = useMemo(() => {
-    return initiatives.map((init) => ({
+    return filteredInitiatives.map((init) => ({
       initiative: init,
       diagrams: diagrams.filter((d) => d.initiative_ids.includes(init.id)),
       soaws: soaws.filter((s) => s.initiative_id === init.id),
     }));
-  }, [initiatives, diagrams, soaws]);
+  }, [filteredInitiatives, diagrams, soaws]);
 
   const unlinkedSoaws = useMemo(
     () => soaws.filter((s) => !s.initiative_id),
@@ -128,6 +225,48 @@ export default function EADeliveryPage() {
   const unlinkedDiagrams = useMemo(
     () => diagrams.filter((d) => d.initiative_ids.length === 0),
     [diagrams],
+  );
+
+  // ── helpers for list view ─────────────────────────────────────────────
+
+  const getRelationsForInitiative = useCallback(
+    (initId: string) => {
+      return relations.filter(
+        (r) => r.source_id === initId || r.target_id === initId,
+      );
+    },
+    [relations],
+  );
+
+  const getRelatedSummary = useCallback(
+    (initId: string) => {
+      const rels = getRelationsForInitiative(initId);
+      const grouped: Record<string, { type: string; names: string[] }> = {};
+      for (const r of rels) {
+        const other = r.source_id === initId ? r.target : r.source;
+        if (!other) continue;
+        if (!grouped[other.type]) grouped[other.type] = { type: other.type, names: [] };
+        if (!grouped[other.type].names.includes(other.name)) {
+          grouped[other.type].names.push(other.name);
+        }
+      }
+      return Object.values(grouped);
+    },
+    [getRelationsForInitiative],
+  );
+
+  const getTypeColor = useCallback(
+    (typeKey: string) => {
+      return metamodelTypes.find((t) => t.key === typeKey)?.color ?? "#666";
+    },
+    [metamodelTypes],
+  );
+
+  const getTypeLabel = useCallback(
+    (typeKey: string) => {
+      return metamodelTypes.find((t) => t.key === typeKey)?.label ?? typeKey;
+    },
+    [metamodelTypes],
   );
 
   // ── create SoAW ────────────────────────────────────────────────────────
@@ -160,7 +299,6 @@ export default function EADeliveryPage() {
 
   const openLinkDialog = (initiativeId: string) => {
     setLinkInitiativeId(initiativeId);
-    // Pre-select diagrams already linked to this initiative
     const alreadyLinked = diagrams
       .filter((d) => d.initiative_ids.includes(initiativeId))
       .map((d) => d.id);
@@ -180,25 +318,18 @@ export default function EADeliveryPage() {
     if (!linkInitiativeId) return;
     setLinking(true);
     try {
-      // For each diagram, update its initiative_ids:
-      // - If newly selected: add this initiative to its existing initiative_ids
-      // - If deselected: remove this initiative from its initiative_ids
       const promises = diagrams.map((d) => {
         const wasLinked = d.initiative_ids.includes(linkInitiativeId);
         const isNowLinked = linkSelected.includes(d.id);
-
-        if (wasLinked === isNowLinked) return null; // no change
-
+        if (wasLinked === isNowLinked) return null;
         const newIds = isNowLinked
           ? [...d.initiative_ids, linkInitiativeId]
           : d.initiative_ids.filter((id) => id !== linkInitiativeId);
-
         return api.patch(`/diagrams/${d.id}`, { initiative_ids: newIds });
       });
-
       await Promise.all(promises.filter(Boolean));
       setLinkOpen(false);
-      await fetchAll(); // refresh
+      await fetchAll();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to link diagrams");
     } finally {
@@ -294,9 +425,9 @@ export default function EADeliveryPage() {
           )}
         </Typography>
         <Chip
-          label={STATUS_LABELS[s.status] ?? s.status}
+          label={SOAW_STATUS_LABELS[s.status] ?? s.status}
           size="small"
-          color={STATUS_COLORS[s.status] ?? "default"}
+          color={SOAW_STATUS_COLORS[s.status] ?? "default"}
           sx={{ mr: 1 }}
         />
         <Chip label="SoAW" size="small" variant="outlined" />
@@ -327,6 +458,255 @@ export default function EADeliveryPage() {
     </Card>
   );
 
+  // ── list view renderer ────────────────────────────────────────────────
+
+  const renderListView = () => {
+    const initDiagramCount = (id: string) =>
+      diagrams.filter((d) => d.initiative_ids.includes(id)).length;
+    const initSoawCount = (id: string) =>
+      soaws.filter((s) => s.initiative_id === id).length;
+
+    return (
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ bgcolor: "grey.50" }}>
+              <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Subtype</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Business Value</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Effort</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Timeline</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Completion</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Artefacts</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Related Elements</TableCell>
+              <TableCell sx={{ fontWeight: 600, width: 80 }}>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredInitiatives.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={10} sx={{ textAlign: "center", py: 4, color: "text.secondary" }}>
+                  No initiatives match the current filters.
+                </TableCell>
+              </TableRow>
+            )}
+            {filteredInitiatives.map((init) => {
+              const attrs = (init.attributes ?? {}) as Record<string, unknown>;
+              const initStatus = attrs.initiativeStatus as string | undefined;
+              const businessValue = attrs.businessValue as string | undefined;
+              const effort = attrs.effort as string | undefined;
+              const startDate = attrs.startDate as string | undefined;
+              const endDate = attrs.endDate as string | undefined;
+              const dCount = initDiagramCount(init.id);
+              const sCount = initSoawCount(init.id);
+              const relatedGroups = getRelatedSummary(init.id);
+
+              return (
+                <TableRow
+                  key={init.id}
+                  hover
+                  sx={{
+                    cursor: "pointer",
+                    opacity: init.status === "ARCHIVED" ? 0.6 : 1,
+                    "&:hover": { bgcolor: "action.hover" },
+                  }}
+                  onClick={() => navigate(`/fact-sheets/${init.id}`)}
+                >
+                  {/* Name */}
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <MaterialSymbol icon="rocket_launch" size={18} color="#33cc58" />
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {init.name}
+                      </Typography>
+                      {init.status === "ARCHIVED" && (
+                        <Chip label="Archived" size="small" variant="outlined" color="default" sx={{ height: 20, fontSize: "0.7rem" }} />
+                      )}
+                    </Box>
+                  </TableCell>
+
+                  {/* Subtype */}
+                  <TableCell>
+                    {init.subtype ? (
+                      <Chip label={init.subtype} size="small" sx={{ textTransform: "capitalize" }} />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">-</Typography>
+                    )}
+                  </TableCell>
+
+                  {/* Initiative Status */}
+                  <TableCell>
+                    {initStatus ? (
+                      <Chip
+                        label={INITIATIVE_STATUS_LABELS[initStatus] ?? initStatus}
+                        size="small"
+                        sx={{
+                          bgcolor: INITIATIVE_STATUS_COLORS[initStatus] ?? "#9e9e9e",
+                          color: "#fff",
+                          fontWeight: 500,
+                        }}
+                      />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">-</Typography>
+                    )}
+                  </TableCell>
+
+                  {/* Business Value */}
+                  <TableCell>
+                    {businessValue ? (
+                      <Chip
+                        label={businessValue.charAt(0).toUpperCase() + businessValue.slice(1)}
+                        size="small"
+                        variant="outlined"
+                        sx={{
+                          borderColor:
+                            businessValue === "high" ? "#2e7d32" :
+                            businessValue === "medium" ? "#ff9800" : "#9e9e9e",
+                          color:
+                            businessValue === "high" ? "#2e7d32" :
+                            businessValue === "medium" ? "#ff9800" : "#9e9e9e",
+                        }}
+                      />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">-</Typography>
+                    )}
+                  </TableCell>
+
+                  {/* Effort */}
+                  <TableCell>
+                    {effort ? (
+                      <Chip
+                        label={effort.charAt(0).toUpperCase() + effort.slice(1)}
+                        size="small"
+                        variant="outlined"
+                        sx={{
+                          borderColor:
+                            effort === "high" ? "#d32f2f" :
+                            effort === "medium" ? "#ff9800" : "#4caf50",
+                          color:
+                            effort === "high" ? "#d32f2f" :
+                            effort === "medium" ? "#ff9800" : "#4caf50",
+                        }}
+                      />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">-</Typography>
+                    )}
+                  </TableCell>
+
+                  {/* Timeline */}
+                  <TableCell>
+                    {startDate || endDate ? (
+                      <Typography variant="body2" sx={{ fontSize: "0.8rem", whiteSpace: "nowrap" }}>
+                        {startDate ? new Date(startDate).toLocaleDateString() : "?"}{" "}
+                        {" - "}
+                        {endDate ? new Date(endDate).toLocaleDateString() : "?"}
+                      </Typography>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">-</Typography>
+                    )}
+                  </TableCell>
+
+                  {/* Completion */}
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 80 }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={init.completion}
+                        sx={{ flex: 1, height: 6, borderRadius: 3 }}
+                      />
+                      <Typography variant="body2" sx={{ fontSize: "0.75rem", minWidth: 32, textAlign: "right" }}>
+                        {Math.round(init.completion)}%
+                      </Typography>
+                    </Box>
+                  </TableCell>
+
+                  {/* Artefacts */}
+                  <TableCell>
+                    <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                      {sCount > 0 && (
+                        <Chip
+                          icon={<MaterialSymbol icon="description" size={14} />}
+                          label={`${sCount} SoAW`}
+                          size="small"
+                          variant="outlined"
+                          sx={{ height: 22, fontSize: "0.75rem" }}
+                        />
+                      )}
+                      {dCount > 0 && (
+                        <Chip
+                          icon={<MaterialSymbol icon="schema" size={14} />}
+                          label={`${dCount} Diagram${dCount > 1 ? "s" : ""}`}
+                          size="small"
+                          variant="outlined"
+                          color="info"
+                          sx={{ height: 22, fontSize: "0.75rem" }}
+                        />
+                      )}
+                      {sCount === 0 && dCount === 0 && (
+                        <Typography variant="body2" color="text.secondary">-</Typography>
+                      )}
+                    </Box>
+                  </TableCell>
+
+                  {/* Related Elements */}
+                  <TableCell>
+                    <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", maxWidth: 280 }}>
+                      {relatedGroups.length > 0 ? (
+                        relatedGroups.map(({ type, names }) => (
+                          <Tooltip key={type} title={names.join(", ")}>
+                            <Chip
+                              label={`${names.length} ${getTypeLabel(type)}`}
+                              size="small"
+                              sx={{
+                                height: 22,
+                                fontSize: "0.75rem",
+                                bgcolor: getTypeColor(type) + "18",
+                                color: getTypeColor(type),
+                                borderColor: getTypeColor(type) + "40",
+                                border: "1px solid",
+                              }}
+                            />
+                          </Tooltip>
+                        ))
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          {relations.length > 0 ? "-" : "..."}
+                        </Typography>
+                      )}
+                    </Box>
+                  </TableCell>
+
+                  {/* Actions */}
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    <Box sx={{ display: "flex" }}>
+                      <Tooltip title="Create SoAW">
+                        <IconButton
+                          size="small"
+                          onClick={() => handleCreateForInitiative(init.id)}
+                        >
+                          <MaterialSymbol icon="add_circle_outline" size={18} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Link diagrams">
+                        <IconButton
+                          size="small"
+                          onClick={() => openLinkDialog(init.id)}
+                        >
+                          <MaterialSymbol icon="link" size={18} />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  };
+
   // ── render ─────────────────────────────────────────────────────────────
 
   if (loading) {
@@ -340,7 +720,7 @@ export default function EADeliveryPage() {
   return (
     <Box>
       {/* Header */}
-      <Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
+      <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
         <MaterialSymbol icon="architecture" size={28} color="#1976d2" />
         <Typography variant="h5" sx={{ ml: 1, fontWeight: 700 }}>
           EA Delivery
@@ -366,6 +746,97 @@ export default function EADeliveryPage() {
         </Alert>
       )}
 
+      {/* Filter bar */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          mb: 2,
+          flexWrap: "wrap",
+        }}
+      >
+        {/* Search */}
+        <TextField
+          size="small"
+          placeholder="Search initiatives..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ minWidth: 220 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <MaterialSymbol icon="search" size={20} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+
+        {/* Status filter */}
+        <TextField
+          select
+          size="small"
+          label="Status"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+          sx={{ minWidth: 130 }}
+        >
+          <MenuItem value="ACTIVE">Active</MenuItem>
+          <MenuItem value="ARCHIVED">Archived</MenuItem>
+          <MenuItem value="">All</MenuItem>
+        </TextField>
+
+        {/* Subtype filter */}
+        <TextField
+          select
+          size="small"
+          label="Subtype"
+          value={subtypeFilter}
+          onChange={(e) => setSubtypeFilter(e.target.value)}
+          sx={{ minWidth: 130 }}
+        >
+          <MenuItem value="">All Subtypes</MenuItem>
+          {subtypes.map((st) => (
+            <MenuItem key={st.key} value={st.key}>
+              {st.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <Box sx={{ flex: 1 }} />
+
+        {/* Result count */}
+        <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
+          {filteredInitiatives.length} initiative{filteredInitiatives.length !== 1 ? "s" : ""}
+        </Typography>
+
+        {/* View toggle */}
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={(_, v) => v && setViewMode(v)}
+          size="small"
+        >
+          <ToggleButton value="cards">
+            <Tooltip title="Card view">
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                <MaterialSymbol icon="dashboard" size={20} />
+              </Box>
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton value="list">
+            <Tooltip title="List view">
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                <MaterialSymbol icon="view_list" size={20} />
+              </Box>
+            </Tooltip>
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* Empty state */}
       {initiatives.length === 0 && soaws.length === 0 && diagrams.length === 0 && (
         <Alert severity="info" sx={{ mb: 2 }}>
           No initiatives found. Create initiatives in the Inventory first, then
@@ -373,163 +844,199 @@ export default function EADeliveryPage() {
         </Alert>
       )}
 
-      {/* Initiative groups */}
-      {groups.map(({ initiative, soaws: initSoaws, diagrams: initDiagrams }) => {
-        const isOpen = expanded[initiative.id] ?? false;
-        const artefactCount = initSoaws.length + initDiagrams.length;
+      {/* List view */}
+      {viewMode === "list" && renderListView()}
 
-        return (
-          <Card
-            key={initiative.id}
-            sx={{ mb: 2, borderLeft: "4px solid #33cc58" }}
-          >
-            {/* Initiative header */}
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                px: 2,
-                py: 1.5,
-                cursor: "pointer",
-                "&:hover": { bgcolor: "grey.50" },
-              }}
-              onClick={() => toggle(initiative.id)}
-            >
-              <IconButton size="small" sx={{ mr: 1 }}>
-                <MaterialSymbol
-                  icon={isOpen ? "expand_more" : "chevron_right"}
-                  size={20}
-                />
-              </IconButton>
-              <MaterialSymbol icon="rocket_launch" size={22} color="#33cc58" />
-              <Typography sx={{ ml: 1, fontWeight: 600, flex: 1 }}>
-                {initiative.name}
-              </Typography>
-              {initiative.subtype && (
-                <Chip
-                  label={initiative.subtype}
-                  size="small"
-                  sx={{ mr: 1, textTransform: "capitalize" }}
-                />
-              )}
-              <Chip
-                label={`${artefactCount} artefact${artefactCount !== 1 ? "s" : ""}`}
-                size="small"
-                variant="outlined"
-                sx={{ mr: 1 }}
-              />
-              <Tooltip title="Link diagrams to this initiative">
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openLinkDialog(initiative.id);
-                  }}
-                  sx={{ mr: 0.5 }}
-                >
-                  <MaterialSymbol icon="link" size={20} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Create SoAW for this initiative">
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleCreateForInitiative(initiative.id);
-                  }}
-                >
-                  <MaterialSymbol icon="add_circle_outline" size={20} />
-                </IconButton>
-              </Tooltip>
-            </Box>
+      {/* Cards view */}
+      {viewMode === "cards" && (
+        <>
+          {filteredInitiatives.length === 0 && initiatives.length > 0 && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              No initiatives match the current filters.
+            </Alert>
+          )}
 
-            {/* Artefact list */}
-            <Collapse in={isOpen}>
-              <Box sx={{ px: 2, pb: 2 }}>
-                {artefactCount === 0 && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ py: 2, textAlign: "center" }}
-                  >
-                    No artefacts yet.{" "}
-                    <Box
-                      component="span"
-                      sx={{
-                        color: "primary.main",
-                        cursor: "pointer",
-                        "&:hover": { textDecoration: "underline" },
-                      }}
-                      onClick={() => openLinkDialog(initiative.id)}
-                    >
-                      Link a diagram
-                    </Box>
-                    {" or "}
-                    <Box
-                      component="span"
-                      sx={{
-                        color: "primary.main",
-                        cursor: "pointer",
-                        "&:hover": { textDecoration: "underline" },
-                      }}
-                      onClick={() => handleCreateForInitiative(initiative.id)}
-                    >
-                      create a Statement of Architecture Work
-                    </Box>
-                    .
+          {/* Initiative groups */}
+          {groups.map(({ initiative, soaws: initSoaws, diagrams: initDiagrams }) => {
+            const isOpen = expanded[initiative.id] ?? false;
+            const artefactCount = initSoaws.length + initDiagrams.length;
+
+            return (
+              <Card
+                key={initiative.id}
+                sx={{
+                  mb: 2,
+                  borderLeft: `4px solid ${initiative.status === "ARCHIVED" ? "#999" : "#33cc58"}`,
+                  opacity: initiative.status === "ARCHIVED" ? 0.7 : 1,
+                }}
+              >
+                {/* Initiative header */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    px: 2,
+                    py: 1.5,
+                    cursor: "pointer",
+                    "&:hover": { bgcolor: "grey.50" },
+                  }}
+                  onClick={() => toggle(initiative.id)}
+                >
+                  <IconButton size="small" sx={{ mr: 1 }}>
+                    <MaterialSymbol
+                      icon={isOpen ? "expand_more" : "chevron_right"}
+                      size={20}
+                    />
+                  </IconButton>
+                  <MaterialSymbol icon="rocket_launch" size={22} color={initiative.status === "ARCHIVED" ? "#999" : "#33cc58"} />
+                  <Typography sx={{ ml: 1, fontWeight: 600, flex: 1 }}>
+                    {initiative.name}
                   </Typography>
-                )}
+                  {initiative.status === "ARCHIVED" && (
+                    <Chip label="Archived" size="small" variant="outlined" color="default" sx={{ mr: 1 }} />
+                  )}
+                  {initiative.subtype && (
+                    <Chip
+                      label={initiative.subtype}
+                      size="small"
+                      sx={{ mr: 1, textTransform: "capitalize" }}
+                    />
+                  )}
+                  {(() => {
+                    const initStatus = (initiative.attributes as Record<string, unknown>)?.initiativeStatus as string | undefined;
+                    return initStatus ? (
+                      <Chip
+                        label={INITIATIVE_STATUS_LABELS[initStatus] ?? initStatus}
+                        size="small"
+                        sx={{
+                          mr: 1,
+                          bgcolor: INITIATIVE_STATUS_COLORS[initStatus] ?? "#9e9e9e",
+                          color: "#fff",
+                          fontWeight: 500,
+                        }}
+                      />
+                    ) : null;
+                  })()}
+                  <Chip
+                    label={`${artefactCount} artefact${artefactCount !== 1 ? "s" : ""}`}
+                    size="small"
+                    variant="outlined"
+                    sx={{ mr: 1 }}
+                  />
+                  <Tooltip title="Link diagrams to this initiative">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openLinkDialog(initiative.id);
+                      }}
+                      sx={{ mr: 0.5 }}
+                    >
+                      <MaterialSymbol icon="link" size={20} />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Create SoAW for this initiative">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCreateForInitiative(initiative.id);
+                      }}
+                    >
+                      <MaterialSymbol icon="add_circle_outline" size={20} />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
 
-                {/* Diagram cards */}
-                {initDiagrams.map((d) => renderDiagramCard(d, initiative.id))}
+                {/* Artefact list */}
+                <Collapse in={isOpen}>
+                  <Box sx={{ px: 2, pb: 2 }}>
+                    {artefactCount === 0 && (
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ py: 2, textAlign: "center" }}
+                      >
+                        No artefacts yet.{" "}
+                        <Box
+                          component="span"
+                          sx={{
+                            color: "primary.main",
+                            cursor: "pointer",
+                            "&:hover": { textDecoration: "underline" },
+                          }}
+                          onClick={() => openLinkDialog(initiative.id)}
+                        >
+                          Link a diagram
+                        </Box>
+                        {" or "}
+                        <Box
+                          component="span"
+                          sx={{
+                            color: "primary.main",
+                            cursor: "pointer",
+                            "&:hover": { textDecoration: "underline" },
+                          }}
+                          onClick={() => handleCreateForInitiative(initiative.id)}
+                        >
+                          create a Statement of Architecture Work
+                        </Box>
+                        .
+                      </Typography>
+                    )}
 
-                {/* SoAW cards */}
-                {initSoaws.map(renderSoawCard)}
+                    {/* Diagram cards */}
+                    {initDiagrams.map((d) => renderDiagramCard(d, initiative.id))}
+
+                    {/* SoAW cards */}
+                    {initSoaws.map(renderSoawCard)}
+                  </Box>
+                </Collapse>
+              </Card>
+            );
+          })}
+
+          {/* Unlinked artefacts */}
+          {(unlinkedSoaws.length > 0 || unlinkedDiagrams.length > 0) && (
+            <Card sx={{ mb: 2, borderLeft: "4px solid #999" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  px: 2,
+                  py: 1.5,
+                  cursor: "pointer",
+                  "&:hover": { bgcolor: "grey.50" },
+                }}
+                onClick={() => toggle("__unlinked__")}
+              >
+                <IconButton size="small" sx={{ mr: 1 }}>
+                  <MaterialSymbol
+                    icon={expanded["__unlinked__"] ? "expand_more" : "chevron_right"}
+                    size={20}
+                  />
+                </IconButton>
+                <MaterialSymbol icon="folder_open" size={22} color="#999" />
+                <Typography
+                  sx={{ ml: 1, fontWeight: 600, flex: 1, color: "text.secondary" }}
+                >
+                  Not linked to an Initiative
+                </Typography>
+                <Chip
+                  label={`${unlinkedSoaws.length + unlinkedDiagrams.length} artefact${unlinkedSoaws.length + unlinkedDiagrams.length !== 1 ? "s" : ""}`}
+                  size="small"
+                  variant="outlined"
+                />
               </Box>
-            </Collapse>
-          </Card>
-        );
-      })}
-
-      {/* Unlinked artefacts */}
-      {(unlinkedSoaws.length > 0 || unlinkedDiagrams.length > 0) && (
-        <Card sx={{ mb: 2, borderLeft: "4px solid #999" }}>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              px: 2,
-              py: 1.5,
-              cursor: "pointer",
-              "&:hover": { bgcolor: "grey.50" },
-            }}
-            onClick={() => toggle("__unlinked__")}
-          >
-            <IconButton size="small" sx={{ mr: 1 }}>
-              <MaterialSymbol
-                icon={expanded["__unlinked__"] ? "expand_more" : "chevron_right"}
-                size={20}
-              />
-            </IconButton>
-            <MaterialSymbol icon="folder_open" size={22} color="#999" />
-            <Typography
-              sx={{ ml: 1, fontWeight: 600, flex: 1, color: "text.secondary" }}
-            >
-              Not linked to an Initiative
-            </Typography>
-            <Chip
-              label={`${unlinkedSoaws.length + unlinkedDiagrams.length} artefact${unlinkedSoaws.length + unlinkedDiagrams.length !== 1 ? "s" : ""}`}
-              size="small"
-              variant="outlined"
-            />
-          </Box>
-          <Collapse in={expanded["__unlinked__"] ?? false}>
-            <Box sx={{ px: 2, pb: 2 }}>
-              {unlinkedDiagrams.map((d) => renderDiagramCard(d))}
-              {unlinkedSoaws.map(renderSoawCard)}
-            </Box>
-          </Collapse>
-        </Card>
+              <Collapse in={expanded["__unlinked__"] ?? false}>
+                <Box sx={{ px: 2, pb: 2 }}>
+                  {unlinkedDiagrams.map((d) => renderDiagramCard(d))}
+                  {unlinkedSoaws.map(renderSoawCard)}
+                </Box>
+              </Collapse>
+            </Card>
+          )}
+        </>
       )}
 
       {/* Context menu for SoAW */}


### PR DESCRIPTION
## Summary
Enhanced the EA Delivery page with a new list view mode and comprehensive filtering capabilities, allowing users to better manage and visualize initiatives in different formats.

## Key Changes

### Frontend (EADeliveryPage.tsx)
- **View Modes**: Added toggle between card view (existing) and new table-based list view
- **Filtering System**:
  - Search by initiative name or description
  - Filter by status (Active/Archived/All)
  - Filter by initiative subtype using metamodel types
  - Display filtered result count
- **List View Features**:
  - Comprehensive table showing initiatives with columns for name, subtype, status, business value, effort, timeline, completion percentage, artefacts, and related elements
  - Displays initiative status with color-coded chips (On Track, At Risk, Off Track, On Hold, Completed)
  - Shows business value and effort levels with visual indicators
  - Displays date ranges for project timelines
  - Linear progress bar for completion percentage
  - Related elements summary with type-based color coding and tooltips
  - Quick action buttons (Create SoAW, Link diagrams) in each row
- **Data Fetching**:
  - Added `useCallback` for `fetchAll` to properly handle dependencies
  - Fetch relations data when in list view for showing related elements
  - Batch relation fetching to avoid excessive parallel requests
- **UI Improvements**:
  - Added new Material-UI components (Table, TableBody, TableCell, etc.)
  - Integrated `useMetamodel` hook to access initiative subtypes
  - Added InputAdornment for search field with icon
  - Added ToggleButtonGroup for view mode switching
  - Support for archived initiatives with visual distinction (reduced opacity, different border color)
- **Constants**: Separated status colors/labels into `SOAW_STATUS_*` and added new `INITIATIVE_STATUS_*` constants

### Backend (fact_sheets.py)
- **Status Filtering**: Enhanced status parameter to support comma-separated values (e.g., `status=ACTIVE,ARCHIVED`)
  - Allows filtering by multiple statuses in a single request
  - Maintains backward compatibility with single status values

## Implementation Details
- Filtering is performed client-side on already-fetched initiatives for responsiveness
- Relations are fetched in batches of 10 to balance performance and API load
- List view only fetches relations when needed (not in card view)
- Archived initiatives are visually distinguished but still displayed based on filter selection
- All new filter state is managed with React hooks and properly integrated with existing data flow

https://claude.ai/code/session_01GCSZ2V6AEFAzvHJcrGhTFQ