### PR TITLE
chore: add CODEOWNERS to route reviews to maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every file in this repo requires review from @vincentmakes before merge.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @vincentmakes


### PR DESCRIPTION
## Summary

Adds a top-level `CODEOWNERS` mapping `*` to `@vincentmakes`. This is the companion to the new "Protect main" ruleset, which requires code-owner review on every PR — without this file, the rule has nothing to match against.

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [x] docs
- [x] chore (CI / build / dependency / housekeeping)
- [ ] security

## Changes

- Add `.github/CODEOWNERS` with `* @vincentmakes`

## Test Plan

- N/A — no code change. After merge, opening a new PR should auto-request review from `@vincentmakes` and the "code-owner review" rule on `main` will gate the merge.

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)