### PR TITLE
Add one-shot Trivy reconcile workflow to drain stale ≤medium alerts

### DIFF
--- a/.github/workflows/trivy-reconcile.yml
+++ b/.github/workflows/trivy-reconcile.yml
@@ -1,0 +1,89 @@
+# One-shot utility to reconcile stale, low-severity Trivy code-scanning alerts.
+#
+# Why this exists
+# ---------------
+# The regular Trivy steps in `docker-publish.yml` and `security-scan-published.yml`
+# scan with `severity: HIGH,CRITICAL` and upload SARIF under category
+# `trivy-<image>`. GitHub only auto-closes a code-scanning alert when a *new*
+# analysis in the SAME category omits it — but a HIGH+CRITICAL-only SARIF never
+# lists note/low/medium rules at all, so any <=medium alert created by an earlier
+# full-severity scan lingers open forever, even after the underlying package has
+# been rebuilt/patched. Rebuilding and republishing therefore cannot clear them.
+#
+# What this does
+# --------------
+# Re-scans the published `:latest` images across ALL severities and:
+#   1. Always prints an installed-vs-fixed vulnerability table to the job log
+#      (the diagnostic: is the package actually patched in the live image yet?).
+#   2. When `upload_sarif=true`, uploads a full-severity SARIF to the same
+#      `trivy-<image>` category so GitHub reconciles the Security tab — anything
+#      genuinely gone from the rebuilt image auto-closes, and anything listed in
+#      `.github/trivy-allowlist` is filtered out of the SARIF and closes too.
+#      (Run the diagnostic first with the default `false` so you can see the
+#      scope before writing to the Security tab.)
+#
+# Trigger from the Actions tab (workflow_dispatch), on `main`. Kept as a runbook
+# tool for future <=medium Trivy drift; see .github/SECURITY_PIPELINE.md.
+
+name: Trivy reconcile (stale alerts)
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_sarif:
+        description: "Upload full-severity SARIF to reconcile/close stale alerts (default: diagnostic table only)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  # Required to upload SARIF (which closes stale alerts) to the Security tab.
+  security-events: write
+
+jobs:
+  reconcile:
+    name: Reconcile ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The three images that carry the stale <=medium alerts. Extend if the
+        # backend / mcp-server images ever accumulate the same drift.
+        image: [db, frontend, nginx]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      # Diagnostic — always runs. Prints the installed vs fixed version per CVE
+      # so we can tell "already patched, just stale" from "genuinely unfixed".
+      - name: Trivy table (all severities, installed vs fixed)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          scan-type: image
+          scanners: vuln
+          format: table
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: "0"
+
+      # Reconcile — opt-in. Same severities + the shared allowlist, uploaded to
+      # the SAME category the stale alerts live under so GitHub closes them.
+      - name: Trivy SARIF (all severities) for reconciliation
+        if: ${{ inputs.upload_sarif }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          scan-type: image
+          scanners: vuln
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          trivyignores: .github/trivy-allowlist
+
+      - name: Upload SARIF to Security tab (same category reconciles stale alerts)
+        if: ${{ inputs.upload_sarif }}
+        uses: github/codeql-action/upload-sarif@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-${{ matrix.image }}


### PR DESCRIPTION
## Summary

The 44 open code-scanning alerts are all Trivy `note`/`low`/`medium` base-image CVEs, but the regular Trivy steps (`docker-publish.yml`, `security-scan-published.yml`) scan `severity: HIGH,CRITICAL` only. GitHub auto-closes an alert solely when a *new* analysis in the same `trivy-<image>` category omits it — and a HIGH+CRITICAL SARIF never lists the lower-severity rules, so these alerts can never self-close no matter how many times the images are rebuilt/republished. This adds a manual utility to reconcile them.

## Type

- [x] chore (CI / build / dependency / housekeeping)
- [x] security

## Changes

- New `.github/workflows/trivy-reconcile.yml` (`workflow_dispatch`, `security-events: write`), matrix over `db` / `frontend` / `nginx`.
- Always prints a Trivy **all-severities installed-vs-fixed table** to the job log — the diagnostic that tells "already patched, just stale" apart from "genuinely unfixed".
- With input `upload_sarif=true`, uploads a full-severity SARIF to the same `trivy-<image>` category (using the shared `.github/trivy-allowlist`) so genuinely-fixed findings auto-close and allowlisted residuals are filtered out — draining the stale backlog to zero.
- Pinned to the same action SHAs already used elsewhere in the repo (`trivy-action` v0.36.0, `codeql-action/upload-sarif` v3, `checkout` v6).

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/trivy-reconcile.yml'))"` → YAML valid.
- Post-merge: run from the Actions tab with the default `upload_sarif=false` to read the diagnostic table (confirms whether Alpine has shipped patched `expat`/db packages in the live `:latest` images), then re-run with `upload_sarif=true` to reconcile the Security tab to zero.

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [ ] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9vsK56XsphhBizhFSMFRx

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vsK56XsphhBizhFSMFRx)_