### PR TITLE
Add report preview thumbnails to saved reports

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "docx": "^9.5.1",
         "dompurify": "^3.3.1",
         "file-saver": "^2.0.5",
+        "html-to-image": "^1.11.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.0",
@@ -3454,6 +3455,12 @@
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/ids": {
       "version": "3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "docx": "^9.5.1",
     "dompurify": "^3.3.1",
     "file-saver": "^2.0.5",
+    "html-to-image": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.0",

--- a/frontend/src/features/reports/CapabilityMapReport.tsx
+++ b/frontend/src/features/reports/CapabilityMapReport.tsx
@@ -22,6 +22,7 @@ import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -655,6 +656,7 @@ export default function CapabilityMapReport() {
   const navigate = useNavigate();
   const { fmtShort } = useCurrency();
   const saved = useSavedReport("capability-map");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
 
   // Data
   const [data, setData] = useState<CapItem[] | null>(null);
@@ -834,7 +836,8 @@ export default function CapabilityMapReport() {
       icon="grid_view"
       iconColor="#003399"
       hasTableToggle={false}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -1213,6 +1216,7 @@ export default function CapabilityMapReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="capability-map"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/CostReport.tsx
+++ b/frontend/src/features/reports/CostReport.tsx
@@ -19,6 +19,7 @@ import MetricCard from "./MetricCard";
 import TimelineSlider from "@/components/TimelineSlider";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { useCurrency } from "@/hooks/useCurrency";
 import { api } from "@/api/client";
 import type { FieldDef } from "@/types";
@@ -104,6 +105,7 @@ export default function CostReport() {
   const { types, loading: ml } = useMetamodel();
   const { fmt } = useCurrency();
   const saved = useSavedReport("cost");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [cardTypeKey, setCardTypeKey] = useState("Application");
   const [costField, setCostField] = useState("totalAnnualCost");
   const [groupBy, setGroupBy] = useState("");
@@ -252,7 +254,8 @@ export default function CostReport() {
       iconColor="#2e7d32"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -382,6 +385,7 @@ export default function CostReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="cost"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/DataQualityReport.tsx
+++ b/frontend/src/features/reports/DataQualityReport.tsx
@@ -18,6 +18,7 @@ import SaveReportDialog from "./SaveReportDialog";
 import MetricCard from "./MetricCard";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { api } from "@/api/client";
 
 interface TypeStat {
@@ -69,6 +70,7 @@ export default function DataQualityReport() {
   const navigate = useNavigate();
   const { types } = useMetamodel();
   const saved = useSavedReport("data-quality");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [data, setData] = useState<DQData | null>(null);
   const [view, setView] = useState<"chart" | "table">("chart");
 
@@ -134,7 +136,8 @@ export default function DataQualityReport() {
       iconColor="#2e7d32"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
     >
@@ -387,6 +390,7 @@ export default function DataQualityReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="data-quality"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/DependencyReport.tsx
+++ b/frontend/src/features/reports/DependencyReport.tsx
@@ -22,6 +22,7 @@ import SaveReportDialog from "./SaveReportDialog";
 import MaterialSymbol from "@/components/MaterialSymbol";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { api } from "@/api/client";
 import type { CardType } from "@/types";
 
@@ -344,6 +345,7 @@ export default function DependencyReport() {
   const navigate = useNavigate();
   const { types } = useMetamodel();
   const saved = useSavedReport("dependencies");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [cardTypeKey, setCardTypeKey] = useState("");
   const [center, setCenter] = useState("");
   const [nodes, setNodes] = useState<GNode[]>([]);
@@ -518,7 +520,8 @@ export default function DependencyReport() {
       iconColor="#6a1b9a"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -1232,6 +1235,7 @@ export default function DependencyReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="dependencies"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/EolReport.tsx
+++ b/frontend/src/features/reports/EolReport.tsx
@@ -21,6 +21,7 @@ import SaveReportDialog from "./SaveReportDialog";
 import ReportLegend from "./ReportLegend";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { api } from "@/api/client";
 
 /* ------------------------------------------------------------------ */
@@ -187,6 +188,7 @@ export default function EolReport() {
   const navigate = useNavigate();
   const { getType } = useMetamodel();
   const saved = useSavedReport("eol");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [data, setData] = useState<EolReportData | null>(null);
   const [view, setView] = useState<"chart" | "table">("chart");
   const [filterStatus, setFilterStatus] = useState("");
@@ -317,7 +319,8 @@ export default function EolReport() {
       iconColor="#d32f2f"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -1037,6 +1040,7 @@ export default function EolReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="eol"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/LifecycleReport.tsx
+++ b/frontend/src/features/reports/LifecycleReport.tsx
@@ -23,6 +23,7 @@ import SaveReportDialog from "./SaveReportDialog";
 import ReportLegend from "./ReportLegend";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { api } from "@/api/client";
 
 /* ------------------------------------------------------------------ */
@@ -110,6 +111,7 @@ export default function LifecycleReport() {
   const navigate = useNavigate();
   const { types, loading: ml } = useMetamodel();
   const saved = useSavedReport("lifecycle");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [cardTypeKey, setCardTypeKey] = useState("");
   const [data, setData] = useState<RoadmapItem[] | null>(null);
   const [view, setView] = useState<"chart" | "table">("chart");
@@ -254,7 +256,8 @@ export default function LifecycleReport() {
       iconColor="#e65100"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -548,6 +551,7 @@ export default function LifecycleReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="lifecycle"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/MatrixReport.tsx
+++ b/frontend/src/features/reports/MatrixReport.tsx
@@ -17,6 +17,7 @@ import SaveReportDialog from "./SaveReportDialog";
 import MetricCard from "./MetricCard";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 import { api } from "@/api/client";
 
 interface MatrixData {
@@ -42,6 +43,7 @@ export default function MatrixReport() {
   const navigate = useNavigate();
   const { types, loading: ml } = useMetamodel();
   const saved = useSavedReport("matrix");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
   const [rowType, setRowType] = useState("Application");
   const [colType, setColType] = useState("BusinessCapability");
   const [data, setData] = useState<MatrixData | null>(null);
@@ -166,7 +168,8 @@ export default function MatrixReport() {
       icon="table_chart"
       iconColor="#6a1b9a"
       hasTableToggle={false}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -444,6 +447,7 @@ export default function MatrixReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="matrix"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/features/reports/PortfolioReport.tsx
+++ b/frontend/src/features/reports/PortfolioReport.tsx
@@ -27,6 +27,7 @@ import MaterialSymbol from "@/components/MaterialSymbol";
 import { api } from "@/api/client";
 import { useMetamodel } from "@/hooks/useMetamodel";
 import { useSavedReport } from "@/hooks/useSavedReport";
+import { useThumbnailCapture } from "@/hooks/useThumbnailCapture";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -527,6 +528,7 @@ export default function PortfolioReport() {
   const navigate = useNavigate();
   const { types: metamodelTypes } = useMetamodel();
   const saved = useSavedReport("portfolio");
+  const { chartRef, thumbnail, captureAndSave } = useThumbnailCapture(() => saved.setSaveDialogOpen(true));
 
   // Data
   const [data, setData] = useState<ApiResponse | null>(null);
@@ -781,7 +783,8 @@ export default function PortfolioReport() {
       iconColor="#0f7eb5"
       view={view}
       onViewChange={setView}
-      onSaveReport={() => saved.setSaveDialogOpen(true)}
+      chartRef={chartRef}
+      onSaveReport={captureAndSave}
       savedReportName={saved.savedReportName ?? undefined}
       onResetSavedReport={saved.resetSavedReport}
       toolbar={
@@ -1378,6 +1381,7 @@ export default function PortfolioReport() {
         onClose={() => saved.setSaveDialogOpen(false)}
         reportType="portfolio"
         config={getConfig()}
+        thumbnail={thumbnail}
       />
     </ReportShell>
   );

--- a/frontend/src/hooks/useThumbnailCapture.ts
+++ b/frontend/src/hooks/useThumbnailCapture.ts
@@ -1,0 +1,31 @@
+import { useRef, useState, useCallback } from "react";
+import { toPng } from "html-to-image";
+
+/**
+ * Hook for capturing a DOM element as a thumbnail preview image.
+ * Returns a ref to attach to the chart container, the captured thumbnail,
+ * and a function that captures the screenshot and opens the save dialog.
+ */
+export function useThumbnailCapture(openDialog: () => void) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [thumbnail, setThumbnail] = useState<string | undefined>();
+
+  const captureAndSave = useCallback(async () => {
+    if (chartRef.current) {
+      try {
+        const dataUrl = await toPng(chartRef.current, {
+          cacheBust: true,
+          pixelRatio: 1,
+          quality: 0.8,
+          backgroundColor: "#ffffff",
+        });
+        setThumbnail(dataUrl);
+      } catch {
+        setThumbnail(undefined);
+      }
+    }
+    openDialog();
+  }, [openDialog]);
+
+  return { chartRef, thumbnail, captureAndSave };
+}


### PR DESCRIPTION
Capture a screenshot of the chart area when saving a report using
html-to-image, and store it as a base64 thumbnail. The preview is
shown in the SaveReportDialog and on saved report cards.

https://claude.ai/code/session_01MhRvdyZkpJxaPNFP8QmULK