### PR TITLE
Add dedicated 'cost' field type to distinguish cost fields from plain…

### DIFF
--- a/backend/alembic/versions/026_add_cost_field_type.py
+++ b/backend/alembic/versions/026_add_cost_field_type.py
@@ -1,0 +1,92 @@
+"""Migrate cost-related fields from type 'number' to type 'cost'.
+
+Introduces a dedicated 'cost' field type so cost fields are distinguished
+from plain numeric fields (e.g. "Number of Users").  Updates built-in
+card types (Application, ITComponent, Initiative) and the relAppToITC
+relation type.
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-02-17
+"""
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "026"
+down_revision: Union[str, None] = "025"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Field keys that should be migrated from "number" to "cost"
+COST_FIELD_KEYS = {"costTotalAnnual", "costBudget", "costActual"}
+
+
+def _migrate_card_type_fields(conn, type_key: str, to_type: str, from_type: str) -> None:
+    result = conn.execute(
+        sa.text("SELECT fields_schema FROM card_types WHERE key = :key"),
+        {"key": type_key},
+    ).fetchone()
+
+    if not result or not result[0]:
+        return
+
+    schema = result[0] if isinstance(result[0], list) else json.loads(result[0])
+    changed = False
+
+    for section in schema:
+        for field in section.get("fields", []):
+            if field.get("key") in COST_FIELD_KEYS and field.get("type") == from_type:
+                field["type"] = to_type
+                changed = True
+
+    if changed:
+        conn.execute(
+            sa.text("UPDATE card_types SET fields_schema = :schema WHERE key = :key"),
+            {"schema": json.dumps(schema), "key": type_key},
+        )
+
+
+def _migrate_relation_type_attrs(conn, type_key: str, to_type: str, from_type: str) -> None:
+    result = conn.execute(
+        sa.text("SELECT attributes_schema FROM relation_types WHERE key = :key"),
+        {"key": type_key},
+    ).fetchone()
+
+    if not result or not result[0]:
+        return
+
+    schema = result[0] if isinstance(result[0], list) else json.loads(result[0])
+    changed = False
+
+    for field in schema:
+        if field.get("key") in COST_FIELD_KEYS and field.get("type") == from_type:
+            field["type"] = to_type
+            changed = True
+
+    if changed:
+        conn.execute(
+            sa.text("UPDATE relation_types SET attributes_schema = :schema WHERE key = :key"),
+            {"schema": json.dumps(schema), "key": type_key},
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for type_key in ("Application", "ITComponent", "Initiative"):
+        _migrate_card_type_fields(conn, type_key, to_type="cost", from_type="number")
+
+    _migrate_relation_type_attrs(conn, "relAppToITC", to_type="cost", from_type="number")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    for type_key in ("Application", "ITComponent", "Initiative"):
+        _migrate_card_type_fields(conn, type_key, to_type="number", from_type="cost")
+
+    _migrate_relation_type_attrs(conn, "relAppToITC", to_type="number", from_type="cost")

--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -199,7 +199,7 @@ async def portfolio(
     type: str = Query("Application"),
     x_axis: str = Query("functionalFit"),
     y_axis: str = Query("technicalFit"),
-    size_field: str = Query("totalAnnualCost"),
+    size_field: str = Query("costTotalAnnual"),
     color_field: str = Query("businessCriticality"),
 ):
     """Portfolio scatter/bubble chart data."""
@@ -477,7 +477,8 @@ async def cost_report(
     items = []
     total = 0
     for card in sheets:
-        cost = (card.attributes or {}).get("totalAnnualCost", 0) or 0
+        attrs = card.attributes or {}
+        cost = attrs.get("costTotalAnnual", 0) or attrs.get("totalAnnualCost", 0) or 0
         if cost:
             items.append({"id": str(card.id), "name": card.name, "cost": cost})
             total += cost
@@ -490,7 +491,7 @@ async def cost_treemap(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
     type: str = Query("Application"),
-    cost_field: str = Query("totalAnnualCost"),
+    cost_field: str = Query("costTotalAnnual"),
     group_by: str | None = Query(None),
 ):
     """Cost treemap: items with cost, optionally grouped by a related type."""

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -226,8 +226,8 @@ TYPES = [
             {
                 "section": "Cost & Timeline",
                 "fields": [
-                    {"key": "costBudget", "label": "Budget", "type": "number", "weight": 1},
-                    {"key": "costActual", "label": "Actual Cost", "type": "number", "weight": 0},
+                    {"key": "costBudget", "label": "Budget", "type": "cost", "weight": 1},
+                    {"key": "costActual", "label": "Actual Cost", "type": "cost", "weight": 0},
                     {"key": "startDate", "label": "Start Date", "type": "date", "weight": 1},
                     {"key": "endDate", "label": "End Date", "type": "date", "weight": 1},
                 ],
@@ -407,7 +407,7 @@ TYPES = [
             {
                 "section": "Cost & Ownership",
                 "fields": [
-                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "number", "weight": 1},
+                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "cost", "weight": 1},
                     {"key": "numberOfUsers", "label": "Number of Users", "type": "number", "weight": 0},
                     {"key": "vendor", "label": "Vendor", "type": "text", "weight": 0},
                     {"key": "productName", "label": "Product Name", "type": "text", "weight": 0},
@@ -493,7 +493,7 @@ TYPES = [
             {
                 "section": "Cost",
                 "fields": [
-                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "number", "weight": 1},
+                    {"key": "costTotalAnnual", "label": "Total Annual Cost", "type": "cost", "weight": 1},
                     {"key": "licenseType", "label": "License Type", "type": "text", "weight": 0},
                 ],
             },
@@ -611,7 +611,7 @@ RELATIONS = [
     ]},
     {"key": "relAppToITC", "label": "uses", "reverse_label": "is used by", "source_type_key": "Application", "target_type_key": "ITComponent", "cardinality": "n:m", "sort_order": 21, "attributes_schema": [
         {"key": "technicalSuitability", "label": "Technical Suitability", "type": "single_select", "options": TECHNICAL_SUITABILITY_OPTIONS},
-        {"key": "costTotalAnnual", "label": "Annual Cost", "type": "number"},
+        {"key": "costTotalAnnual", "label": "Annual Cost", "type": "cost"},
     ]},
     {"key": "relAppToSystem", "label": "runs on", "reverse_label": "runs", "source_type_key": "Application", "target_type_key": "System", "cardinality": "n:m", "sort_order": 22},
 

--- a/frontend/src/components/CreateCardDialog.tsx
+++ b/frontend/src/components/CreateCardDialog.tsx
@@ -305,6 +305,7 @@ export default function CreateCardDialog({
           </FormControl>
         );
 
+      case "cost":
       case "number":
         return (
           <TextField

--- a/frontend/src/features/admin/MetamodelAdmin.tsx
+++ b/frontend/src/features/admin/MetamodelAdmin.tsx
@@ -51,6 +51,7 @@ import type {
 const FIELD_TYPE_OPTIONS: { value: FieldDef["type"]; label: string }[] = [
   { value: "text", label: "Text" },
   { value: "number", label: "Number" },
+  { value: "cost", label: "Cost" },
   { value: "boolean", label: "Boolean" },
   { value: "date", label: "Date" },
   { value: "single_select", label: "Single Select" },

--- a/frontend/src/features/cards/CardDetail.tsx
+++ b/frontend/src/features/cards/CardDetail.tsx
@@ -40,8 +40,10 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
 import Autocomplete from "@mui/material/Autocomplete";
+import InputAdornment from "@mui/material/InputAdornment";
 import ProcessFlowTab from "@/features/bpm/ProcessFlowTab";
 import ProcessAssessmentPanel from "@/features/bpm/ProcessAssessmentPanel";
+import { useCurrency } from "@/hooks/useCurrency";
 import type {
   Card,
   Relation,
@@ -121,6 +123,7 @@ const PHASE_LABELS: Record<string, string> = {
 
 // ── Read-only field value renderer ──────────────────────────────
 function FieldValue({ field, value }: { field: FieldDef; value: unknown }) {
+  const { fmt } = useCurrency();
   if (field.type === "single_select" && field.options) {
     const opt = field.options.find((o) => o.key === value);
     return opt ? (
@@ -144,6 +147,13 @@ function FieldValue({ field, value }: { field: FieldDef; value: unknown }) {
       />
     );
   }
+  if (field.type === "cost") {
+    return (
+      <Typography variant="body2">
+        {value != null && value !== "" ? fmt.format(Number(value)) : "—"}
+      </Typography>
+    );
+  }
   return (
     <Typography variant="body2">
       {value != null && value !== "" ? String(value) : "—"}
@@ -161,6 +171,7 @@ function FieldEditor({
   value: unknown;
   onChange: (v: unknown) => void;
 }) {
+  const { symbol } = useCurrency();
   switch (field.type) {
     case "single_select":
       return (
@@ -193,6 +204,20 @@ function FieldEditor({
             ))}
           </Select>
         </FormControl>
+      );
+    case "cost":
+      return (
+        <TextField
+          size="small"
+          label={field.label}
+          type="number"
+          value={value ?? ""}
+          onChange={(e) =>
+            onChange(e.target.value ? Number(e.target.value) : undefined)
+          }
+          slotProps={{ input: { startAdornment: <InputAdornment position="start">{symbol}</InputAdornment> } }}
+          sx={{ minWidth: 200 }}
+        />
       );
     case "number":
       return (

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -705,7 +705,7 @@ export default function InventoryPage() {
       );
     }
 
-    if (fd.type === "number") {
+    if (fd.type === "number" || fd.type === "cost") {
       return (
         <TextField
           fullWidth

--- a/frontend/src/features/inventory/excelImport.ts
+++ b/frontend/src/features/inventory/excelImport.ts
@@ -359,6 +359,7 @@ export function validateImport(
 
       // Validate by field type
       switch (field.type) {
+        case "cost":
         case "number": {
           // Rule 11
           const num = Number(val);

--- a/frontend/src/features/surveys/SurveyRespond.tsx
+++ b/frontend/src/features/surveys/SurveyRespond.tsx
@@ -187,7 +187,7 @@ export default function SurveyRespond() {
       );
     }
 
-    if (field.type === "number") {
+    if (field.type === "number" || field.type === "cost") {
       return (
         <TextField
           type="number"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,7 +99,7 @@ export interface FieldOption {
 export interface FieldDef {
   key: string;
   label: string;
-  type: "text" | "number" | "boolean" | "date" | "single_select" | "multiple_select";
+  type: "text" | "number" | "cost" | "boolean" | "date" | "single_select" | "multiple_select";
   options?: FieldOption[];
   required?: boolean;
   weight?: number;


### PR DESCRIPTION
… numbers

The cost report previously showed all number fields (including "Number of Users") in the cost field dropdown. This introduces a proper 'cost' field type that:

- Displays values with the configured currency symbol in card detail views
- Shows a currency adornment when editing cost fields
- Filters the cost report dropdown to only show cost-typed fields
- Auto-selects the cost field when a card type has exactly one
- Migrates existing cost fields (costTotalAnnual, costBudget, costActual) from 'number' to 'cost' type via Alembic migration 026

https://claude.ai/code/session_01QC6hTEvADzJ3Gp14hEhj6R