### PR TITLE
Fix blank card page: move useState hooks before conditional returns

### DIFF
--- a/frontend/src/features/cards/CardDetail.tsx
+++ b/frontend/src/features/cards/CardDetail.tsx
@@ -1814,6 +1814,8 @@ export default function CardDetail() {
     null
   );
   const [perms, setPerms] = useState<CardEffectivePermissions["effective"]>(DEFAULT_PERMISSIONS);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Fetch effective permissions for this card
   useEffect(() => {
@@ -1876,9 +1878,6 @@ export default function CardDetail() {
   };
 
   // ── Archive / Restore / Delete ───────────────────────────────
-  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-
   const handleArchive = async () => {
     setArchiveDialogOpen(false);
     const updated = await api.post<Card>(`/cards/${card.id}/archive`);


### PR DESCRIPTION
The archive/delete dialog useState hooks were declared after the early returns for loading/error state, violating React's Rules of Hooks and causing the component to crash with a blank page.

https://claude.ai/code/session_01MmxxDX7FzMo7JmE2naWz7K