### PR TITLE
docs: Update CLAUDE.md and README.md with latest features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ turbo-ea/
 │   │   ├── api/
 │   │   │   ├── deps.py                # Auth dependencies (get_current_user, require_permission)
 │   │   │   └── v1/
-│   │   │       ├── router.py          # Mounts all 34 API routers
+│   │   │       ├── router.py          # Mounts all 39 API routers
 │   │   │       ├── auth.py            # /auth (login, register, me, SSO, set-password)
 │   │   │       ├── cards.py           # /cards CRUD + hierarchy + approval status + CSV export
 │   │   │       ├── metamodel.py       # /metamodel (types + relation types + field/section usage)
@@ -345,13 +345,16 @@ turbo-ea/
 │   │   │       ├── notifications.py   # /notifications (user notifications)
 │   │   │       ├── servicenow.py      # /servicenow (CMDB sync integration)
 │   │   │       ├── adr.py             # /adr (Architecture Decision Records)
-│   │   │       └── file_attachments.py # /cards/{id}/attachments (file uploads)
+│   │   │       ├── file_attachments.py # /cards/{id}/attachments (file uploads)
+│   │   │       ├── risks.py           # /risks + /cards/{id}/risks (TOGAF Risk Register)
+│   │   │       ├── favorites.py       # /favorites (per-user favorited cards)
+│   │   │       └── capability_catalogue.py # /capability-catalogue (industry catalogue)
 │   │   ├── core/
 │   │   │   ├── security.py            # JWT creation/validation (PyJWT HS256), bcrypt
 │   │   │   ├── permissions.py         # Permission key registry (single source of truth)
 │   │   │   ├── encryption.py          # Fernet symmetric encryption for DB secrets
 │   │   │   └── rate_limit.py          # slowapi rate limiter instance
-│   │   ├── models/                    # SQLAlchemy ORM models (30 files, see Database section)
+│   │   ├── models/                    # SQLAlchemy ORM models (44 files, see Database section)
 │   │   ├── schemas/                   # Pydantic request/response models
 │   │   │   ├── auth.py                # Auth schemas
 │   │   │   ├── card.py                # Card schemas
@@ -377,7 +380,7 @@ turbo-ea/
 │   │   ├── config.py                  # Settings from env vars + APP_VERSION
 │   │   ├── database.py                # Async engine + session factory
 │   │   └── main.py                    # FastAPI app, lifespan (migrations + seed + purge loop + AI auto-config)
-│   ├── alembic/                       # Database migrations (64 versions)
+│   ├── alembic/                       # Database migrations (65 versions)
 │   ├── tests/
 │   ├── pyproject.toml
 │   └── Dockerfile                     # Python 3.12-alpine + uvicorn (root context)
@@ -505,6 +508,11 @@ turbo-ea/
 │   │   │   │   ├── SurveyRespond.tsx        # Survey response form
 │   │   │   │   └── MySurveys.tsx            # User's pending surveys
 │   │   │   ├── web-portals/PortalViewer.tsx # Public portal (no auth)
+│   │   │   ├── capability-catalogue/        # Industry capability catalogue browser
+│   │   │   │   ├── CapabilityCataloguePage.tsx
+│   │   │   │   ├── CapabilityCatalogueBrowser.tsx
+│   │   │   │   └── IndustryFilter.tsx
+│   │   │   ├── turbolens/                   # AI-powered EA intelligence (see TurboLens section)
 │   │   │   └── admin/
 │   │   │       ├── MetamodelAdmin.tsx       # Type list + relation graph orchestrator
 │   │   │       ├── metamodel/               # Modular metamodel admin components
@@ -527,6 +535,9 @@ turbo-ea/
 │   │   │       ├── SurveyResults.tsx
 │   │   │       ├── WebPortalsAdmin.tsx
 │   │   │       ├── ServiceNowAdmin.tsx
+│   │   │       ├── AuthAdmin.tsx          # SSO / Authentication settings
+│   │   │       ├── PrinciplesAdmin.tsx    # EA principles CRUD (statement, rationale, implications)
+│   │   │       ├── TurboLensAdmin.tsx     # TurboLens analysis settings
 │   │   │       └── AiAdmin.tsx            # AI suggestion settings (provider, model, search)
 │   │   ├── App.tsx                          # Routes + MUI theme (lazy imports)
 │   │   └── main.tsx                         # React entry point
