### PR TITLE
Auto-close PRs from unallowlisted authors

### DIFF
--- a/.github/workflows/restrict-pr-authors.yml
+++ b/.github/workflows/restrict-pr-authors.yml
@@ -1,0 +1,43 @@
+name: Restrict PR authors
+
+# Closes any PR opened by an author not on the allowlist with a polite comment.
+# Uses pull_request_target so the job runs in the base repo's context and has
+# permission to close PRs from forks. No fork code is checked out, so this is safe.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close if author not on allowlist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          ALLOWED=(
+            "vincentmakes"
+            "dependabot[bot]"
+            "claude[bot]"
+            "claude-code[bot]"
+            "aqua-bot"
+          )
+          for allowed in "${ALLOWED[@]}"; do
+            if [[ "$AUTHOR" == "$allowed" ]]; then
+              echo "PR author '$AUTHOR' is on the allowlist."
+              exit 0
+            fi
+          done
+          echo "PR author '$AUTHOR' is not on the allowlist; closing PR #$PR_NUMBER."
+          gh pr comment "$PR_NUMBER" --body "Thanks for your interest in Turbo EA. This repository only accepts pull requests from the maintainer and a small set of trusted bots. Unsolicited PRs are auto-closed to keep the contribution surface manageable.
+
+          If you'd like to propose a change, please [open an issue](../../issues/new) first to discuss it. Direct PRs without a prior discussion will not be reviewed."
+          gh pr close "$PR_NUMBER"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-closes any PR opened by an author not on a small allowlist, with a polite comment pointing them to open an issue first. Goal: stop the inflow of drive-by PRs from contributors who don't follow the project's conventions.

## Type

- [x] chore (CI / build / dependency / housekeeping)

## Changes

- New workflow `.github/workflows/restrict-pr-authors.yml` triggered on `pull_request_target` (`opened`, `reopened`)
- Allowlist: `vincentmakes`, `dependabot[bot]`, `claude[bot]`, `claude-code[bot]`, `aqua-bot`
- Non-allowlisted authors get a polite comment and the PR is closed immediately

## Test Plan

- Workflow only triggers on new/reopened PRs after merge — existing open PRs are unaffected
- `pull_request_target` runs in the base repo's context with `pull-requests: write`, so it can close fork PRs without checking out fork code (safe — no untrusted code runs)
- After merge, will verify by watching the next non-allowlisted PR get auto-closed

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)