### PR TITLE
Fix hidden type filtering: check visible types instead of hidden set

### DIFF
--- a/frontend/src/features/admin/WebPortalsAdmin.tsx
+++ b/frontend/src/features/admin/WebPortalsAdmin.tsx
@@ -154,14 +154,15 @@ export default function WebPortalsAdmin() {
     selectedType?.fields_schema?.flatMap((s) => s.fields) || [];
 
   // Relation types applicable to the selected card type
-  const hiddenTypeKeys = new Set(types.filter((t) => t.is_hidden).map((t) => t.key));
+  // Since the API excludes hidden types, check that the other-end type exists in visible types
+  const visibleTypeKeys = new Set(types.map((t) => t.key));
   const applicableRelTypes = cardType
     ? relationTypes.filter(
         (r) =>
           !r.is_hidden &&
           (r.source_type_key === cardType ||
             r.target_type_key === cardType) &&
-          !hiddenTypeKeys.has(
+          visibleTypeKeys.has(
             r.source_type_key === cardType
               ? r.target_type_key
               : r.source_type_key

--- a/frontend/src/features/cards/CardDetail.tsx
+++ b/frontend/src/features/cards/CardDetail.tsx
@@ -1073,7 +1073,7 @@ function HierarchySection({
 function RelationsSection({ fsId, cardTypeKey, refreshKey = 0, canManageRelations = true }: { fsId: string; cardTypeKey: string; refreshKey?: number; canManageRelations?: boolean }) {
   const [relations, setRelations] = useState<Relation[]>([]);
   const { types: allTypes, relationTypes, getType } = useMetamodel();
-  const hiddenTypeKeys = useMemo(() => new Set(allTypes.filter((t) => t.is_hidden).map((t) => t.key)), [allTypes]);
+  const visibleTypeKeys = useMemo(() => new Set(allTypes.map((t) => t.key)), [allTypes]);
   const navigate = useNavigate();
 
   // Add relation dialog state
@@ -1099,7 +1099,7 @@ function RelationsSection({ fsId, cardTypeKey, refreshKey = 0, canManageRelation
     (rt) =>
       !rt.is_hidden &&
       (rt.source_type_key === cardTypeKey || rt.target_type_key === cardTypeKey) &&
-      !hiddenTypeKeys.has(
+      visibleTypeKeys.has(
         rt.source_type_key === cardTypeKey ? rt.target_type_key : rt.source_type_key
       )
   );

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -172,19 +172,20 @@ export default function InventoryPage() {
   const selectedType = filters.types.length === 1 ? filters.types[0] : "";
   const typeConfig = types.find((t) => t.key === selectedType);
 
-  // Relevant relation types for the selected type (excluding hidden types on either end)
-  const hiddenTypeKeys = useMemo(() => new Set(types.filter((t) => t.is_hidden).map((t) => t.key)), [types]);
+  // Relevant relation types for the selected type (excluding relations to hidden types)
+  // Since the API excludes hidden types, check that the other-end type exists in visible types
+  const visibleTypeKeys = useMemo(() => new Set(types.map((t) => t.key)), [types]);
   const relevantRelTypes = useMemo(() => {
     if (!selectedType) return [];
     return relationTypes.filter(
       (rt) =>
         !rt.is_hidden &&
         (rt.source_type_key === selectedType || rt.target_type_key === selectedType) &&
-        !hiddenTypeKeys.has(
+        visibleTypeKeys.has(
           rt.source_type_key === selectedType ? rt.target_type_key : rt.source_type_key
         )
     );
-  }, [selectedType, relationTypes, hiddenTypeKeys]);
+  }, [selectedType, relationTypes, visibleTypeKeys]);
 
   const loadData = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
The metamodel API excludes hidden types by default, so the `types` array from useMetamodel() never contains hidden types. Checking `types.filter(t => t.is_hidden)` was always empty. Instead, check that the other-end type key exists in the visible types set.

https://claude.ai/code/session_01EC7CrE3Ruxgjfc1LcLKhcy