@@ -669,6 +680,14 @@ All tables use UUID primary keys and `created_at`/`updated_at` timestamps (from 
 | `web_portals` | `WebPortal` | Public portals with slug-based URLs |
 | `saved_reports` | `SavedReport` | Persisted report configurations with thumbnails |
 | `sso_invitations` | `SsoInvitation` | Pre-assigned SSO invitations |
+| `architecture_decisions` | `ArchitectureDecision` | ADR records (status, context, decision, alternatives, consequences) |
+| `architecture_decision_cards` | `ArchitectureDecisionCard` | M:N junction between ADRs and cards |
+| `ea_principles` | `EAPrinciple` | EA principles (statement, rationale, implications, sort_order) — exposed via `/metamodel/principles` |
+| `kpi_snapshots` | `KpiSnapshot` | Daily KPI snapshots powering the dashboard trend charts |
+| `user_favorites` | `UserFavorite` | Per-user favorited cards (M:N user × card) |
+| `risks` | `Risk` | EA Risk Register entries (TOGAF Phase G) — see Risk Register section |
+| `risk_cards` | `RiskCard` | M:N junction between risks and affected cards |
+| `turbolens_*` | TurboLens models | Vendor analysis, duplicates, modernizations, analysis runs, CVE + compliance findings — see TurboLens section |
 
 ### ServiceNow Integration Tables
 
@@ -683,7 +702,7 @@ All tables use UUID primary keys and `created_at`/`updated_at` timestamps (from 
 
 ### Migrations
 
-Located in `backend/alembic/versions/` (64 migration files, sequentially numbered `001_` through `064_`). The app auto-runs Alembic on startup:
+Located in `backend/alembic/versions/` (65 migration files, sequentially numbered `001_` through `065_`). The app auto-runs Alembic on startup:
 - Fresh DB: `create_all` + stamp head
 - Existing DB without Alembic: stamp head
 - Normal: `upgrade head` (run pending migrations)
@@ -986,7 +1005,7 @@ All route-level pages use `lazy()` imports for code splitting. Auth pages (Login
 
 ## Metamodel
 
-The default metamodel seeds 14 card types across 4 layers and 30+ relation types. Created on first startup by `backend/app/services/seed.py`.
+The default metamodel seeds 13 card types across 4 layers and 30+ relation types. Created on first startup by `backend/app/services/seed.py`.
 
 ### Card Types
 
@@ -1005,7 +1024,6 @@ The default metamodel seeds 14 card types across 4 layers and 30+ relation types
 | `ITComponent` | IT Component | memory | #d29270 | Technical Architecture | Yes | Software, Hardware, SaaS, PaaS, IaaS, Service, AI Model |
 | `TechCategory` | Tech Category | category | #a6566d | Technical Architecture | Yes | - |
 | `Provider` | Provider | storefront | #ffa31f | Technical Architecture | No | - |
-| `System` | System | dns | #5B738B | Technical Architecture | No | - |
 
 ### Fields Schema Structure
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ The demo comes pre-populated with the NexaTech Industries dataset — 150+ cards
 - **Inventory Management** — AG Grid-powered data table with search, dynamic multi-select filtering for all columns (subtype, lifecycle, data quality, attributes), column customization, Excel import/export, mass archive/delete, and select-all across filtered rows.
 - **Card Detail Pages** — Full detail view with fields, lifecycle, hierarchy, relations, stakeholders, comments, todos, documents, and event history. Approval workflow (Draft/Approved/Rejected/Broken) with auto-breaking on substantive edits. Auto-computed data quality scoring (0–100%) based on field weights.
 - **Hierarchy Support** — Parent-child trees for hierarchical card types. Business Capabilities enforce max 5-level depth with auto-computed capability levels.
+- **Inline Title Editing** — Rename cards directly from the title in the detail page header (no dialog needed) with permission-gated controls.
+- **Favorites** — Per-user favorited cards for quick access from the dashboard.
+- **Capability Catalogue** — Browsable industry capability catalogue (`/capabilities`) grouped by industry, with sticky filter bars, quick-filter chips, and a back-to-top button. Use as a reference when designing your own capability map.
 
 ### Reporting & Analytics
 
-- **Interactive Reports** — Portfolio bubble chart, capability heatmap, lifecycle roadmap, dependency graph, cost treemap, matrix cross-reference, data quality dashboard, and EOL risk report. All report filters, colors, and grouping are dynamically generated from card type field schemas with auto-persist to localStorage.
+- **Interactive Reports** — Portfolio bubble chart, capability heatmap, lifecycle roadmap, dependency graph, cost treemap, matrix cross-reference, data quality dashboard, EOL risk report, and process map. All report filters, colors, and grouping are dynamically generated from card type field schemas with auto-persist to localStorage.
+- **Dashboard with Trend Charts** — Daily KPI snapshots feed trend charts on the home dashboard (cards by type, average data quality, approvals over time) alongside a redesigned Recent Activity panel.
 - **Time-Travel** — View any report as it appeared at a historical date using a timeline slider with year-level granularity.
 - **Saved Reports** — Save report configurations (filters, axes, colors, grouping), share with other users (edit/view permissions), and generate OData feeds for programmatic access.
 - **Print-to-PDF** — Native browser print for all reports with optimized compact layout, white background, and time-travel date display.
@@ -73,10 +77,9 @@ The demo comes pre-populated with the NexaTech Industries dataset — 150+ cards
 - **Risk Management** — Risk register with probability/impact scoring (1-5), auto-computed risk score, status tracking (open/mitigating/mitigated/closed/accepted), mitigation plans, and risk matrix visualization.
 - **PPM Reports** — Portfolio-level dashboard with KPIs (total budget, actual spend, health distribution) and Gantt timeline with optional grouping.
 
-### Diagrams & Documents
+### Diagrams
 
 - **Diagram Editor** — Self-hosted DrawIO integration for creating architecture diagrams linked to your cards. Shapes are colored by card type with synced/pending states.
-- **EA Delivery** — TOGAF-compliant Statement of Architecture Work (SoAW) editor with rich text editing (TipTap), version history, sign-off requests, and DOCX export.
 
 ### AI-Powered Assistance
 
@@ -90,7 +93,15 @@ AI-powered EA analysis module — originally ported from [ArchLens](https://gith
 - **Vendor Resolution** — Builds a canonical vendor hierarchy by resolving aliases, parent-child relationships, and product groupings. Displays confidence scores for each resolution.
 - **Duplicate Detection** — Identifies functional duplicate cards using AI clustering across Application, IT Component, and Interface types. Union-find algorithm merges overlapping clusters across batches. Each cluster includes evidence and retirement recommendations.
 - **Modernization Assessment** — Evaluates cards for modernization opportunities based on current technology trends, providing effort estimates, priority levels, and specific recommendations.
-- **Architecture AI** — 3-phase conversational architecture assistant: (1) business clarification questions, (2) technical deep-dive questions, (3) structured architecture recommendation with component layers, gap analysis with market recommendations, integration map, risk assessment, and interactive Mermaid diagrams.
+- **Architecture AI** — 5-step guided wizard: (1) Requirements (objective + capability selection), (2) Business Fit clarification questions, (3) Technical Fit deep-dive, (4) Solution (options → gap analysis → dependency analysis), (5) Target Architecture with capability mapping and an interactive C4 dependency diagram (React Flow). Commits to a real Initiative card with proposed cards, relations, and a draft ADR.
+- **Security & Compliance** — On-demand CVE scans (NIST NVD-backed with deterministic probability scoring) and compliance scans across EU AI Act, GDPR, NIS2, DORA, SOC 2, and ISO 27001. Findings show severity, business impact, and remediation. A clickable risk matrix drills through to filtered findings; any finding can be promoted to a Risk Register entry in one click.
+
+### EA Delivery (TOGAF)
+
+- **Architecture Decision Records (ADR)** — Capture decisions, context, alternatives considered, consequences, and links to affected cards. Sign-off workflow with audit trail.
+- **EA Risk Register (TOGAF Phase G)** — Landscape-level register separate from initiative risks. Auto-generated `R-000123` references, initial vs residual 4×4 probability×impact matrices, sequential status workflow (analysis → mitigation → monitoring → closed) with explicit Accept / Reopen side actions, owner→Todo→notification loop, and idempotent promote-from-finding for CVE and compliance findings.
+- **EA Principles** — Admin-curated list of architecture principles (statement, rationale, implications) referenced from SoAW and ADR documents.
+- **Statement of Architecture Work** — TOGAF-compliant SoAW editor with rich text editing (TipTap), version history, sign-off requests, and DOCX export.
 
 ### Data Governance
 
@@ -106,7 +117,7 @@ AI-powered EA analysis module — originally ported from [ArchLens](https://gith
 - **Todos** — Task management linked to cards with assignment, due dates, and status tracking. Badge counts for open todos shown in navigation.
 - **Stakeholders** — Per-card stakeholder roles (responsible, observer, technical/business application owner) with configurable custom roles per card type.
 - **Documents** — URL/link attachments on cards.
-- **Tags** — Hierarchical tag groups with single/multi-select modes and open/restricted creation. Filter-by-tag across inventory and reports.
+- **Tags** — Tag groups with single/multi-select modes, mandatory flags, and per-card-type restrictions. Filter-by-tag across inventory and reports.
 
 ### Integrations
 
@@ -130,6 +141,7 @@ AI-powered EA analysis module — originally ported from [ArchLens](https://gith
 - **Custom Branding** — Upload a custom logo (max 2 MB; PNG, JPEG, SVG, WebP, GIF) and favicon. Per-portal logo visibility toggle.
 - **Currency Settings** — Global display currency for all cost values with compact formatting.
 - **SMTP Email Configuration** — Configure SMTP settings from the admin UI with test email support.
+- **Design Tokens & UI Guidelines** — Centralized colors, spacing, typography, status/severity/layer palettes and icon sizes (`frontend/src/theme/tokens.ts`). See [`frontend/UI_GUIDELINES.md`](frontend/UI_GUIDELINES.md) for the full design system.
 
 ## Screenshots
 
@@ -539,9 +551,12 @@ turbo-ea/
 │   │   │   ├── cards/       # Card detail page
 │   │   │   ├── dashboard/   # KPI cards + recent activity
 │   │   │   ├── diagrams/    # DrawIO editor + shape system
-│   │   │   ├── ea-delivery/ # SoAW editor + preview + DOCX export
+│   │   │   ├── ea-delivery/ # SoAW + ADR editor, EA Risk Register, DOCX export
 │   │   │   ├── inventory/   # AG Grid table + Excel import/export
-│   │   │   ├── reports/     # 9 report types + saved reports
+│   │   │   ├── reports/     # 10 report types + saved reports
+│   │   │   ├── turbolens/   # AI-powered EA intelligence (vendors, duplicates,
+│   │   │   │                # modernization, architecture AI, security & compliance)
+│   │   │   ├── capability-catalogue/ # Industry capability catalogue browser
 │   │   │   ├── surveys/     # Survey response page
 │   │   │   ├── todos/       # Todos + surveys combined page
 │   │   │   └── web-portals/ # Public portal viewer


### PR DESCRIPTION
## Summary

This PR updates the project documentation to reflect recent feature additions and architectural changes, including new API endpoints (risks, favorites, capability catalogue), new database models, frontend components, and TurboLens enhancements. No source code changes—documentation only.

## Changes

- Updated API router count from 34 to 39 routers in `CLAUDE.md`
- Added three new API endpoint modules: `risks.py`, `favorites.py`, `capability_catalogue.py`
- Updated database model count from 30 to 44 files in `CLAUDE.md`
- Updated Alembic migration count from 64 to 65 versions
- Added new database tables: `architecture_decisions`, `architecture_decision_cards`, `ea_principles`, `kpi_snapshots`, `user_favorites`, `risks`, `risk_cards`, and TurboLens-related tables
- Removed `System` card type from metamodel (14 → 13 card types)
- Added frontend components for capability catalogue browser and TurboLens
- Added new admin pages: `AuthAdmin.tsx`, `PrinciplesAdmin.tsx`, `TurboLensAdmin.tsx`
- Updated README.md feature descriptions:
  - Added inline title editing, favorites, and capability catalogue features
  - Enhanced reporting section with process map and KPI trend charts
  - Expanded TurboLens section with security & compliance scanning
  - Added EA Delivery section covering ADR, Risk Register, EA Principles, and SoAW
  - Updated tag system description (removed hierarchical, added mandatory flags)
  - Added design tokens & UI guidelines reference
- Updated directory structure documentation to reflect new feature modules

## Test Plan

N/A — Documentation-only changes. No source code modifications to test.

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [x] Documentation is accurate and up-to-date with codebase structure

https://claude.ai/code/session_012L2DaQKGBFJG5LZtcug7w8