### PR TITLE
Disable MathJax in DrawIO to fix 404 on math font loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ When working on this codebase, follow these conventions:
 └───────────────────────────────────────────────────────────┘
 ```
 
-**DrawIO** is self-hosted inside the frontend Docker image (cloned at build time from `jgraph/drawio` v29.5.1) and served under `/drawio/` by Nginx.
+**DrawIO** is self-hosted inside the frontend Docker image (cloned at build time from `jgraph/drawio` v26.0.9) and served under `/drawio/` by Nginx.
 
 ---
 
@@ -826,7 +826,7 @@ BusinessProcess cards show extra tabs in CardDetail:
 ## DrawIO Integration
 
 ### How It Works
-1. **Build time**: Frontend Dockerfile clones `jgraph/drawio` v29.5.1
+1. **Build time**: Frontend Dockerfile clones `jgraph/drawio` v26.0.9
 2. **Runtime**: Nginx serves DrawIO at `/drawio/` (same origin)
 3. **Editor**: `DiagramEditor.tsx` loads DrawIO in a same-origin iframe
 4. **Communication**: Direct DOM access to iframe's `mxGraph` API. Graph reference stored on `iframe.contentWindow.__turboGraph`
@@ -996,7 +996,7 @@ PostgreSQL is external (not managed by this compose file). A separate `docker-co
 
 ### Frontend Dockerfile (multi-stage, root context)
 1. **build stage**: `node:20-alpine` — copies `frontend/package.json` + `VERSION`, npm ci, vite build
-2. **drawio stage**: `alpine/git` — clone jgraph/drawio v29.5.1
+2. **drawio stage**: `alpine/git` — clone jgraph/drawio v26.0.9
 3. **production stage**: `nginx:alpine` — serve built frontend + DrawIO + security configs, runs as non-root `nginx` user
 
 ### Backend Dockerfile (root context)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 # Pin to a release tag for reproducible builds.
 # ---------------------------------------------------------------------------
 FROM alpine/git:latest AS drawio
-RUN git clone --depth 1 --branch v29.5.1 https://github.com/jgraph/drawio.git /drawio
+RUN git clone --depth 1 --branch v26.0.9 https://github.com/jgraph/drawio.git /drawio
 
 FROM nginx:alpine AS production
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/frontend/src/features/diagrams/DiagramEditor.tsx
+++ b/frontend/src/features/diagrams/DiagramEditor.tsx
@@ -58,7 +58,6 @@ const DRAWIO_URL_PARAMS = new URLSearchParams({
   saveAndExit: "1",
   noSaveBtn: "0",
   noExitBtn: "0",
-  math: "0",
 }).toString();
 
 const EMPTY_DIAGRAM =


### PR DESCRIPTION
DrawIO v29.5.1 upgraded from MathJax 3 to MathJax 4, renaming the math/ directory to math4/. Legacy code still tries to load from the old math/es5/ path, causing 404 errors. Math rendering is not needed for EA diagrams, so disable it via the math=0 URL parameter.

https://claude.ai/code/session_01T7NfZSWBMRXZ9ChVDxgc7d

## Summary

<!-- What does this PR do and why? Keep it brief (1-3 sentences). -->

## Changes

<!-- Bulleted list of the key changes. -->

-

## Test Plan

<!-- How did you verify this works? Be specific. -->

- [ ] Backend linting passes (`ruff check . && ruff format --check .`)
- [ ] Frontend linting passes (`npm run lint`)
- [ ] Frontend builds without errors (`npm run build`)
- [ ] Manually tested the affected feature
- [ ] Existing tests pass (`pytest`)

## Checklist

- [ ] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] Screenshots attached for UI changes (if applicable)
