### PR TITLE
ci(docker-publish): weekly cron + no-cache on dispatch to clear apk CVEs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     tags: ["v*.*.*"]
   workflow_dispatch:
+  # Weekly fresh rebuild so apk-package CVEs in the alpine bases are picked
+  # up even during code-quiet weeks. Combined with `no-cache` below, this
+  # guarantees `apk upgrade --no-cache` actually re-runs against the live
+  # alpine repos instead of reusing a cached layer.
+  schedule:
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
@@ -77,6 +83,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          # Bypass build cache on scheduled and manual runs so `apk upgrade`
+          # actually re-runs against fresh alpine repos. Regular push builds
+          # keep the cache for speed (~1m vs ~14m).
+          no-cache: ${{ github.event_name != 'push' }}
           provenance: true
           sbom: true
 


### PR DESCRIPTION
## Summary

Adds a weekly cron trigger and forces `no-cache` on scheduled + manual runs of the Docker publish workflow, so `apk upgrade --no-cache` in the Dockerfile actually re-runs against fresh alpine repos instead of reusing a stale cached layer. Permanent fix for the recurring apk-package CVE backlog (e.g. the 28 curl/libcurl alerts currently open).

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore (CI / build / dependency / housekeeping)
- [x] security

## Changes

- Add `schedule: cron "0 6 * * 1"` (Mondays 06:00 UTC) to `docker-publish.yml`.
- Pass `no-cache: ${{ github.event_name != 'push' }}` to `docker/build-push-action` — push-triggered builds keep cache for speed (~1m), scheduled and dispatch runs rebuild from scratch (~14m) and pick up the latest alpine package set.

## Test Plan

- Workflow YAML reviewed; only the `on:` block and the `build-push-action` step are touched.
- Push builds will continue to cache as before (no observable change).
- Manual verification path: merge → run `gh workflow run docker-publish.yml` → confirm build duration jumps from ~1m to ~14m → confirm Trivy scan against fresh digest reports curl ≥ 8.19.0-r0 → the 28 open code-scanning alerts should auto-close on the next SARIF upload.

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)