### PR TITLE
Recompute data_quality on bulk card update (PATCH /cards/bulk)

### DIFF
--- a/backend/app/api/v1/cards.py
+++ b/backend/app/api/v1/cards.py
@@ -1298,6 +1298,14 @@ async def bulk_update(
             "would_update": len(diffs),
         }
 
+    # Recompute data-quality for every updated card. Unlike create_card,
+    # bulk_create_cards and the single-card update_card, this bulk PATCH path
+    # historically skipped the recompute, leaving scores frozen at their prior
+    # (often creation-time) value after any bulk edit. Mirror the other paths so
+    # bulk edits keep the canonical completeness score in sync.
+    for card in sheets:
+        card.data_quality = await calc_data_quality(db, card)
+
     await db.commit()
     result = await db.execute(
         select(Card)

--- a/backend/tests/api/test_cards.py
+++ b/backend/tests/api/test_cards.py
@@ -748,3 +748,45 @@ class TestRelationSummary:
         # The Drill-Down menu must not lie about the number of children
         # it can actually fetch through /hierarchy.
         assert response.json()["hierarchy"]["children_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# PATCH /cards/bulk  (data-quality recompute regression)
+# ---------------------------------------------------------------------------
+
+
+class TestBulkUpdateRecomputesDataQuality:
+    """Regression: PATCH /cards/bulk must recompute ``data_quality`` like the
+    create and single-card update paths do. The bulk path previously committed
+    field changes without rescoring, leaving completeness scores frozen at
+    their prior (often creation-time) value."""
+
+    async def test_bulk_update_refreshes_score(self, client, db, cards_env):
+        admin = cards_env["admin"]
+        # Card created understated: no description, no attributes, score 0.
+        card = await create_card(
+            db,
+            card_type="Application",
+            name="Stale Score App",
+            data_quality=0.0,
+            attributes={},
+        )
+
+        response = await client.patch(
+            "/api/v1/cards/bulk",
+            json={
+                "ids": [str(card.id)],
+                "updates": {
+                    "description": "Now documented",
+                    "attributes": {"costTotalAnnual": 50000, "riskLevel": "high"},
+                },
+            },
+            headers=auth_headers(admin),
+        )
+
+        assert response.status_code == 200
+        updated = response.json()
+        assert len(updated) == 1
+        # Filling description + two weighted fields must lift the recomputed
+        # score above the stale 0.0 the card was created with.
+        assert updated[0]["data_quality"] > 0


### PR DESCRIPTION
## Problem
`data_quality` scores never refresh when cards are edited via `PATCH /cards/bulk` (the endpoint behind the MCP `update_cards_bulk` tool). Field/lifecycle/attribute changes persist correctly, but the completeness score stays frozen at each card's prior — usually creation-time — value.

## Root cause
`create_card`, `bulk_create_cards`, and the single-card `update_card` (`PATCH /cards/{id}`) all call `calc_data_quality` after applying changes. `bulk_update` (`PATCH /cards/bulk`) does not — it applies the updates and commits without rescoring. So a card created near-empty (~6%) stays at 6% no matter how many scored fields a later bulk edit fills, while the same edit through the single-card form recomputes correctly.

Surfaced while driving the API through the MCP `update_cards_bulk` tool: an inventory fully populated via bulk edits still reported near-zero completeness.

## Fix
Recompute `data_quality` for every updated card before commit in `bulk_update`, mirroring the other write paths:

```python
for card in sheets:
    card.data_quality = await calc_data_quality(db, card)
```

(`calc_data_quality` is already imported in the module.)

## Test
Adds `TestBulkUpdateRecomputesDataQuality::test_bulk_update_refreshes_score` in `tests/api/test_cards.py`: a card created with `data_quality=0` and no fields, then a bulk update filling `description` + two weighted attributes, asserting the returned `data_quality > 0`. Fails before this change, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
