### PR TITLE
Sync search URL param into filters on navigation

### DIFF
--- a/frontend/src/features/inventory/InventoryPage.tsx
+++ b/frontend/src/features/inventory/InventoryPage.tsx
@@ -191,6 +191,15 @@ export default function InventoryPage() {
     }
   }, [searchParams]);
 
+  // Sync ?search= URL param into filters when navigating to inventory from elsewhere (e.g. toolbar)
+  useEffect(() => {
+    const urlSearch = searchParams.get("search") || "";
+    if (urlSearch !== filters.search) {
+      setFilters((prev) => ({ ...prev, search: urlSearch }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
   // Derive the single selected type for column rendering (only when exactly one type selected)
   const selectedType = filters.types.length === 1 ? filters.types[0] : "";
   const typeConfig = types.find((t) => t.key === selectedType);


### PR DESCRIPTION
## Summary
Added a new effect hook to synchronize the `?search=` URL parameter into the filters state when navigating to the inventory page from other parts of the application (e.g., toolbar).

## Key Changes
- Added a `useEffect` hook that monitors the `searchParams` and updates the `filters.search` state whenever the URL search parameter changes
- The effect only updates the filter state if the URL parameter differs from the current filter value, preventing unnecessary state updates
- Includes an ESLint disable comment for the exhaustive-deps rule since `filters` is intentionally excluded from the dependency array to avoid circular updates

## Implementation Details
- The effect reads the `search` query parameter from the URL using `searchParams.get("search")`
- Defaults to an empty string if the parameter is not present
- Uses the functional setState pattern (`setFilters((prev) => ...)`) to safely update the search filter
- This complements the existing effect that syncs filters back to the URL, enabling bidirectional synchronization

https://claude.ai/code/session_01DxmjvgcRXSnRfsa8JQLg6d