### PR TITLE
Refine responsive breakpoints, update login logo, and fix apple-touch…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/api/v1/settings/favicon" />
-    <link rel="apple-touch-icon" href="/api/v1/settings/favicon" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Turbo EA</title>
     <link

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -8,7 +8,6 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Alert from "@mui/material/Alert";
 import Divider from "@mui/material/Divider";
-import MaterialSymbol from "@/components/MaterialSymbol";
 import { auth } from "@/api/client";
 import type { SsoConfig } from "@/types";
 
@@ -78,11 +77,12 @@ export default function LoginPage({ onLogin, onRegister }: Props) {
     >
       <Card sx={{ p: 4, width: 400, maxWidth: "90vw" }}>
         <Box sx={{ textAlign: "center", mb: 3 }}>
-          <MaterialSymbol icon="hub" size={48} color="#1976d2" />
-          <Typography variant="h5" fontWeight={700} sx={{ mt: 1 }}>
-            Turbo EA
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <img
+            src="/logo.png"
+            alt="Turbo EA"
+            style={{ height: 64, objectFit: "contain" }}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
             Enterprise Architecture Management
           </Typography>
         </Box>

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -103,8 +103,9 @@ export default function AppLayout({ children, user, onLogout }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const isCompact = useMediaQuery("(max-width:1279px)");
+  const isMobile = useMediaQuery("(max-width:767px)");
+  const isCompact = useMediaQuery("(max-width:1023px)");
+  const isCondensed = useMediaQuery("(max-width:1279px)");
   const { getType } = useMetamodel();
   const { bpmEnabled } = useBpmEnabled();
 
@@ -260,9 +261,9 @@ export default function AppLayout({ children, user, onLogout }: Props) {
     color: active ? "#fff" : "rgba(255,255,255,0.7)",
     textTransform: "none" as const,
     fontWeight: active ? 700 : 500,
-    fontSize: "0.85rem",
+    fontSize: isCondensed ? "0.75rem" : "0.85rem",
     minWidth: 0,
-    px: isCompact && !isMobile ? 1 : 1.5,
+    px: isCondensed ? 0.75 : 1.5,
     whiteSpace: "nowrap" as const,
     borderRadius: 1,
     bgcolor: active ? "rgba(255,255,255,0.12)" : "transparent",
@@ -546,7 +547,7 @@ export default function AppLayout({ children, user, onLogout }: Props) {
             sx={{
               display: "flex",
               alignItems: "center",
-              mr: isMobile ? 0 : 3,
+              mr: isMobile ? 0 : isCondensed ? 1.5 : 3,
               cursor: "pointer",
             }}
             onClick={() => navigate("/")}
@@ -660,8 +661,8 @@ export default function AppLayout({ children, user, onLogout }: Props) {
                     if (searchResults.length > 0) setSearchOpen(true);
                   }}
                   sx={{
-                    maxWidth: isCompact ? 180 : 360,
-                    minWidth: isCompact ? 140 : 180,
+                    maxWidth: isCondensed ? 200 : 360,
+                    minWidth: isCondensed ? 140 : 180,
                     bgcolor: "rgba(255,255,255,0.08)",
                     borderRadius: 1,
                     "& .MuiOutlinedInput-notchedOutline": { border: "none" },


### PR DESCRIPTION
…-icon

Toolbar responsiveness:
- 3-tier breakpoint strategy: hamburger (<768px), icon-only (768-1023px), condensed text (1024-1279px), full desktop (>=1280px)
- Tablet landscape now keeps text labels with smaller font (0.75rem) and tighter padding instead of switching to icon-only
- Tighter logo margin and slightly smaller search bar in condensed range

Login page:
- Show the default static logo instead of the custom/API logo
- Remove "Turbo EA" heading since the logo already includes the text

Apple-touch-icon:
- Use static /favicon.png instead of the API endpoint

https://claude.ai/code/session_01G1i7fDNvSKKyerkCccXRaV