### PR TITLE
Refactor capability catalogue row styling for better visual hierarchy

### DIFF
--- a/frontend/src/features/capability-catalogue/capabilityCatalogue.css
+++ b/frontend/src/features/capability-catalogue/capabilityCatalogue.css
@@ -55,7 +55,7 @@
   flex: 1;
   font-size: 15px;
   font-weight: 700;
-  color: #003399;
+  color: #334155;
   background: none;
   border: 0;
   padding: 0;
@@ -65,10 +65,11 @@
   word-break: break-word;
   overflow-wrap: anywhere;
   line-height: 1.3;
+  transition: color 120ms ease;
 }
 
 .tcc-root .tcc-l1-name:hover {
-  opacity: 0.85;
+  color: #003399;
 }
 
 /* Cap-count badge — picks up the row's foreground colour via
@@ -164,6 +165,12 @@
 
 .tcc-root .tcc-row.is-l2 {
   background: #F9FAFC;
+}
+
+/* L3+ rows shed the boxed look so the L2 band reads as the group anchor
+   and the deeper levels feel like a flat outline list. */
+.tcc-root .tcc-l2-children .tcc-row {
+  border-color: transparent;
 }
 
 .tcc-root .tcc-row.is-selected {
@@ -360,7 +367,15 @@
 }
 
 .tcc-root.tcc-root--dark .tcc-l1-name {
+  color: #cdd9ee;
+}
+
+.tcc-root.tcc-root--dark .tcc-l1-name:hover {
   color: #a8c4ff;
+}
+
+.tcc-root.tcc-root--dark .tcc-l2-children .tcc-row {
+  border-color: transparent;
 }
 
 .tcc-root.tcc-root--dark .tcc-row {

--- a/frontend/src/features/capability-catalogue/capabilityCatalogue.css
+++ b/frontend/src/features/capability-catalogue/capabilityCatalogue.css
@@ -139,9 +139,11 @@
   border-left: 1px solid rgba(0, 51, 153, 0.10);
 }
 
-/* Rows are neutral — paper bg, divider border, navy text. Depth is conveyed
+/* Rows are neutral — paper bg, divider border, slate text. Depth is conveyed
    by indentation (.tcc-l2-children) + typography (is-l2 weight bump),
-   never by background tint. */
+   plus a barely-there grey wash on the L2 group header. The brand navy
+   #003399 is reserved for hover + selected state, so the eye picks up
+   interaction without the catalog reading as a wall of navy. */
 .tcc-root .tcc-row {
   display: flex;
   align-items: center;
@@ -150,17 +152,23 @@
   border: 1px solid var(--mui-palette-divider, rgba(0, 0, 0, 0.08));
   border-radius: 8px;
   background: var(--mui-palette-background-paper, #fff);
-  color: #003399;
+  color: #334155;
   min-width: 0;
-  transition: box-shadow 120ms ease, background-color 120ms ease;
+  transition: box-shadow 120ms ease, background-color 120ms ease, color 120ms ease;
 }
 
 .tcc-root .tcc-row:hover {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  color: #003399;
+}
+
+.tcc-root .tcc-row.is-l2 {
+  background: #F9FAFC;
 }
 
 .tcc-root .tcc-row.is-selected {
   background: rgba(0, 51, 153, 0.06);
+  color: #003399;
   box-shadow: 0 0 0 1px rgba(0, 51, 153, 0.45);
 }
 
@@ -363,10 +371,16 @@
 
 .tcc-root.tcc-root--dark .tcc-row:hover {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  color: #a8c4ff;
+}
+
+.tcc-root.tcc-root--dark .tcc-row.is-l2 {
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .tcc-root.tcc-root--dark .tcc-row.is-selected {
   background: rgba(168, 196, 255, 0.08);
+  color: #a8c4ff;
   box-shadow: 0 0 0 1px rgba(168, 196, 255, 0.6);
 }
 


### PR DESCRIPTION
## Summary

Updates the capability catalogue row styling to improve visual hierarchy and interaction clarity. Changes the default text color from navy to slate, reserves navy for hover and selected states, and adds a subtle background wash to L2 group headers. This reduces visual noise while making interactive states more prominent.

## Changes

- Changed default row text color from `#003399` (navy) to `#334155` (slate)
- Added navy color (`#003399`) to hover and selected states for better interaction feedback
- Added subtle grey background (`#F9FAFC`) to L2 group header rows
- Updated dark mode equivalents: hover and selected states now use `#a8c4ff` (light blue)
- Added dark mode L2 background with `rgba(255, 255, 255, 0.03)` subtle wash
- Added `color` to transition properties to smoothly animate text color changes
- Updated inline documentation to explain the new design rationale

## Test Plan

- [ ] All CI checks pass (frontend lint, frontend build, frontend tests)
- [ ] Manually tested the capability catalogue in light and dark modes to verify:
  - Default rows display in slate text
  - Hover state shows navy text and shadow
  - Selected state shows navy text and background tint
  - L2 group headers have subtle grey background

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [x] Screenshots not needed (styling-only change, visual review via manual testing)

https://claude.ai/code/session_01CS6FH52rHUeYoKxP3ozWW3