### PR TITLE
Add hierarchical sorting support to matrix reports

### DIFF
--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -427,8 +427,8 @@ async def matrix(
             intersections.add((tid, sid))
 
     return {
-        "rows": [{"id": str(r.id), "name": r.name} for r in rows],
-        "columns": [{"id": str(c.id), "name": c.name} for c in cols],
+        "rows": [{"id": str(r.id), "name": r.name, "parent_id": str(r.parent_id) if r.parent_id else None} for r in rows],
+        "columns": [{"id": str(c.id), "name": c.name, "parent_id": str(c.parent_id) if c.parent_id else None} for c in cols],
         "intersections": [{"row_id": r, "col_id": c} for r, c in intersections],
     }
 


### PR DESCRIPTION
## Summary
This PR adds support for hierarchical sorting in matrix reports, allowing rows and columns to be organized by their parent-child relationships when the underlying data type supports hierarchy.

## Key Changes

**Frontend (MatrixReport.tsx):**
- Added `MatrixItem` interface to include `parent_id` field for hierarchy support
- Introduced `SortMode` type to support three sorting options: "alpha", "count", and "hierarchy"
- Implemented `hierarchySort()` function that organizes items by parent-child relationships with alphabetical sorting within each level
- Added validation logic to reset hierarchy sort to alphabetical when switching to non-hierarchical data types
- Enhanced row/column headers with visual hierarchy indicators:
  - Indentation based on depth in hierarchy (16px per level)
  - Bold font weight for parent items
  - "└ " prefix for child items
- Updated sort dropdown menus to conditionally show "Hierarchy" option only when the data type supports it
- Modified `MetricCard` calls to use dynamic icons and colors from type metadata
- Added `getDepth()` utility function to calculate indentation levels

**Backend (reports.py):**
- Updated matrix report endpoint to include `parent_id` field in row and column responses
- Properly serializes `parent_id` as string or null to match frontend expectations

## Implementation Details
- Hierarchy sorting uses a depth-first traversal approach, maintaining alphabetical order within each parent group
- The implementation gracefully handles cases where parent references don't exist in the current dataset
- Sort mode validation ensures users cannot select hierarchy sorting for non-hierarchical data types
- Visual hierarchy is only applied when hierarchy sort mode is active, maintaining clean UI for other sort modes

https://claude.ai/code/session_01TgWc619Tm6pWr2qQEYoCCi