### PR TITLE
Add code-scanning alerts reporting workflow and script

### DIFF
--- a/.github/SECURITY_PIPELINE.md
+++ b/.github/SECURITY_PIPELINE.md
@@ -64,6 +64,20 @@ Why this exists: CVEs disclosed *after* the last image build would otherwise go 
 
 ## Operational runbook
 
+### Listing the current code-scanning alerts
+
+The Security tab needs interactive auth, which scripts and CI log viewers don't
+have. To get the open alerts (CodeQL + Trivy + Scout) as a plain table:
+
+- **In CI** — run the [`Code Scanning Report`](workflows/code-scanning-report.yml)
+  workflow (`gh workflow run code-scanning-report.yml`, or the Actions UI; it
+  also runs weekly). It dumps every open alert — rule id, severity, file:line,
+  title — to the **job logs**, the **run summary**, and a `code-scanning-alerts`
+  JSON artifact. Anything that can read an Actions run (including agent tooling
+  that lacks the code-scanning API) can then read the findings.
+- **Locally** — `./scripts/security/code-scanning-report.sh` (needs `gh auth
+  login` + `jq`); add `--json` for the raw payload.
+
 ### A Trivy gate failed the publish
 
 1. Read the `Trivy image scan (gate, CRITICAL only)` step output — the CVE id and affected package are in the table.

--- a/.github/workflows/code-scanning-report.yml
+++ b/.github/workflows/code-scanning-report.yml
@@ -1,0 +1,72 @@
+name: Code Scanning Report
+
+# Dumps the repository's *open* code-scanning alerts (CodeQL + Trivy + Scout
+# SARIF) to a place that's readable without the Security tab: the job logs, the
+# run summary, and a JSON artifact. The GitHub MCP toolset (and most CI/log
+# viewers) can read Actions logs but cannot call the code-scanning alerts API,
+# so this workflow bridges that gap — run it, then read the result from the run.
+#
+# Uses the runner's preinstalled `gh` CLI with the built-in GITHUB_TOKEN and a
+# read-only `security-events` grant. No extra secrets.
+#
+# Manual run: `gh workflow run code-scanning-report.yml` (or the Actions UI).
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly snapshot so the latest list is always one click away.
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+  security-events: read
+
+concurrency:
+  group: code-scanning-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Dump open code-scanning alerts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch and render open alerts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate \
+            "repos/$REPO/code-scanning/alerts?state=open&per_page=100" \
+            > alerts.json
+
+          count=$(jq 'length' alerts.json)
+          echo "Open code-scanning alerts: $count"
+          echo
+
+          # Human-readable table -> stdout (lands in the job logs).
+          jq -r '.[] | [
+            (.number | tostring),
+            .tool.name,
+            .rule.id,
+            (.rule.security_severity_level // .rule.severity // "n/a"),
+            "\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)",
+            (.rule.description // .most_recent_instance.message.text | gsub("\n"; " "))
+          ] | @tsv' alerts.json | column -t -s "$(printf '\t')" || true
+
+          # Same data as markdown -> run summary.
+          {
+            echo "## Open code-scanning alerts ($count)"
+            echo
+            echo "| # | Tool | Rule | Severity | Location | Title |"
+            echo "| - | ---- | ---- | -------- | -------- | ----- |"
+            jq -r '.[] | "| \(.number) | \(.tool.name) | `\(.rule.id)` | \(.rule.security_severity_level // .rule.severity // "n/a") | `\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)` | \(.rule.description // .most_recent_instance.message.text | gsub("\n"; " ")) |"' alerts.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload alerts JSON
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: code-scanning-alerts
+          path: alerts.json
+          if-no-files-found: warn

--- a/scripts/security/code-scanning-report.sh
+++ b/scripts/security/code-scanning-report.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# List the repository's open code-scanning alerts (CodeQL + Trivy + Scout) as a
+# table, so you can triage them without opening the GitHub Security tab.
+#
+# Usage:
+#   ./scripts/security/code-scanning-report.sh             # table to stdout
+#   ./scripts/security/code-scanning-report.sh --json      # raw JSON to stdout
+#
+# Requires: gh (authenticated via `gh auth login`) and jq.
+# The CI equivalent is the "Code Scanning Report" workflow
+# (.github/workflows/code-scanning-report.yml).
+set -euo pipefail
+
+REPO="${REPO:-vincentmakes/turbo-ea}"
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "error: '$bin' is required but not installed." >&2
+    exit 1
+  fi
+done
+
+alerts="$(gh api --paginate \
+  "repos/$REPO/code-scanning/alerts?state=open&per_page=100")"
+
+if [[ "${1:-}" == "--json" ]]; then
+  echo "$alerts"
+  exit 0
+fi
+
+count="$(jq 'length' <<<"$alerts")"
+echo "Open code-scanning alerts for $REPO: $count"
+echo
+
+jq -r '.[] | [
+  (.number | tostring),
+  .tool.name,
+  .rule.id,
+  (.rule.security_severity_level // .rule.severity // "n/a"),
+  "\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)",
+  (.rule.description // .most_recent_instance.message.text | gsub("\n"; " "))
+] | @tsv' <<<"$alerts" | column -t -s "$(printf '\t')"


### PR DESCRIPTION
## Summary

Adds tooling to surface open code-scanning alerts (CodeQL, Trivy, Scout) without requiring interactive access to the GitHub Security tab. Includes a scheduled GitHub Actions workflow that dumps alerts to job logs, run summary, and a JSON artifact, plus a local bash script for on-demand reporting.

## Type

- [x] chore (CI / build / dependency / housekeeping)
- [x] docs

## Changes

- **`.github/workflows/code-scanning-report.yml`** — New workflow that runs weekly (Mondays 7 AM UTC) and on manual trigger. Fetches open code-scanning alerts via `gh api`, renders them as a TSV table (job logs), markdown table (run summary), and JSON artifact. Uses read-only `security-events` permission and the built-in `GITHUB_TOKEN`.
- **`scripts/security/code-scanning-report.sh`** — New bash script for local alert reporting. Requires `gh` (authenticated) and `jq`. Outputs a formatted table by default; `--json` flag returns raw payload. Configurable repo via `REPO` env var.
- **`.github/SECURITY_PIPELINE.md`** — Updated operational runbook with instructions for listing current alerts in CI (via workflow) and locally (via script).

## Test Plan

- Workflow can be triggered manually via `gh workflow run code-scanning-report.yml` or the Actions UI; verify it completes successfully and produces the three outputs (logs, summary, artifact).
- Local script can be run with `./scripts/security/code-scanning-report.sh` (requires prior `gh auth login`); verify table output and `--json` flag.
- No automated tests needed — both are simple data-fetching and formatting tools with no business logic.

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [x] I did not bump `/VERSION` (no user-facing feature change)
- [x] I updated user documentation in `docs/` (`.github/SECURITY_PIPELINE.md`)

https://claude.ai/code/session_01Jvgrp9tFfsunHfNNHn2XA3