### PR TITLE
ci: keep :latest patched by rebuilding apk-upgrade stages on every publish

### DIFF
--- a/.github/SECURITY_PIPELINE.md
+++ b/.github/SECURITY_PIPELINE.md
@@ -40,6 +40,17 @@ Two scanners covering the same layer is deliberate — different vuln DBs have d
 5. **Trivy gate** (CRITICAL only, `exit-code: 1`, `ignore-unfixed: true`) — fails the publish on any CRITICAL not in [`.github/trivy-allowlist`](trivy-allowlist). Introduced after CVE-2026-42945 ("NGINX Rift") slipped through the observe-only setup.
 6. **Scout observe** (`only-severities: critical,high`, `exit-code: false`) — SARIF → Security tab under `scout-<image>`. Gated on `DOCKERHUB_PAT` secret presence so the workflow stays green if credentials are removed.
 
+> **apk fixes stick on every build, not just no-cache runs.** `no-cache: true`
+> is only set on `schedule` / `workflow_dispatch`, but the build step also sets
+> `no-cache-filter: backend,db,frontend,nginx,mcp-server` so the runtime stages
+> (the ones running `apk upgrade --no-cache`) are rebuilt against the live alpine
+> repos on **every** build, including cached `push` builds. Without this, a clean
+> republish that pulled a fresh apk fix was silently reverted by the next
+> push-to-`main`, which reused the cached (unpatched) `apk upgrade` layer and
+> overwrote `:latest` — the failure mode behind the persistent curl 8.19.0-r0
+> findings in July 2026. The expensive `frontend-build` / `backend-build` stages
+> are deliberately excluded from the filter, so push builds stay fast.
+
 ### Weekly — Monday 06:00 UTC
 [`docker-publish.yml`](workflows/docker-publish.yml) re-runs with `no-cache: true` for cron events. The runtime Dockerfile stages each run `apk upgrade --no-cache`, so a forced rebuild against fresh alpine repos automatically picks up apk-package CVEs in pinned bases — no human in the loop.
 
@@ -87,6 +98,33 @@ have. To get the open alerts (CodeQL + Trivy + Scout) as a plain table:
    - **No patch, not exploitable in our usage path** → allowlist in `.github/trivy-allowlist`. **Required**: a comment block above the CVE explaining package, why it isn't exploitable for us, reviewer initials, date. Re-evaluate next quarter.
    - **No patch, exploitable** → don't ship. Mitigate at the nginx / app layer if possible; otherwise the workflow stays red until upstream fixes.
 3. Re-run the workflow.
+
+### An apk-fixable finding won't clear after republishing
+
+Symptom: a `curl` / `openssl` / `nghttp2` etc. CVE that Trivy marks `fixed`
+(a patched apk version exists) keeps showing open in the Security tab even after
+you republish the image.
+
+1. **Confirm the live image is actually patched.** Run
+   [`trivy-reconcile.yml`](workflows/trivy-reconcile.yml) with the default
+   `upload_sarif=false` and read the installed-vs-fixed table in the job log. If
+   the **installed** version is still the old one, the image itself is stale —
+   go to step 2. If it already shows the fixed version, the alert is just stale
+   in the tab — skip to step 3.
+2. **Republish so `:latest` carries the fix.** Since the build step sets
+   `no-cache-filter` on the runtime stages, any publish (a merge to `main`, or a
+   `workflow_dispatch` run of `docker-publish.yml`) now rebuilds `apk upgrade`
+   against the live alpine repos, so `:latest` picks up the fix and stays patched
+   across subsequent pushes. (Before that filter existed, a cached push would
+   overwrite the patched `:latest` right back to the stale layer.)
+3. **Close stale `<=medium` alerts.** The routine observe scans are
+   `HIGH,CRITICAL` only, so a MEDIUM alert created by an earlier all-severity
+   scan never auto-closes on rebuild. Run `trivy-reconcile.yml` with
+   `upload_sarif=true` — it uploads an all-severity SARIF to the same
+   `trivy-<image>` category, so GitHub closes everything now absent from the
+   rebuilt image. HIGH/CRITICAL alerts self-heal via the next publish/daily
+   observe once the image is patched, but the reconcile closes them immediately
+   too.
 
 ### The Trivy allowlist file
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,6 +97,15 @@ jobs:
           # actually re-runs against fresh alpine repos. Regular push builds
           # keep the cache for speed (~1m vs ~14m).
           no-cache: ${{ github.event_name != 'push' }}
