### PR TITLE
Remove VERSION from path filters so version bumps don't trigger all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,9 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
-              - 'VERSION'
               - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
-              - 'VERSION'
               - '.github/workflows/ci.yml'
 
   # ── Backend ───────────────────────────────────────────────────────────


### PR DESCRIPTION
VERSION is bumped in every PR, so including it in both filters meant the full suite always ran, defeating the purpose of path-based filtering.

https://claude.ai/code/session_014spShSikHHAGWcC6QvJGuX

## Summary

<!-- What does this PR do and why? Keep it brief (1-3 sentences). -->

## Changes

<!-- Bulleted list of the key changes. -->

-

## Test Plan

<!-- How did you verify this works? CI runs automatically on every PR. -->

- [ ] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [ ] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] Screenshots attached for UI changes (if applicable)
