### PR TITLE
Add saved reports feature: save, share, and load report configurations

### DIFF
--- a/backend/alembic/versions/025_add_custom_reports.py
+++ b/backend/alembic/versions/025_add_custom_reports.py
@@ -1,0 +1,47 @@
+"""Add saved_reports and saved_report_shares tables.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-02-17
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "025"
+down_revision: Union[str, None] = "024"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "saved_reports",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("owner_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("report_type", sa.String(50), nullable=False),
+        sa.Column("config", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("thumbnail", sa.Text(), nullable=True),
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="private"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_saved_reports_owner_id", "saved_reports", ["owner_id"])
+    op.create_index("ix_saved_reports_visibility", "saved_reports", ["visibility"])
+
+    op.create_table(
+        "saved_report_shares",
+        sa.Column("saved_report_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("saved_reports.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("user_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("saved_report_shares")
+    op.drop_index("ix_saved_reports_visibility", table_name="saved_reports")
+    op.drop_index("ix_saved_reports_owner_id", table_name="saved_reports")
+    op.drop_table("saved_reports")

--- a/backend/app/api/v1/custom_reports.py
+++ b/backend/app/api/v1/custom_reports.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select, or_, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.models.custom_report import SavedReport, saved_report_shares
+from app.models.user import User
+from app.schemas.common import SavedReportCreate, SavedReportUpdate
+from app.services.permission_service import PermissionService
+
+router = APIRouter(prefix="/saved-reports", tags=["saved-reports"])
+
+VALID_REPORT_TYPES = {
+    "portfolio", "capability-map", "lifecycle", "dependencies",
+    "cost", "matrix", "data-quality", "eol",
+}
+
+
+def _serialize(report: SavedReport, current_user_id: uuid.UUID) -> dict:
+    shared_user_ids = [str(u.id) for u in (report.shared_with_users or [])]
+    shared_user_names = [
+        {"id": str(u.id), "display_name": u.display_name, "email": u.email}
+        for u in (report.shared_with_users or [])
+    ]
+    return {
+        "id": str(report.id),
+        "owner_id": str(report.owner_id),
+        "owner_name": report.owner.display_name if hasattr(report, "owner") and report.owner else None,
+        "name": report.name,
+        "description": report.description,
+        "report_type": report.report_type,
+        "config": report.config,
+        "thumbnail": report.thumbnail,
+        "visibility": report.visibility,
+        "shared_with": shared_user_ids,
+        "shared_with_users": shared_user_names,
+        "is_owner": report.owner_id == current_user_id,
+        "created_at": report.created_at.isoformat() if report.created_at else None,
+        "updated_at": report.updated_at.isoformat() if report.updated_at else None,
+    }
+
+
+@router.get("")
+async def list_saved_reports(
+    filter: str = Query("all", regex="^(all|my|shared|public)$"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """List saved reports visible to the current user."""
+    base = select(SavedReport).options(
+        selectinload(SavedReport.shared_with_users),
+    )
+
+    if filter == "my":
+        stmt = base.where(SavedReport.owner_id == user.id)
+    elif filter == "public":
+        stmt = base.where(SavedReport.visibility == "public")
+    elif filter == "shared":
+        stmt = base.where(
+            SavedReport.id.in_(
+                select(saved_report_shares.c.saved_report_id).where(
+                    saved_report_shares.c.user_id == user.id
+                )
+            )
+        )
+    else:
+        # "all" — own + shared with me + public
+        stmt = base.where(
+            or_(
+                SavedReport.owner_id == user.id,
+                SavedReport.visibility == "public",
+                SavedReport.id.in_(
+                    select(saved_report_shares.c.saved_report_id).where(
+                        saved_report_shares.c.user_id == user.id
+                    )
+                ),
+            )
+        )
+
+    stmt = stmt.order_by(SavedReport.updated_at.desc())
+    result = await db.execute(stmt)
+    reports = result.scalars().unique().all()
+
+    # Eagerly load owner names
+    owner_ids = {r.owner_id for r in reports}
+    owners = {}
+    if owner_ids:
+        owner_result = await db.execute(select(User).where(User.id.in_(owner_ids)))
+        for u in owner_result.scalars().all():
+            owners[u.id] = u
+    for r in reports:
+        r.owner = owners.get(r.owner_id)  # type: ignore[attr-defined]
+
+    return [_serialize(r, user.id) for r in reports]
+
+
+@router.post("", status_code=201)
+async def create_saved_report(
+    body: SavedReportCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    await PermissionService.require_permission(db, user, "saved_reports.create")
+
+    if body.report_type not in VALID_REPORT_TYPES:
+        raise HTTPException(400, f"Invalid report_type. Must be one of: {', '.join(sorted(VALID_REPORT_TYPES))}")
+    if body.visibility not in ("private", "public", "shared"):
+        raise HTTPException(400, "visibility must be private, public, or shared")
+
+    report = SavedReport(
+        owner_id=user.id,
+        name=body.name,
+        description=body.description,
+        report_type=body.report_type,
+        config=body.config,
+        thumbnail=body.thumbnail,
+        visibility=body.visibility,
+    )
+    db.add(report)
+    await db.flush()
+
+    # Handle shared users
+    if body.shared_with and body.visibility == "shared":
+        for uid_str in body.shared_with:
+            try:
+                uid = uuid.UUID(uid_str)
+            except ValueError:
+                continue
+            await db.execute(
+                saved_report_shares.insert().values(
+                    saved_report_id=report.id, user_id=uid
+                )
+            )
+
+    await db.commit()
+    await db.refresh(report, ["shared_with_users"])
+    report.owner = user  # type: ignore[attr-defined]
+    return _serialize(report, user.id)
+
+
+@router.get("/{report_id}")
+async def get_saved_report(
+    report_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    rid = uuid.UUID(report_id)
+    result = await db.execute(
+        select(SavedReport)
+        .options(selectinload(SavedReport.shared_with_users))
+        .where(SavedReport.id == rid)
+    )
+    report = result.scalar_one_or_none()
+    if not report:
+        raise HTTPException(404, "Saved report not found")
+
+    # Access check
+    is_owner = report.owner_id == user.id
+    is_public = report.visibility == "public"
+    is_shared = any(u.id == user.id for u in (report.shared_with_users or []))
+    if not (is_owner or is_public or is_shared):
+        raise HTTPException(403, "Access denied")
+
+    # Load owner
+    owner_result = await db.execute(select(User).where(User.id == report.owner_id))
+    report.owner = owner_result.scalar_one_or_none()  # type: ignore[attr-defined]
+
+    return _serialize(report, user.id)
+
+
+@router.patch("/{report_id}")
+async def update_saved_report(
+    report_id: str,
+    body: SavedReportUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    rid = uuid.UUID(report_id)
+    result = await db.execute(
+        select(SavedReport)
+        .options(selectinload(SavedReport.shared_with_users))
+        .where(SavedReport.id == rid)
+    )
+    report = result.scalar_one_or_none()
+    if not report:
+        raise HTTPException(404, "Saved report not found")
+    if report.owner_id != user.id:
+        raise HTTPException(403, "Only the owner can update this report")
+
+    data = body.model_dump(exclude_unset=True)
+
+    if "visibility" in data and data["visibility"] not in ("private", "public", "shared"):
+        raise HTTPException(400, "visibility must be private, public, or shared")
+
+    shared_with = data.pop("shared_with", None)
+
+    for field, value in data.items():
+        setattr(report, field, value)
+
+    # Update shares if provided
+    if shared_with is not None:
+        await db.execute(
+            delete(saved_report_shares).where(
+                saved_report_shares.c.saved_report_id == report.id
+            )
+        )
+        if report.visibility == "shared" and shared_with:
+            for uid_str in shared_with:
+                try:
+                    uid = uuid.UUID(uid_str)
+                except ValueError:
+                    continue
+                await db.execute(
+                    saved_report_shares.insert().values(
+                        saved_report_id=report.id, user_id=uid
+                    )
+                )
+
+    await db.commit()
+    await db.refresh(report, ["shared_with_users"])
+    report.owner = user  # type: ignore[attr-defined]
+    return _serialize(report, user.id)
+
+
+@router.delete("/{report_id}", status_code=204)
+async def delete_saved_report(
+    report_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    rid = uuid.UUID(report_id)
+    result = await db.execute(
+        select(SavedReport).where(SavedReport.id == rid)
+    )
+    report = result.scalar_one_or_none()
+    if not report:
+        raise HTTPException(404, "Saved report not found")
+    if report.owner_id != user.id:
+        raise HTTPException(403, "Only the owner can delete this report")
+
+    await db.delete(report)
+    await db.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -8,6 +8,7 @@ from app.api.v1 import (
     bpm_reports,
     bpm_workflow,
     comments,
+    custom_reports,
     diagrams,
     documents,
     eol,
@@ -40,6 +41,7 @@ api_router.include_router(todos.router)
 api_router.include_router(tags.router)
 api_router.include_router(documents.router)
 api_router.include_router(bookmarks.router)
+api_router.include_router(custom_reports.router)
 api_router.include_router(reports.router)
 api_router.include_router(diagrams.router)
 api_router.include_router(soaw.router)

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -100,6 +100,12 @@ APP_PERMISSIONS: dict[str, dict] = {
             "bookmarks.manage": "Manage own bookmarks",
         },
     },
+    "saved_reports": {
+        "label": "Saved Reports",
+        "permissions": {
+            "saved_reports.create": "Create and manage saved reports",
+        },
+    },
     "eol": {
         "label": "End of Life",
         "permissions": {
@@ -218,6 +224,7 @@ BPM_ADMIN_PERMISSIONS: dict[str, bool] = {
     "soaw.sign": True,
     "tags.manage": True,
     "bookmarks.manage": True,
+    "saved_reports.create": True,
     "eol.view": True,
     "eol.manage": True,
     "web_portals.view": True,
@@ -263,6 +270,7 @@ MEMBER_PERMISSIONS: dict[str, bool] = {
     "soaw.sign": True,
     "tags.manage": True,
     "bookmarks.manage": True,
+    "saved_reports.create": True,
     "eol.view": True,
     "eol.manage": True,
     "web_portals.view": True,
@@ -309,6 +317,7 @@ VIEWER_PERMISSIONS: dict[str, bool] = {
     "soaw.sign": False,
     "tags.manage": False,
     "bookmarks.manage": True,
+    "saved_reports.create": False,
     "eol.view": True,
     "eol.manage": False,
     "web_portals.view": True,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.app_settings import AppSettings
 from app.models.base import Base
 from app.models.bookmark import Bookmark
 from app.models.comment import Comment
+from app.models.custom_report import SavedReport
 from app.models.diagram import Diagram
 from app.models.document import Document
 from app.models.event import Event
@@ -39,6 +40,7 @@ __all__ = [
     "Tag",
     "CardTag",
     "Comment",
+    "SavedReport",
     "Todo",
     "Event",
     "Document",

--- a/backend/app/models/custom_report.py
+++ b/backend/app/models/custom_report.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Column, ForeignKey, String, Text, Table
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, UUIDMixin, TimestampMixin
+
+# Association table for sharing reports with specific users
+saved_report_shares = Table(
+    "saved_report_shares",
+    Base.metadata,
+    Column("saved_report_id", UUID(as_uuid=True), ForeignKey("saved_reports.id", ondelete="CASCADE"), primary_key=True),
+    Column("user_id", UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class SavedReport(Base, UUIDMixin, TimestampMixin):
+    __tablename__ = "saved_reports"
+
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    report_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    thumbnail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
+
+    shared_with_users = relationship("User", secondary=saved_report_shares, lazy="selectin")

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -174,6 +174,25 @@ class WebPortalUpdate(BaseModel):
     is_published: bool | None = None
 
 
+class SavedReportCreate(BaseModel):
+    name: str
+    description: str | None = None
+    report_type: str
+    config: dict
+    thumbnail: str | None = None
+    visibility: str = "private"
+    shared_with: list[str] | None = None
+
+
+class SavedReportUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    config: dict | None = None
+    thumbnail: str | None = None
+    visibility: str | None = None
+    shared_with: list[str] | None = None
+
+
 # Fix forward refs
 TagGroupResponse.model_rebuild()
 CommentResponse.model_rebuild()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import CostReport from "@/features/reports/CostReport";
 import MatrixReport from "@/features/reports/MatrixReport";
 import DataQualityReport from "@/features/reports/DataQualityReport";
 import EolReport from "@/features/reports/EolReport";
+import SavedReportsPage from "@/features/reports/SavedReportsPage";
 import DiagramsPage from "@/features/diagrams/DiagramsPage";
 import DiagramEditor from "@/features/diagrams/DiagramEditor";
 import TodosPage from "@/features/todos/TodosPage";
@@ -103,6 +104,7 @@ function AppRoutes() {
               <Route path="/reports/matrix" element={<MatrixReport />} />
               <Route path="/reports/data-quality" element={<DataQualityReport />} />
               <Route path="/reports/eol" element={<EolReport />} />
+              <Route path="/reports/saved" element={<SavedReportsPage />} />
               <Route path="/bpm" element={<BpmDashboard />} />
               <Route path="/bpm/processes/:id/flow" element={<ProcessFlowEditorPage />} />
               <Route path="/diagrams" element={<DiagramsPage />} />

--- a/frontend/src/features/reports/CapabilityMapReport.tsx
+++ b/frontend/src/features/reports/CapabilityMapReport.tsx
@@ -16,10 +16,12 @@ import Switch from "@mui/material/Switch";
 import Autocomplete from "@mui/material/Autocomplete";
 import { useNavigate } from "react-router-dom";
 import ReportShell from "./ReportShell";
+import SaveReportDialog from "./SaveReportDialog";
 import TimelineSlider from "@/components/TimelineSlider";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import { useCurrency } from "@/hooks/useCurrency";
+import { useSavedReport } from "@/hooks/useSavedReport";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -652,6 +654,7 @@ const HOST_OPTS = [
 export default function CapabilityMapReport() {
   const navigate = useNavigate();
   const { fmtShort } = useCurrency();
+  const saved = useSavedReport("capability-map");
 
   // Data
   const [data, setData] = useState<CapItem[] | null>(null);
@@ -675,6 +678,26 @@ export default function CapabilityMapReport() {
   const [filterFunc, setFilterFunc] = useState<string[]>([]);
   const [filterTech, setFilterTech] = useState<string[]>([]);
   const [filterHost, setFilterHost] = useState<string[]>([]);
+
+  // Load saved report config
+  useEffect(() => {
+    const cfg = saved.consumeConfig();
+    if (cfg) {
+      if (cfg.metric) setMetric(cfg.metric as Metric);
+      if (cfg.displayLevel != null) setDisplayLevel(cfg.displayLevel as number);
+      if (cfg.showApps != null) setShowApps(cfg.showApps as boolean);
+      if (cfg.colorBy) setColorBy(cfg.colorBy as AppColorBy);
+      if (cfg.timelineDate) setTimelineDate(cfg.timelineDate as number);
+      if (cfg.filterOrgs) setFilterOrgs(cfg.filterOrgs as string[]);
+      if (cfg.filterTime) setFilterTime(cfg.filterTime as string[]);
+      if (cfg.filterCrit) setFilterCrit(cfg.filterCrit as string[]);
+      if (cfg.filterFunc) setFilterFunc(cfg.filterFunc as string[]);
+      if (cfg.filterTech) setFilterTech(cfg.filterTech as string[]);
+      if (cfg.filterHost) setFilterHost(cfg.filterHost as string[]);
+    }
+  }, [saved.loadedConfig]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const getConfig = () => ({ metric, displayLevel, showApps, colorBy, timelineDate, filterOrgs, filterTime, filterCrit, filterFunc, filterTech, filterHost });
 
   useEffect(() => {
     api
@@ -811,6 +834,9 @@ export default function CapabilityMapReport() {
       icon="grid_view"
       iconColor="#003399"
       hasTableToggle={false}
+      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      savedReportName={saved.savedReportName ?? undefined}
+      onResetSavedReport={saved.resetSavedReport}
       toolbar={
         <>
           {/* Row 1: Main controls */}
@@ -1182,6 +1208,12 @@ export default function CapabilityMapReport() {
           </Box>
         )}
       </Drawer>
+      <SaveReportDialog
+        open={saved.saveDialogOpen}
+        onClose={() => saved.setSaveDialogOpen(false)}
+        reportType="capability-map"
+        config={getConfig()}
+      />
     </ReportShell>
   );
 }

--- a/frontend/src/features/reports/EditReportDialog.tsx
+++ b/frontend/src/features/reports/EditReportDialog.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import Autocomplete from "@mui/material/Autocomplete";
+import Chip from "@mui/material/Chip";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { SavedReport, User } from "@/types";
+
+interface Props {
+  open: boolean;
+  report: SavedReport | null;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+export default function EditReportDialog({ open, report, onClose, onUpdated }: Props) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState<"private" | "public" | "shared">("private");
+  const [sharedWith, setSharedWith] = useState<User[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open && report) {
+      setName(report.name);
+      setDescription(report.description || "");
+      setVisibility(report.visibility);
+      // Pre-select shared users
+      if (report.shared_with_users) {
+        setSharedWith(report.shared_with_users.map((u) => ({
+          id: u.id,
+          display_name: u.display_name,
+          email: u.email,
+          role: "",
+          is_active: true,
+        })));
+      }
+    }
+  }, [open, report]);
+
+  useEffect(() => {
+    if (open && visibility === "shared" && users.length === 0) {
+      api.get<User[]>("/users").then(setUsers).catch(() => {});
+    }
+  }, [open, visibility, users.length]);
+
+  const handleSave = async () => {
+    if (!report || !name.trim()) return;
+    setSaving(true);
+    try {
+      await api.patch(`/saved-reports/${report.id}`, {
+        name: name.trim(),
+        description: description.trim() || null,
+        visibility,
+        shared_with: visibility === "shared" ? sharedWith.map((u) => u.id) : [],
+      });
+      onUpdated();
+      onClose();
+    } catch {
+      // error handled by api client
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <MaterialSymbol icon="edit" size={22} color="#1976d2" />
+        Edit Saved Report
+      </DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: "8px !important" }}>
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+          required
+          autoFocus
+          size="small"
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          fullWidth
+          multiline
+          rows={2}
+          size="small"
+        />
+        <TextField
+          select
+          label="Visibility"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value as "private" | "public" | "shared")}
+          fullWidth
+          size="small"
+        >
+          <MenuItem value="private">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="lock" size={16} />
+              Private — Only me
+            </Box>
+          </MenuItem>
+          <MenuItem value="public">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="public" size={16} />
+              Public — All users
+            </Box>
+          </MenuItem>
+          <MenuItem value="shared">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="group" size={16} />
+              Shared — Specific users
+            </Box>
+          </MenuItem>
+        </TextField>
+
+        {visibility === "shared" && (
+          <Autocomplete
+            multiple
+            options={users.filter((u) => u.is_active)}
+            getOptionLabel={(u) => `${u.display_name} (${u.email})`}
+            value={sharedWith}
+            onChange={(_, v) => setSharedWith(v)}
+            isOptionEqualToValue={(o, v) => o.id === v.id}
+            renderTags={(value, getTagProps) =>
+              value.map((u, idx) => (
+                <Chip label={u.display_name} size="small" {...getTagProps({ index: idx })} key={u.id} />
+              ))
+            }
+            renderInput={(params) => (
+              <TextField {...params} label="Share with" size="small" placeholder="Search users..." />
+            )}
+            size="small"
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!name.trim() || saving}
+          startIcon={saving ? <CircularProgress size={16} /> : <MaterialSymbol icon="save" size={18} />}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/reports/SaveReportDialog.tsx
+++ b/frontend/src/features/reports/SaveReportDialog.tsx
@@ -1,0 +1,174 @@
+import { useState, useEffect } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import Autocomplete from "@mui/material/Autocomplete";
+import Chip from "@mui/material/Chip";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import { api } from "@/api/client";
+import type { User } from "@/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  reportType: string;
+  config: Record<string, unknown>;
+  thumbnail?: string;
+  onSaved?: (id: string) => void;
+}
+
+export default function SaveReportDialog({ open, onClose, reportType, config, thumbnail, onSaved }: Props) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState<"private" | "public" | "shared">("private");
+  const [sharedWith, setSharedWith] = useState<User[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open && visibility === "shared" && users.length === 0) {
+      api.get<User[]>("/users").then(setUsers).catch(() => {});
+    }
+  }, [open, visibility, users.length]);
+
+  // Reset form on open
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setDescription("");
+      setVisibility("private");
+      setSharedWith([]);
+    }
+  }, [open]);
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const res = await api.post<{ id: string }>("/saved-reports", {
+        name: name.trim(),
+        description: description.trim() || null,
+        report_type: reportType,
+        config,
+        thumbnail: thumbnail || null,
+        visibility,
+        shared_with: visibility === "shared" ? sharedWith.map((u) => u.id) : null,
+      });
+      onSaved?.(res.id);
+      onClose();
+    } catch {
+      // error handled by api client
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <MaterialSymbol icon="bookmark_add" size={22} color="#1976d2" />
+        Save Report
+      </DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: "8px !important" }}>
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+          required
+          autoFocus
+          size="small"
+          placeholder="e.g. Q1 Application Portfolio"
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          fullWidth
+          multiline
+          rows={2}
+          size="small"
+          placeholder="Optional description of this report view"
+        />
+        <TextField
+          select
+          label="Visibility"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value as "private" | "public" | "shared")}
+          fullWidth
+          size="small"
+        >
+          <MenuItem value="private">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="lock" size={16} />
+              Private — Only me
+            </Box>
+          </MenuItem>
+          <MenuItem value="public">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="public" size={16} />
+              Public — All users
+            </Box>
+          </MenuItem>
+          <MenuItem value="shared">
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <MaterialSymbol icon="group" size={16} />
+              Shared — Specific users
+            </Box>
+          </MenuItem>
+        </TextField>
+
+        {visibility === "shared" && (
+          <Autocomplete
+            multiple
+            options={users.filter((u) => u.is_active)}
+            getOptionLabel={(u) => `${u.display_name} (${u.email})`}
+            value={sharedWith}
+            onChange={(_, v) => setSharedWith(v)}
+            renderTags={(value, getTagProps) =>
+              value.map((u, idx) => (
+                <Chip label={u.display_name} size="small" {...getTagProps({ index: idx })} key={u.id} />
+              ))
+            }
+            renderInput={(params) => (
+              <TextField {...params} label="Share with" size="small" placeholder="Search users..." />
+            )}
+            size="small"
+          />
+        )}
+
+        {thumbnail && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+              Preview
+            </Typography>
+            <Box
+              component="img"
+              src={thumbnail}
+              alt="Report preview"
+              sx={{ width: "100%", maxHeight: 150, objectFit: "contain", borderRadius: 1, border: "1px solid", borderColor: "divider" }}
+            />
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!name.trim() || saving}
+          startIcon={saving ? <CircularProgress size={16} /> : <MaterialSymbol icon="save" size={18} />}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/reports/SavedReportsPage.tsx
+++ b/frontend/src/features/reports/SavedReportsPage.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardActionArea from "@mui/material/CardActionArea";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import CircularProgress from "@mui/material/CircularProgress";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import Alert from "@mui/material/Alert";
+import MaterialSymbol from "@/components/MaterialSymbol";
+import EditReportDialog from "./EditReportDialog";
+import { api } from "@/api/client";
+import type { SavedReport } from "@/types";
+
+const REPORT_TYPE_META: Record<string, { label: string; icon: string; color: string; path: string }> = {
+  portfolio: { label: "Portfolio", icon: "dashboard", color: "#1976d2", path: "/reports/portfolio" },
+  "capability-map": { label: "Capability Map", icon: "grid_view", color: "#003399", path: "/reports/capability-map" },
+  lifecycle: { label: "Lifecycle", icon: "timeline", color: "#2e7d32", path: "/reports/lifecycle" },
+  dependencies: { label: "Dependencies", icon: "hub", color: "#e65100", path: "/reports/dependencies" },
+  cost: { label: "Cost", icon: "payments", color: "#6a1b9a", path: "/reports/cost" },
+  matrix: { label: "Matrix", icon: "table_chart", color: "#6a1b9a", path: "/reports/matrix" },
+  "data-quality": { label: "Data Quality", icon: "verified", color: "#00695c", path: "/reports/data-quality" },
+  eol: { label: "End of Life", icon: "update", color: "#bf360c", path: "/reports/eol" },
+};
+
+const VISIBILITY_ICONS: Record<string, { icon: string; label: string; color: string }> = {
+  private: { icon: "lock", label: "Private", color: "#757575" },
+  public: { icon: "public", label: "Public", color: "#2e7d32" },
+  shared: { icon: "group", label: "Shared", color: "#1565c0" },
+};
+
+export default function SavedReportsPage() {
+  const navigate = useNavigate();
+  const [reports, setReports] = useState<SavedReport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState(0); // 0 = My Reports, 1 = Shared with Me, 2 = Public
+  const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; report: SavedReport } | null>(null);
+  const [editReport, setEditReport] = useState<SavedReport | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<SavedReport | null>(null);
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    try {
+      const filter = tab === 0 ? "my" : tab === 1 ? "shared" : "public";
+      const data = await api.get<SavedReport[]>(`/saved-reports?filter=${filter}`);
+      setReports(data);
+    } catch {
+      setReports([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  const handleOpen = (report: SavedReport) => {
+    const meta = REPORT_TYPE_META[report.report_type];
+    if (meta) {
+      navigate(`${meta.path}?saved_report_id=${report.id}`);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteConfirm) return;
+    try {
+      await api.delete(`/saved-reports/${deleteConfirm.id}`);
+      setDeleteConfirm(null);
+      fetchReports();
+    } catch {
+      // error handled by api client
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 1200, mx: "auto" }}>
+      {/* Header */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+        <MaterialSymbol icon="bookmarks" size={26} color="#1976d2" />
+        <Typography variant="h5" sx={{ fontWeight: 700, flex: 1 }}>
+          Saved Reports
+        </Typography>
+      </Box>
+
+      {/* Tabs */}
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3 }}>
+        <Tab
+          label="My Reports"
+          icon={<MaterialSymbol icon="person" size={18} />}
+          iconPosition="start"
+          sx={{ textTransform: "none", minHeight: 42 }}
+        />
+        <Tab
+          label="Shared with Me"
+          icon={<MaterialSymbol icon="group" size={18} />}
+          iconPosition="start"
+          sx={{ textTransform: "none", minHeight: 42 }}
+        />
+        <Tab
+          label="Public"
+          icon={<MaterialSymbol icon="public" size={18} />}
+          iconPosition="start"
+          sx={{ textTransform: "none", minHeight: 42 }}
+        />
+      </Tabs>
+
+      {/* Content */}
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : reports.length === 0 ? (
+        <Alert severity="info" sx={{ maxWidth: 500 }}>
+          {tab === 0
+            ? "You haven't saved any reports yet. Open a report, configure it, and click the save button to create one."
+            : tab === 1
+              ? "No reports have been shared with you yet."
+              : "No public reports available."}
+        </Alert>
+      ) : (
+        <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))", gap: 2 }}>
+          {reports.map((report) => {
+            const meta = REPORT_TYPE_META[report.report_type] || {
+              label: report.report_type,
+              icon: "analytics",
+              color: "#666",
+              path: "#",
+            };
+            const vis = VISIBILITY_ICONS[report.visibility] || VISIBILITY_ICONS.private;
+
+            return (
+              <Card key={report.id} variant="outlined" sx={{ position: "relative" }}>
+                <CardActionArea onClick={() => handleOpen(report)}>
+                  {/* Thumbnail */}
+                  {report.thumbnail ? (
+                    <Box
+                      component="img"
+                      src={report.thumbnail}
+                      alt={report.name}
+                      sx={{
+                        width: "100%",
+                        height: 160,
+                        objectFit: "cover",
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                        bgcolor: "#fafafa",
+                      }}
+                    />
+                  ) : (
+                    <Box
+                      sx={{
+                        width: "100%",
+                        height: 160,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: `${meta.color}08`,
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                      }}
+                    >
+                      <MaterialSymbol icon={meta.icon} size={56} color={`${meta.color}40`} />
+                    </Box>
+                  )}
+                  <CardContent sx={{ pb: "12px !important" }}>
+                    <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1, mb: 0.5 }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1, lineHeight: 1.3 }} noWrap>
+                        {report.name}
+                      </Typography>
+                    </Box>
+                    {report.description && (
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+                        {report.description}
+                      </Typography>
+                    )}
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                      <Chip
+                        icon={<MaterialSymbol icon={meta.icon} size={14} />}
+                        label={meta.label}
+                        size="small"
+                        sx={{ height: 22, fontSize: "0.7rem", bgcolor: `${meta.color}14`, color: meta.color, fontWeight: 600 }}
+                      />
+                      <Chip
+                        icon={<MaterialSymbol icon={vis.icon} size={14} />}
+                        label={vis.label}
+                        size="small"
+                        variant="outlined"
+                        sx={{ height: 22, fontSize: "0.7rem", color: vis.color, borderColor: `${vis.color}40` }}
+                      />
+                      {!report.is_owner && report.owner_name && (
+                        <Typography variant="caption" color="text.secondary">
+                          by {report.owner_name}
+                        </Typography>
+                      )}
+                    </Box>
+                  </CardContent>
+                </CardActionArea>
+
+                {/* Actions menu (owner only) */}
+                {report.is_owner && (
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenuAnchor({ el: e.currentTarget, report });
+                    }}
+                    sx={{ position: "absolute", top: 8, right: 8, bgcolor: "rgba(255,255,255,0.85)", "&:hover": { bgcolor: "rgba(255,255,255,0.95)" } }}
+                  >
+                    <MaterialSymbol icon="more_vert" size={18} />
+                  </IconButton>
+                )}
+              </Card>
+            );
+          })}
+        </Box>
+      )}
+
+      {/* Actions menu */}
+      <Menu
+        anchorEl={menuAnchor?.el}
+        open={!!menuAnchor}
+        onClose={() => setMenuAnchor(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            setEditReport(menuAnchor!.report);
+            setMenuAnchor(null);
+          }}
+        >
+          <ListItemIcon><MaterialSymbol icon="edit" size={18} /></ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setDeleteConfirm(menuAnchor!.report);
+            setMenuAnchor(null);
+          }}
+          sx={{ color: "error.main" }}
+        >
+          <ListItemIcon><MaterialSymbol icon="delete" size={18} color="#d32f2f" /></ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      {/* Edit dialog */}
+      <EditReportDialog
+        open={!!editReport}
+        report={editReport}
+        onClose={() => setEditReport(null)}
+        onUpdated={fetchReports}
+      />
+
+      {/* Delete confirmation */}
+      <Dialog open={!!deleteConfirm} onClose={() => setDeleteConfirm(null)} maxWidth="xs">
+        <DialogTitle>Delete Saved Report</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete <strong>{deleteConfirm?.name}</strong>? This cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirm(null)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/hooks/useSavedReport.ts
+++ b/frontend/src/hooks/useSavedReport.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { api } from "@/api/client";
+import type { SavedReport } from "@/types";
+
+/**
+ * Hook for loading and saving report configurations.
+ *
+ * Usage in a report component:
+ *   const { savedReport, saveDialogOpen, setSaveDialogOpen, getConfig, applyConfig, resetSavedReport } = useSavedReport("portfolio");
+ *
+ * - On mount, if URL has ?saved_report_id=..., fetches and returns the config
+ * - `applyConfig` is called once after the saved config is fetched
+ * - `getConfig` should be called when user wants to save
+ */
+export function useSavedReport(reportType: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [savedReport, setSavedReport] = useState<SavedReport | null>(null);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [loadedConfig, setLoadedConfig] = useState<Record<string, unknown> | null>(null);
+  const appliedRef = useRef(false);
+
+  const savedReportId = searchParams.get("saved_report_id");
+
+  useEffect(() => {
+    if (!savedReportId) {
+      setSavedReport(null);
+      setLoadedConfig(null);
+      appliedRef.current = false;
+      return;
+    }
+    api.get<SavedReport>(`/saved-reports/${savedReportId}`)
+      .then((r) => {
+        setSavedReport(r);
+        setLoadedConfig(r.config);
+        appliedRef.current = false;
+      })
+      .catch(() => {
+        setSavedReport(null);
+        setLoadedConfig(null);
+      });
+  }, [savedReportId]);
+
+  const resetSavedReport = useCallback(() => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.delete("saved_report_id");
+    setSearchParams(newParams, { replace: true });
+    setSavedReport(null);
+    setLoadedConfig(null);
+    appliedRef.current = false;
+  }, [searchParams, setSearchParams]);
+
+  /**
+   * Call this in your component to consume the loaded config exactly once.
+   * Returns the config if not yet applied, or null otherwise.
+   */
+  const consumeConfig = useCallback((): Record<string, unknown> | null => {
+    if (loadedConfig && !appliedRef.current) {
+      appliedRef.current = true;
+      return loadedConfig;
+    }
+    return null;
+  }, [loadedConfig]);
+
+  return {
+    savedReport,
+    savedReportName: savedReport?.name || null,
+    saveDialogOpen,
+    setSaveDialogOpen,
+    loadedConfig,
+    consumeConfig,
+    resetSavedReport,
+    reportType,
+  };
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -63,6 +63,7 @@ const NAV_ITEMS: NavItemWithPermission[] = [
       { label: "Matrix", icon: "table_chart", path: "/reports/matrix" },
       { label: "Data Quality", icon: "verified", path: "/reports/data-quality" },
       { label: "End of Life", icon: "update", path: "/reports/eol" },
+      { label: "Saved Reports", icon: "bookmarks", path: "/reports/saved" },
     ],
   },
   { label: "BPM", icon: "route", path: "/bpm", permission: "bpm.view" },
@@ -633,21 +634,26 @@ export default function AppLayout({ children, user, onLogout }: Props) {
             open={!!reportsMenu}
             onClose={() => setReportsMenu(null)}
           >
-            {navItems.find((n) => n.children)?.children?.map((child) => (
-              <MenuItem
-                key={child.path}
-                selected={isActive(child.path)}
-                onClick={() => {
-                  navigate(child.path);
-                  setReportsMenu(null);
-                }}
-              >
-                <ListItemIcon>
-                  <MaterialSymbol icon={child.icon} size={18} />
-                </ListItemIcon>
-                <ListItemText>{child.label}</ListItemText>
-              </MenuItem>
-            ))}
+            {navItems.find((n) => n.children)?.children?.map((child, idx, arr) => {
+              const isSavedReports = child.path === "/reports/saved";
+              return (
+                <Box key={child.path}>
+                  {isSavedReports && idx > 0 && <Divider sx={{ my: 0.5 }} />}
+                  <MenuItem
+                    selected={isActive(child.path)}
+                    onClick={() => {
+                      navigate(child.path);
+                      setReportsMenu(null);
+                    }}
+                  >
+                    <ListItemIcon>
+                      <MaterialSymbol icon={child.icon} size={18} />
+                    </ListItemIcon>
+                    <ListItemText>{child.label}</ListItemText>
+                  </MenuItem>
+                </Box>
+              );
+            })}
           </Menu>
 
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -281,6 +281,23 @@ export interface Bookmark {
   created_at?: string;
 }
 
+export interface SavedReport {
+  id: string;
+  owner_id: string;
+  owner_name?: string;
+  name: string;
+  description?: string;
+  report_type: string;
+  config: Record<string, unknown>;
+  thumbnail?: string;
+  visibility: "private" | "public" | "shared";
+  shared_with: string[];
+  shared_with_users?: { id: string; display_name: string; email: string }[];
+  is_owner: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
 export interface EventEntry {
   id: string;
   card_id?: string;


### PR DESCRIPTION
Users can now save customized report views with name, description, and
sharing settings. Saved reports appear in a dedicated page accessible
from the Reports menu. Reports can be private, shared with specific
users, or made public. Viewers cannot create saved reports but can
access public/shared ones (RBAC enforced via saved_reports.create
permission).

Backend: new saved_reports + saved_report_shares tables, CRUD API at
/saved-reports, Alembic migration 025, Pydantic schemas, permission
registration.

Frontend: SaveReportDialog, EditReportDialog, SavedReportsPage with
My/Shared/Public tabs, useSavedReport hook, ReportShell save button
+ banner, all 8 report components updated with save/load support.

https://claude.ai/code/session_01MNXcq6WHwbv7a8osJwUaXT