### PR TITLE
Add archive/restore/delete card workflow with split permissions

### DIFF
--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -13,7 +13,8 @@ APP_PERMISSIONS: dict[str, dict] = {
             "inventory.view": "View card lists and detail pages",
             "inventory.create": "Create new cards",
             "inventory.edit": "Edit any card (overrides stakeholder-level)",
-            "inventory.delete": "Delete or archive cards",
+            "inventory.archive": "Archive and restore cards",
+            "inventory.delete": "Permanently delete cards (admin)",
             "inventory.export": "Export CSV or Excel data",
             "inventory.approval_status": "Approve, reject, or reset approval status on any card",
             "inventory.bulk_edit": "Bulk update multiple cards",
@@ -150,7 +151,8 @@ for group in APP_PERMISSIONS.values():
 CARD_PERMISSIONS: dict[str, str] = {
     "card.view": "View this card's detail page",
     "card.edit": "Edit this card's fields, name, description, lifecycle",
-    "card.delete": "Delete or archive this card",
+    "card.archive": "Archive or restore this card",
+    "card.delete": "Permanently delete this card (admin)",
     "card.approval_status": "Approve, reject, or reset approval status",
     "card.manage_stakeholders": "Add or remove other users' stakeholder assignments",
     "card.manage_relations": "Add or remove relations on this card",
@@ -171,6 +173,7 @@ ALL_CARD_PERMISSION_KEYS: set[str] = set(CARD_PERMISSIONS.keys())
 
 APP_TO_CARD_PERMISSION_MAP: dict[str, str] = {
     "inventory.edit": "card.edit",
+    "inventory.archive": "card.archive",
     "inventory.delete": "card.delete",
     "inventory.approval_status": "card.approval_status",
     "stakeholders.manage": "card.manage_stakeholders",
@@ -196,7 +199,8 @@ BPM_ADMIN_PERMISSIONS: dict[str, bool] = {
     "inventory.view": True,
     "inventory.create": True,
     "inventory.edit": True,
-    "inventory.delete": True,
+    "inventory.archive": True,
+    "inventory.delete": False,
     "inventory.export": True,
     "inventory.approval_status": True,
     "inventory.bulk_edit": True,
@@ -241,7 +245,8 @@ MEMBER_PERMISSIONS: dict[str, bool] = {
     "inventory.view": True,
     "inventory.create": True,
     "inventory.edit": True,
-    "inventory.delete": True,
+    "inventory.archive": True,
+    "inventory.delete": False,
     "inventory.export": True,
     "inventory.approval_status": True,
     "inventory.bulk_edit": True,
@@ -287,6 +292,7 @@ VIEWER_PERMISSIONS: dict[str, bool] = {
     "inventory.view": True,
     "inventory.create": False,
     "inventory.edit": False,
+    "inventory.archive": False,
     "inventory.delete": False,
     "inventory.export": True,
     "inventory.approval_status": False,
@@ -337,7 +343,8 @@ VIEWER_PERMISSIONS: dict[str, bool] = {
 RESPONSIBLE_CARD_PERMISSIONS: dict[str, bool] = {
     "card.view": True,
     "card.edit": True,
-    "card.delete": True,
+    "card.archive": True,
+    "card.delete": False,
     "card.approval_status": True,
     "card.manage_stakeholders": True,
     "card.manage_relations": True,
@@ -352,6 +359,7 @@ RESPONSIBLE_CARD_PERMISSIONS: dict[str, bool] = {
 OBSERVER_CARD_PERMISSIONS: dict[str, bool] = {
     "card.view": True,
     "card.edit": False,
+    "card.archive": False,
     "card.delete": False,
     "card.approval_status": False,
     "card.manage_stakeholders": False,
@@ -367,6 +375,7 @@ OBSERVER_CARD_PERMISSIONS: dict[str, bool] = {
 PROCESS_OWNER_CARD_PERMISSIONS: dict[str, bool] = {
     "card.view": True,
     "card.edit": True,
+    "card.archive": False,
     "card.delete": False,
     "card.approval_status": True,
     "card.manage_stakeholders": True,
@@ -382,6 +391,7 @@ PROCESS_OWNER_CARD_PERMISSIONS: dict[str, bool] = {
 TECH_APP_OWNER_CARD_PERMISSIONS: dict[str, bool] = {
     "card.view": True,
     "card.edit": True,
+    "card.archive": False,
     "card.delete": False,
     "card.approval_status": False,
     "card.manage_stakeholders": False,
@@ -397,6 +407,7 @@ TECH_APP_OWNER_CARD_PERMISSIONS: dict[str, bool] = {
 BIZ_APP_OWNER_CARD_PERMISSIONS: dict[str, bool] = {
     "card.view": True,
     "card.edit": True,
+    "card.archive": False,
     "card.delete": False,
     "card.approval_status": False,
     "card.manage_stakeholders": False,

--- a/backend/app/models/card.py
+++ b/backend/app/models/card.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
-from sqlalchemy import Float, ForeignKey, String, Text
+from sqlalchemy import DateTime, Float, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -26,6 +27,7 @@ class Card(Base, UUIDMixin, TimestampMixin):
     data_quality: Mapped[float] = mapped_column(Float, default=0.0)
     external_id: Mapped[str | None] = mapped_column(String(500))
     alias: Mapped[str | None] = mapped_column(String(500))
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
     updated_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
 

--- a/backend/app/schemas/card.py
+++ b/backend/app/schemas/card.py
@@ -68,6 +68,7 @@ class CardResponse(BaseModel):
     data_quality: float
     external_id: str | None = None
     alias: str | None = None
+    archived_at: datetime | None = None
     created_by: str | None = None
     updated_by: str | None = None
     created_at: datetime | None = None

--- a/backend/app/services/permission_service.py
+++ b/backend/app/services/permission_service.py
@@ -183,6 +183,7 @@ class PermissionService:
         effective = {
             "can_view": is_admin or app_perms.get("inventory.view", False) or card_level.get("card.view", False),
             "can_edit": is_admin or app_perms.get("inventory.edit", False) or card_level.get("card.edit", False),
+            "can_archive": is_admin or app_perms.get("inventory.archive", False) or card_level.get("card.archive", False),
             "can_delete": is_admin or app_perms.get("inventory.delete", False) or card_level.get("card.delete", False),
             "can_approval_status": is_admin or app_perms.get("inventory.approval_status", False) or card_level.get("card.approval_status", False),
             "can_manage_stakeholders": is_admin or app_perms.get("stakeholders.manage", False) or card_level.get("card.manage_stakeholders", False),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -55,6 +55,7 @@ export interface CardEffectivePermissions {
   effective: {
     can_view: boolean;
     can_edit: boolean;
+    can_archive: boolean;
     can_delete: boolean;
     can_approval_status: boolean;
     can_manage_stakeholders: boolean;
@@ -181,6 +182,7 @@ export interface Card {
   data_quality: number;
   external_id?: string;
   alias?: string;
+  archived_at?: string;
   created_by?: string;
   updated_by?: string;
   created_at?: string;


### PR DESCRIPTION
Backend:
- Split inventory.delete into inventory.archive (archive/restore) and inventory.delete (permanent delete, admin only) permissions
- Add card.archive card-level permission alongside card.delete
- Members get inventory.archive=true, inventory.delete=false by default
- Admin retains wildcard (*) granting both
- Add POST /cards/:id/archive endpoint (sets status=ARCHIVED, records archived_at)
- Add POST /cards/:id/restore endpoint (restores to ACTIVE, clears archived_at)
- Change DELETE /cards/:id to permanently delete (admin only), removes relations
- Add archived_at column to Card model
- Add background auto-purge task: permanently deletes cards archived 30+ days
- Add can_archive to effective permissions in PermissionService

Frontend:
- Add can_archive to CardEffectivePermissions type and defaults
- Add archived_at to Card interface
- Show Archive button on active cards (for users with can_archive)
- Show archived banner with Restore and Delete buttons on archived cards
- Show days-until-purge countdown on archived cards
- Confirmation dialogs for both archive and permanent delete actions

https://claude.ai/code/session_01MmxxDX7FzMo7JmE2naWz7K