### PR TITLE
Document COMPOSE_PROFILES in sample env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@
 #   docker compose -f docker-compose.yml -f dev/docker-compose.dev.yml up -d --build
 TURBO_EA_TAG=latest
 
+# Optional Docker Compose profiles to start by default.
+# Set to `ai` to always include Ollama, or `ai,mcp` to include both optional
+# services without passing `--profile ...` on every docker compose command.
+COMPOSE_PROFILES=
+
 # Public HTTP port exposed by the bundled edge nginx service.
 # Standard deployments should leave this at 80.
 HOST_PORT=80


### PR DESCRIPTION
## Summary

Document the optional `COMPOSE_PROFILES` environment variable in `.env.example` so operators can persistently enable the `ai` or `mcp` compose profiles without passing `--profile` on every `docker compose` command.

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [x] docs
- [ ] chore (CI / build / dependency / housekeeping)
- [ ] security

## Changes

- Add `COMPOSE_PROFILES=` to `.env.example`
- Document `ai` and `ai,mcp` as the supported default profile combinations

## Test Plan

- Confirmed the branch diff against `main` only changes `.env.example`
- Reviewed the rendered `.env.example` diff locally to verify the new variable and comments are placed near the other top-level compose settings
- [ ] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [x] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [x] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [x] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)