+          # ...but even on cached push builds, always rebuild the runtime stages
+          # so `apk upgrade --no-cache` re-runs against the live alpine repos and
+          # `:latest` can never regress to a stale cached apk layer. Without this,
+          # a clean workflow_dispatch/schedule republish that pulls a fresh apk
+          # fix is silently overwritten by the very next push-to-main, which
+          # reuses the cached (unpatched) `apk upgrade` layer. The expensive
+          # build stages (frontend-build npm ci/build, backend-build pip) are NOT
+          # listed here, so they stay cached and push builds stay fast.
+          no-cache-filter: backend,db,frontend,nginx,mcp-server
           provenance: true
           sbom: true
 


### PR DESCRIPTION
## Summary

Persistent HIGH+MEDIUM `curl`/`libcurl` code-scanning findings on the `frontend` and `nginx` images kept reappearing after republishing. Root cause: the publish build only set `no-cache` on `schedule`/`workflow_dispatch`, so a clean republish that pulled a fresh Alpine curl fix (8.20.0-r0) was silently overwritten by the next push-to-`main`, which reused the cached (unpatched, 8.19.0-r0) `apk upgrade` layer and re-tagged `:latest`.

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore (CI / build / dependency / housekeeping)
- [x] security

## Changes

- Add `no-cache-filter: backend,db,frontend,nginx,mcp-server` to the `docker/build-push-action` step in `docker-publish.yml`, so the runtime stages that run `apk upgrade --no-cache` are rebuilt against the live Alpine repos on **every** build (including cached `push` builds), while the expensive `frontend-build` / `backend-build` stages stay cached and push builds stay fast. `:latest` can no longer regress to a stale apk layer.
- Document the regression and the reconcile runbook (clearing stale `<=medium` alerts via `trivy-reconcile.yml` with `upload_sarif=true`) in `.github/SECURITY_PIPELINE.md`.

## Test Plan

Diagnosis was evidence-based, from the repo's own tooling on the live images (2026-07-15):
- `code-scanning-report.yml` dump → 32 open alerts, all the same 8 curl CVEs (2 HIGH + 6 MEDIUM) × `curl`/`libcurl` across `frontend` + `nginx`.
- `trivy-reconcile.yml` installed-vs-fixed table → live `frontend:latest` is alpine 3.23.5 with `curl`/`libcurl` **8.19.0-r0**; fix available in **8.20.0-r0** (Trivy status `fixed`).
- `docker-publish.yml` run history → a clean `workflow_dispatch` publish at 06:23 was followed by cached `push` publishes (06:28 / 06:46 / 09:11 / 12:45) that reverted `:latest`.

Post-merge verification (this push triggers `docker-publish.yml`):
- Re-run `trivy-reconcile.yml` (diagnostic, `upload_sarif=false`) → expect `curl`/`libcurl` **8.20.0-r0**, zero curl rows.
- Run `trivy-reconcile.yml` with `upload_sarif=true` (frontend, nginx) → closes the stale MEDIUM alerts.
- Re-run `code-scanning-report.yml` → expect the 32 curl alerts gone.

- [ ] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [x] Manually tested the affected feature <!-- verified via CI workflow logs / Trivy diagnostic on the live images -->
- [ ] Added/updated tests for new or changed behavior <!-- CI workflow change; no unit-testable surface -->

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints <!-- n/a: CI-only change -->
- [ ] I created an Alembic migration for any schema changes <!-- n/a -->
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven) <!-- n/a -->
- [ ] I used `async def` for all new route handlers and DB operations <!-- n/a -->
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses <!-- n/a -->
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change) <!-- n/a: internal CI/pipeline change, not user-facing -->
- [ ] I added translations for new UI strings in all 8 locales (if applicable) <!-- n/a -->
- [ ] I updated user documentation in `docs/` (if UI or feature change) <!-- n/a: internal pipeline doc updated instead -->
- [ ] Screenshots attached for UI changes (if applicable) <!-- n/a -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018xngb7WPtFVHx5WgpghXFp)_