### PR TITLE
Improve error handling in capability catalogue fetch endpoint

### DIFF
--- a/backend/app/api/v1/capability_catalogue.py
+++ b/backend/app/api/v1/capability_catalogue.py
@@ -12,6 +12,8 @@ Visibility:
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +22,8 @@ from app.api.deps import require_permission
 from app.database import get_db
 from app.models.user import User
 from app.services import capability_catalogue_service as svc
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/capability-catalogue", tags=["capability-catalogue"])
 
@@ -96,5 +100,6 @@ async def update_fetch(
     """Download the latest catalogue from the public site and cache it."""
     try:
         return await svc.fetch_remote_catalogue(db)
-    except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"Catalogue fetch failed: {exc}")
+    except Exception:
+        logger.exception("Capability catalogue fetch failed")
+        raise HTTPException(status_code=502, detail="Catalogue fetch failed")


### PR DESCRIPTION
## Summary

Improves error handling and logging in the capability catalogue fetch endpoint by adding structured logging and removing sensitive exception details from API responses.

## Changes

- Added `logging` module import and logger initialization
- Changed exception handler to use `logger.exception()` for structured error logging instead of including exception details in the HTTP response
- Removed exception message from HTTP response detail to avoid exposing internal error information to clients

## Test Plan

- [ ] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [x] I did not expose sensitive fields in API responses

https://claude.ai/code/session_01UAn3AYjTVpiqMhZm7xUetP