### PR TITLE
Filter hidden types from relation type lists across the app

### DIFF
--- a/frontend/src/features/admin/WebPortalsAdmin.tsx
+++ b/frontend/src/features/admin/WebPortalsAdmin.tsx
@@ -154,12 +154,18 @@ export default function WebPortalsAdmin() {
     selectedType?.fields_schema?.flatMap((s) => s.fields) || [];
 
   // Relation types applicable to the selected card type
+  const hiddenTypeKeys = new Set(types.filter((t) => t.is_hidden).map((t) => t.key));
   const applicableRelTypes = cardType
     ? relationTypes.filter(
         (r) =>
           !r.is_hidden &&
           (r.source_type_key === cardType ||
-            r.target_type_key === cardType)
+            r.target_type_key === cardType) &&
+          !hiddenTypeKeys.has(
+            r.source_type_key === cardType
+              ? r.target_type_key
+              : r.source_type_key
+          )
       )
     : [];
 

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -172,13 +172,19 @@ export default function InventoryPage() {
   const selectedType = filters.types.length === 1 ? filters.types[0] : "";
   const typeConfig = types.find((t) => t.key === selectedType);
 
-  // Relevant relation types for the selected type
+  // Relevant relation types for the selected type (excluding hidden types on either end)
+  const hiddenTypeKeys = useMemo(() => new Set(types.filter((t) => t.is_hidden).map((t) => t.key)), [types]);
   const relevantRelTypes = useMemo(() => {
     if (!selectedType) return [];
     return relationTypes.filter(
-      (rt) => !rt.is_hidden && (rt.source_type_key === selectedType || rt.target_type_key === selectedType)
+      (rt) =>
+        !rt.is_hidden &&
+        (rt.source_type_key === selectedType || rt.target_type_key === selectedType) &&
+        !hiddenTypeKeys.has(
+          rt.source_type_key === selectedType ? rt.target_type_key : rt.source_type_key
+        )
     );
-  }, [selectedType, relationTypes]);
+  }, [selectedType, relationTypes, hiddenTypeKeys]);
 
   const loadData = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
Relations to hidden card types (e.g. System) were still visible in web portal setup, card detail relations section, and inventory columns. Now all relation type filters also exclude relations where the other end type is hidden, both in frontend components and the backend public portal endpoint.

https://claude.ai/code/session_01EC7CrE3Ruxgjfc1LcLKhcy