### PR TITLE
Auto-navigate to newly created cards

### DIFF
--- a/frontend/src/components/CreateCardDialog.tsx
+++ b/frontend/src/components/CreateCardDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -40,7 +41,7 @@ interface Props {
     parent_id?: string;
     attributes?: Record<string, unknown>;
     lifecycle?: Record<string, string>;
-  }) => Promise<void>;
+  }) => Promise<string>;
   initialType?: string;
 }
 
@@ -55,6 +56,7 @@ export default function CreateCardDialog({
   onCreate,
   initialType,
 }: Props) {
+  const navigate = useNavigate();
   const { types } = useMetamodel();
 
   const [selectedType, setSelectedType] = useState(initialType || "");
@@ -249,7 +251,7 @@ export default function CreateCardDialog({
         }
       }
 
-      await onCreate({
+      const newId = await onCreate({
         type: selectedType,
         subtype: subtype || undefined,
         name: name.trim(),
@@ -260,6 +262,7 @@ export default function CreateCardDialog({
         lifecycle,
       });
       onClose();
+      navigate(`/cards/${newId}`);
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "Failed to create card";

--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -378,9 +378,10 @@ export default function InventoryPage() {
     parent_id?: string;
     attributes?: Record<string, unknown>;
     lifecycle?: Record<string, string>;
-  }) => {
-    await api.post("/cards", createData);
+  }): Promise<string> => {
+    const card = await api.post<Card>("/cards", createData);
     loadData();
+    return card.id;
   };
 
   const handleSelectionChanged = useCallback((event: SelectionChangedEvent) => {


### PR DESCRIPTION
## Summary
Updated the card creation flow to automatically navigate users to the newly created card after successful creation.

## Key Changes
- Modified `onCreate` callback signature to return the created card's ID (`Promise<string>` instead of `Promise<void>`)
- Updated `CreateCardDialog` to navigate to the new card's detail page after creation completes
- Modified `InventoryPage.handleCreateCard` to return the card ID from the API response
- Added `useNavigate` hook import to `CreateCardDialog` for routing

## Implementation Details
- The `onCreate` handler in `InventoryPage` now extracts the card ID from the API response and returns it
- After the dialog closes, users are automatically redirected to `/cards/{newId}` to view the newly created card
- This improves UX by eliminating the need for users to manually navigate to their newly created content

https://claude.ai/code/session_019hE992nkPLurczziS9SKFH