### PR TITLE
Fix file download with non-Latin1 filenames

### DIFF
--- a/backend/app/api/v1/file_attachments.py
+++ b/backend/app/api/v1/file_attachments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import Response
@@ -152,10 +153,18 @@ async def download_file_attachment(
     if not attachment:
         raise HTTPException(404, "File attachment not found")
 
+    # RFC 6266 / RFC 5987: HTTP header values must be Latin-1 encodable, so a
+    # raw filename with non-Latin-1 characters (Cyrillic, CJK, emoji, ...) would
+    # crash the response serializer with UnicodeEncodeError. Emit an ASCII
+    # fallback plus a percent-encoded UTF-8 form that modern browsers prefer.
+    ascii_fallback = attachment.name.encode("ascii", "replace").decode("ascii")
+    ascii_fallback = ascii_fallback.replace("\\", "_").replace('"', "_")
+    encoded_name = quote(attachment.name, safe="")
+    disposition = f"attachment; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded_name}"
     return Response(
         content=attachment.data,
         media_type=attachment.mime_type,
-        headers={"Content-Disposition": f'attachment; filename="{attachment.name}"'},
+        headers={"Content-Disposition": disposition},
     )
 
 

--- a/backend/tests/api/test_file_attachments.py
+++ b/backend/tests/api/test_file_attachments.py
@@ -160,6 +160,34 @@ class TestDownloadFile:
         )
         assert resp.status_code == 200
 
+    async def test_download_with_non_latin1_filename(self, client, db, file_env):
+        # Regression: filenames containing characters outside Latin-1 (Cyrillic,
+        # CJK, emoji) must not crash the response serializer with HTTP 500.
+        admin = file_env["admin"]
+        card = file_env["card"]
+        unicode_name = "отчёт 报告 🚀.pdf"
+
+        upload_resp = await client.post(
+            f"/api/v1/cards/{card.id}/file-attachments",
+            files={"file": (unicode_name, b"unicode-bytes", "application/pdf")},
+            headers=auth_headers(admin),
+        )
+        assert upload_resp.status_code == 201
+        attachment_id = upload_resp.json()["id"]
+
+        resp = await client.get(
+            f"/api/v1/file-attachments/{attachment_id}/download",
+            headers=auth_headers(admin),
+        )
+        assert resp.status_code == 200
+        assert resp.content == b"unicode-bytes"
+
+        from urllib.parse import quote
+
+        disposition = resp.headers.get("content-disposition", "")
+        assert 'filename="' in disposition
+        assert f"filename*=UTF-8''{quote(unicode_name, safe='')}" in disposition
+
 
 # -------------------------------------------------------------------
 # DELETE /file-attachments/{id}


### PR DESCRIPTION
## Summary

Fix HTTP 500 errors when downloading file attachments with non-Latin1 characters (Cyrillic, CJK, emoji, etc.) in the filename. The issue occurred because HTTP headers must be Latin-1 encodable per RFC 6266. The fix implements RFC 5987 to provide both an ASCII fallback and a percent-encoded UTF-8 filename that modern browsers prefer.

## Changes

- Updated `/api/v1/file-attachments/{id}/download` endpoint to generate RFC 5987-compliant `Content-Disposition` headers
- ASCII fallback filename replaces non-ASCII characters with `?` and sanitizes problematic characters (`\`, `"`)
- UTF-8 filename provided via `filename*` parameter for modern browser support
- Added regression test covering upload and download of files with Unicode filenames (Cyrillic, CJK, emoji)

## Test Plan

- [x] Added comprehensive test case `test_download_with_non_latin1_filename` that verifies:
  - File upload with Unicode filename succeeds
  - Download returns 200 with correct content
  - Response headers include both ASCII fallback and UTF-8 encoded filename
- [x] All existing file attachment tests continue to pass

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [x] I used `async def` for all new route handlers and DB operations
- [x] I did not expose sensitive fields in API responses

https://claude.ai/code/session_01HvWw3iiQKjhdX5j1yGCTbB