### PR TITLE
Rename subscribers to stakeholders and filter hidden types

### DIFF
--- a/frontend/src/components/CreateCardDialog.tsx
+++ b/frontend/src/components/CreateCardDialog.tsx
@@ -408,7 +408,7 @@ export default function CreateCardDialog({
             label="Type"
             onChange={(e) => setSelectedType(e.target.value)}
           >
-            {types.map((t) => (
+            {types.filter((t) => !t.is_hidden).map((t) => (
               <MenuItem key={t.key} value={t.key}>
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Box

--- a/frontend/src/features/admin/SurveyBuilder.tsx
+++ b/frontend/src/features/admin/SurveyBuilder.tsx
@@ -736,7 +736,7 @@ export default function SurveyBuilder() {
 
               {preview.total_cards === 0 && (
                 <Alert severity="warning" sx={{ mb: 2 }}>
-                  No cards matched your filters, or no subscribers were found with the selected roles.
+                  No cards matched your filters, or no stakeholders were found with the selected roles.
                   Go back and adjust your targeting criteria.
                 </Alert>
               )}

--- a/frontend/src/features/admin/WebPortalsAdmin.tsx
+++ b/frontend/src/features/admin/WebPortalsAdmin.tsx
@@ -38,7 +38,7 @@ const BUILT_IN_PROPERTIES = [
   { key: "description", label: "Description" },
   { key: "lifecycle", label: "Lifecycle" },
   { key: "tags", label: "Tags" },
-  { key: "subscribers", label: "Team / Subscribers" },
+  { key: "subscribers", label: "Team / Stakeholders" },
   { key: "data_quality", label: "Data Quality" },
   { key: "approval_status", label: "Approval Status" },
 ];

--- a/frontend/src/features/dashboard/Dashboard.tsx
+++ b/frontend/src/features/dashboard/Dashboard.tsx
@@ -120,7 +120,7 @@ export default function Dashboard() {
   if (!data) return <LinearProgress />;
 
   const typeCards = types.filter(
-    (t) => (data.by_type[t.key] ?? 0) > 0 || ["Application", "BusinessCapability", "ITComponent", "Initiative"].includes(t.key),
+    (t) => !t.is_hidden && ((data.by_type[t.key] ?? 0) > 0 || ["Application", "BusinessCapability", "ITComponent", "Initiative"].includes(t.key)),
   );
 
   return (

--- a/frontend/src/features/reports/CostReport.tsx
+++ b/frontend/src/features/reports/CostReport.tsx
@@ -270,7 +270,7 @@ export default function CostReport() {
       toolbar={
         <>
           <TextField select size="small" label="Card Type" value={cardTypeKey} onChange={(e) => setCardTypeKey(e.target.value)} sx={{ minWidth: 150 }}>
-            {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
+            {types.filter((t) => !t.is_hidden).map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
           </TextField>
           {costFields.length > 1 && (
             <TextField select size="small" label="Cost Field" value={costField} onChange={(e) => setCostField(e.target.value)} sx={{ minWidth: 160 }}>

--- a/frontend/src/features/reports/DependencyReport.tsx
+++ b/frontend/src/features/reports/DependencyReport.tsx
@@ -539,7 +539,7 @@ export default function DependencyReport() {
             sx={{ minWidth: 150 }}
           >
             <MenuItem value="">All Types</MenuItem>
-            {types.map((t) => (
+            {types.filter((t) => !t.is_hidden).map((t) => (
               <MenuItem key={t.key} value={t.key}>
                 {t.label}
               </MenuItem>

--- a/frontend/src/features/reports/LifecycleReport.tsx
+++ b/frontend/src/features/reports/LifecycleReport.tsx
@@ -264,7 +264,7 @@ export default function LifecycleReport() {
         <>
           <TextField select size="small" label="Card Type" value={cardTypeKey} onChange={(e) => setCardTypeKey(e.target.value)} sx={{ minWidth: 180 }}>
             <MenuItem value="">All Types</MenuItem>
-            {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
+            {types.filter((t) => !t.is_hidden).map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
           </TextField>
 
           {isInitiativeType && (

--- a/frontend/src/features/reports/MatrixReport.tsx
+++ b/frontend/src/features/reports/MatrixReport.tsx
@@ -396,10 +396,10 @@ export default function MatrixReport() {
       toolbar={
         <>
           <TextField select size="small" label="Rows" value={rowType} onChange={(e) => setRowType(e.target.value)} sx={{ minWidth: 150 }}>
-            {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
+            {types.filter((t) => !t.is_hidden).map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
           </TextField>
           <TextField select size="small" label="Columns" value={colType} onChange={(e) => setColType(e.target.value)} sx={{ minWidth: 150 }}>
-            {types.map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
+            {types.filter((t) => !t.is_hidden).map((t) => <MenuItem key={t.key} value={t.key}>{t.label}</MenuItem>)}
           </TextField>
           <TextField select size="small" label="Cell Display" value={cellMode} onChange={(e) => setCellMode(e.target.value as CellMode)} sx={{ minWidth: 140 }}>
             <MenuItem value="exists">Exists (dot)</MenuItem>

--- a/frontend/src/features/web-portals/PortalViewer.tsx
+++ b/frontend/src/features/web-portals/PortalViewer.tsx
@@ -940,7 +940,7 @@ export default function PortalViewer() {
                     );
                   })()}
 
-                  {/* Bottom row: subscribers + data_quality */}
+                  {/* Bottom row: stakeholders + data_quality */}
                   {(show("subscribers", "card") || show("data_quality", "card")) && (
                   <Box
                     sx={{
@@ -952,7 +952,7 @@ export default function PortalViewer() {
                       borderTop: "1px solid #f0f0f0",
                     }}
                   >
-                    {/* Subscribers */}
+                    {/* Stakeholders */}
                     {show("subscribers", "card") && card.stakeholders && card.stakeholders.length > 0 && (
                       <Tooltip
                         title={card.stakeholders
@@ -1319,7 +1319,7 @@ export default function PortalViewer() {
                 );
               })}
 
-              {/* Subscribers */}
+              {/* Stakeholders */}
               {show("subscribers", "detail") && selectedFs.stakeholders &&
                 selectedFs.stakeholders.length > 0 && (
                   <Box sx={{ mb: 3 }}>
@@ -1334,7 +1334,7 @@ export default function PortalViewer() {
                         color: "#888",
                       }}
                     >
-                      Subscribers
+                      Stakeholders
                     </Typography>
                     <Box
                       sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}


### PR DESCRIPTION
## Summary
This PR updates terminology throughout the application to use "stakeholders" instead of "subscribers" and implements filtering to hide card types marked as hidden from user-facing dropdowns and displays.

## Key Changes

- **Terminology Update**: Renamed all user-facing references from "subscribers" to "stakeholders" across multiple components:
  - PortalViewer: Updated comments and display labels in card views
  - SurveyBuilder: Updated warning message text
  - WebPortalsAdmin: Updated property label for the subscribers field

- **Hidden Types Filtering**: Added `!t.is_hidden` filter to type selection dropdowns and displays in:
  - MatrixReport: Filter rows and columns dropdowns
  - CreateCardDialog: Filter card type selection dropdown
  - Dashboard: Filter typeCards calculation
  - CostReport: Filter card type dropdown
  - DependencyReport: Filter card type dropdown
  - LifecycleReport: Filter card type dropdown

## Implementation Details

The filtering is consistently applied using `.filter((t) => !t.is_hidden)` before mapping over types arrays. This prevents hidden card types from appearing in user-facing selection menus while maintaining backward compatibility with existing code that doesn't check the `is_hidden` property.

The terminology change is purely cosmetic and improves clarity around the concept of users who have a stake in or are responsible for a card's content.

https://claude.ai/code/session_01EC7CrE3Ruxgjfc1LcLKhcy