### PR TITLE
Update marketing site branding and GitHub links

### DIFF
--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -16,7 +16,7 @@
   <nav class="nav" id="nav">
     <div class="nav-inner container">
       <a href="#" class="nav-logo">
-        <span class="nav-logo-text">Turbo EA</span>
+        <img src="assets/logo.png" alt="Turbo EA" class="nav-logo-img">
       </a>
       <div class="nav-links" id="nav-links">
         <a href="#features" class="nav-link">Features</a>
@@ -24,7 +24,7 @@
         <a href="#architecture" class="nav-link">Architecture</a>
         <a href="#reports" class="nav-link">Reports</a>
         <a href="#self-hosted" class="nav-link">Self-Hosted</a>
-        <a href="#get-started" class="nav-btn">Get Started</a>
+        <a href="https://github.com/vincentmakes/turbo-ea/" class="nav-btn" target="_blank" rel="noopener">GitHub</a>
       </div>
       <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
@@ -53,9 +53,9 @@
         all with a fully admin-configurable metamodel.
       </p>
       <div class="hero-actions fade-in">
-        <a href="#get-started" class="btn btn-primary btn-lg">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-          Get Started
+        <a href="https://github.com/vincentmakes/turbo-ea/" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+          View on GitHub
         </a>
         <a href="#features" class="btn btn-outline btn-lg">
           Explore Features
@@ -771,7 +771,7 @@
         <h2 class="cta-title">Ready to map your IT landscape?</h2>
         <p class="cta-desc">Deploy Turbo EA in minutes. The first user gets admin automatically. Add your team, configure your metamodel, and start building your architecture digital twin.</p>
         <div class="cta-actions">
-          <a href="https://github.com" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+          <a href="https://github.com/vincentmakes/turbo-ea/" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
             View on GitHub
           </a>


### PR DESCRIPTION
## Summary
Updated the marketing site to replace text-based branding with a logo image and redirect primary calls-to-action to the GitHub repository instead of an internal "Get Started" section.

## Key Changes
- **Navigation Logo**: Replaced text-based "Turbo EA" logo with an image asset (`assets/logo.png`)
- **Navigation CTA**: Changed "Get Started" link to "GitHub" with direct link to the repository
- **Hero Section CTA**: Updated primary button from internal "Get Started" link to GitHub repository link, including GitHub icon SVG
- **Footer CTA**: Corrected incomplete GitHub URL (`https://github.com` → `https://github.com/vincentmakes/turbo-ea/`)
- **Link Attributes**: Added `target="_blank"` and `rel="noopener"` to all external GitHub links for security and UX best practices

## Implementation Details
- All GitHub links now point to the consistent repository URL: `https://github.com/vincentmakes/turbo-ea/`
- GitHub icon SVG added to hero section button for visual consistency
- Navigation maintains all other section links (Features, BPM, Architecture, Reports, Self-Hosted) unchanged

https://claude.ai/code/session_01Ap55xoGsd3k87uvtw4Xiwf