### PR TITLE
Add custom favicon upload support to admin settings

### DIFF
--- a/backend/alembic/versions/023_add_custom_favicon.py
+++ b/backend/alembic/versions/023_add_custom_favicon.py
@@ -1,0 +1,26 @@
+"""Add custom_favicon and custom_favicon_mime columns to app_settings.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-02-16
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "023"
+down_revision: Union[str, None] = "022"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("app_settings", sa.Column("custom_favicon", sa.LargeBinary(), nullable=True))
+    op.add_column("app_settings", sa.Column("custom_favicon_mime", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "custom_favicon_mime")
+    op.drop_column("app_settings", "custom_favicon")

--- a/backend/app/models/app_settings.py
+++ b/backend/app/models/app_settings.py
@@ -19,6 +19,8 @@ class AppSettings(Base):
     general_settings: Mapped[dict | None] = mapped_column(JSONB, default=dict)
     custom_logo: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     custom_logo_mime: Mapped[str | None] = mapped_column(Text, nullable=True)
+    custom_favicon: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    custom_favicon_mime: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )


### PR DESCRIPTION
## Summary
This PR adds the ability for administrators to upload and manage a custom favicon separately from the logo. Previously, the favicon was derived from the custom logo. Now users can set a distinct favicon for browser tabs and Apple touch icons.

## Key Changes

**Frontend (SettingsAdmin.tsx):**
- Added `FaviconInfo` interface to track custom favicon state and MIME type
- Added favicon state management (hasCustomFavicon, faviconVersion, uploadingFavicon)
- Implemented `handleFaviconUpload()` and `handleFaviconReset()` functions mirroring logo functionality
- Added new "Favicon" settings section with upload/reset UI and preview
- Updated logo description to clarify it only affects the navigation bar
- Removed `updateFavicons()` calls from logo handlers (no longer needed since favicon is independent)

**Backend (settings.py):**
- Updated `get_favicon()` endpoint to return custom favicon if set, otherwise default favicon
- Added `get_favicon_info()` endpoint to return favicon metadata for admin UI
- Added `upload_favicon()` endpoint to handle custom favicon uploads with validation
- Added `reset_favicon()` endpoint to clear custom favicon and revert to default
- All favicon endpoints require admin.settings permission

**Database (app_settings.py & migration):**
- Added `custom_favicon` (LargeBinary) and `custom_favicon_mime` (Text) columns to AppSettings model
- Created migration 023 to add these columns to the app_settings table

## Implementation Details

- Favicon upload accepts PNG, JPEG, WebP, and GIF formats (same as logo)
- Reuses existing `MAX_LOGO_SIZE` (2 MB) and `ALLOWED_LOGO_MIMES` constants for validation
- Favicon preview displays in an 80x80px box with cache-busting version parameter
- UI mirrors logo upload pattern for consistency
- Favicon endpoint returns 300-second cache control header for performance

https://claude.ai/code/session_01NEJhfF7X8ZwcKJTeVtoqTG