### PR TITLE
Increase inventory page size limit to 10000

### DIFF
--- a/backend/app/api/v1/cards.py
+++ b/backend/app/api/v1/cards.py
@@ -200,7 +200,7 @@ async def list_cards(
     parent_id: str | None = Query(None),
     approval_status: str | None = Query(None),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=500),
+    page_size: int = Query(10000, ge=1, le=10000),
     sort_by: str = Query("name"),
     sort_dir: str = Query("asc"),
 ):

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -222,7 +222,7 @@ export default function InventoryPage() {
       if (filters.showArchived) {
         params.set("status", "ARCHIVED");
       }
-      params.set("page_size", "500");
+      params.set("page_size", "10000");
       const res = await api.get<CardListResponse>(
         `/cards?${params}`
       );
@@ -1068,8 +1068,6 @@ export default function InventoryPage() {
             getRowId={(p) => p.data.id}
             getRowStyle={(p) => p.data?.status === "ARCHIVED" ? { opacity: 0.6 } : undefined}
             animateRows
-            pagination
-            paginationPageSize={500}
             defaultColDef={{
               sortable: true,
               filter: true,


### PR DESCRIPTION
## Summary
This PR increases the page size limit for the inventory cards list from 500 to 10000 items, allowing users to load and view more cards at once without pagination.

## Key Changes
- **Backend API**: Updated the `list_cards` endpoint to accept a maximum `page_size` of 10000 (previously 500)
- **Frontend**: 
  - Increased the default page size parameter from 500 to 10000 when fetching cards
  - Removed client-side pagination controls from the AG Grid table, as all cards are now loaded in a single request

## Implementation Details
- The backend now defaults to returning 10000 items per request with a maximum limit of 10000
- The frontend no longer uses AG Grid's built-in pagination feature, instead displaying all loaded results in a single scrollable view
- This change improves the user experience by eliminating the need to navigate between pages when working with large inventories

https://claude.ai/code/session_01HWFq7WqzUAXQkkLFbKebq4