### PR TITLE
ci: fix no-cache-filters typo so release :latest gets fresh apk packages

### DIFF
--- a/.github/SECURITY_PIPELINE.md
+++ b/.github/SECURITY_PIPELINE.md
@@ -40,16 +40,29 @@ Two scanners covering the same layer is deliberate — different vuln DBs have d
 5. **Trivy gate** (CRITICAL only, `exit-code: 1`, `ignore-unfixed: true`) — fails the publish on any CRITICAL not in [`.github/trivy-allowlist`](trivy-allowlist). Introduced after CVE-2026-42945 ("NGINX Rift") slipped through the observe-only setup.
 6. **Scout observe** (`only-severities: critical,high`, `exit-code: false`) — SARIF → Security tab under `scout-<image>`. Gated on `DOCKERHUB_PAT` secret presence so the workflow stays green if credentials are removed.
 
-> **apk fixes stick on every build, not just no-cache runs.** `no-cache: true`
-> is only set on `schedule` / `workflow_dispatch`, but the build step also sets
-> `no-cache-filter: backend,db,frontend,nginx,mcp-server` so the runtime stages
-> (the ones running `apk upgrade --no-cache`) are rebuilt against the live alpine
-> repos on **every** build, including cached `push` builds. Without this, a clean
-> republish that pulled a fresh apk fix was silently reverted by the next
-> push-to-`main`, which reused the cached (unpatched) `apk upgrade` layer and
-> overwrote `:latest` — the failure mode behind the persistent curl 8.19.0-r0
-> findings in July 2026. The expensive `frontend-build` / `backend-build` stages
-> are deliberately excluded from the filter, so push builds stay fast.
+> **`:latest` publishing + apk freshness — the two things to know.**
+> 1. **What publishes `:latest`.** `latest=auto` + the two explicit `type=raw`
+>    entries mean `:latest` is retagged on **semver tag pushes** (`v*.*.*`
+>    releases), on **`workflow_dispatch` from `main`**, and on the **weekly
+>    `schedule`**. A plain merge to `main` publishes `:main` + `:sha-XXX` only —
+>    **not** `:latest`. So `:latest` (what docker-compose and the daily security
+>    scan consume) tracks releases + the weekly rebuild, not every commit.
+> 2. **Keeping cached builds apk-fresh.** `no-cache: true` is only set on
+>    `schedule` / `workflow_dispatch`; branch **and tag** pushes are `push`
+>    events, so they build **cached**. Because a `v*.*.*` tag push is cached yet
+>    publishes `:latest`, a release could otherwise ship `:latest` with a stale
+>    apk layer. The build step therefore also sets
+>    `no-cache-filters: backend,db,frontend,nginx,mcp-server` (plural — the
+>    singular form is silently ignored), which forces just the runtime stages
+>    (the ones running `apk upgrade --no-cache`) to rebuild against the live
+>    alpine repos on **every** build, cached ones included, while the expensive
+>    `frontend-build` / `backend-build` stages stay cached. This closes the curl
+>    8.19.0-r0 → 8.20.0-r0 gap seen in July 2026, where `:latest` kept shipping a
+>    cached, unpatched curl.
+>
+> To force a fresh `:latest` on demand (e.g. right after an alpine CVE fix lands
+> in the repo), run `docker-publish.yml` via **`workflow_dispatch` from `main`**
+> — it is `no-cache: true` and tags `:latest`.
 
 ### Weekly — Monday 06:00 UTC
 [`docker-publish.yml`](workflows/docker-publish.yml) re-runs with `no-cache: true` for cron events. The runtime Dockerfile stages each run `apk upgrade --no-cache`, so a forced rebuild against fresh alpine repos automatically picks up apk-package CVEs in pinned bases — no human in the loop.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,15 +97,18 @@ jobs:
           # actually re-runs against fresh alpine repos. Regular push builds
           # keep the cache for speed (~1m vs ~14m).
           no-cache: ${{ github.event_name != 'push' }}
-          # ...but even on cached push builds, always rebuild the runtime stages
-          # so `apk upgrade --no-cache` re-runs against the live alpine repos and
-          # `:latest` can never regress to a stale cached apk layer. Without this,
-          # a clean workflow_dispatch/schedule republish that pulls a fresh apk
-          # fix is silently overwritten by the very next push-to-main, which
-          # reuses the cached (unpatched) `apk upgrade` layer. The expensive
-          # build stages (frontend-build npm ci/build, backend-build pip) are NOT
-          # listed here, so they stay cached and push builds stay fast.
-          no-cache-filter: backend,db,frontend,nginx,mcp-server
+          # ...but even on cached `push` builds, always rebuild the runtime
+          # stages so `apk upgrade --no-cache` re-runs against the live alpine
+          # repos. This matters most for RELEASES: a `v*.*.*` tag push is a
+          # `push` event, so `no-cache` above is false and the build is cached —
+          # yet a tag push is what publishes `:latest` (via `latest=auto`).
+          # Without this filter a release could ship `:latest` with a stale
+          # cached apk layer (the curl 8.19.0-r0 vs 8.20.0-r0 gap in July 2026).
+          # The expensive build stages (frontend-build npm ci/build,
+          # backend-build pip) are NOT listed, so they stay cached and builds
+          # stay fast. NOTE: the input is `no-cache-filters` (plural) —
+          # build-push-action silently ignores the singular form.
+          no-cache-filters: backend,db,frontend,nginx,mcp-server
           provenance: true
           sbom: true
 


### PR DESCRIPTION
## Summary

Follow-up to #836. That PR added `no-cache-filter` (singular) to the publish build step, but `docker/build-push-action` silently ignores it — GitHub logs `Unexpected input(s) 'no-cache-filter'` — so the change was inert and the runtime stages were never force-rebuilt. This corrects it to `no-cache-filters` (plural) and fixes the accompanying doc, which described the wrong mechanism.

## Type

- [ ] feature
- [x] fix
- [ ] refactor
- [ ] docs
- [x] chore (CI / build / dependency / housekeeping)
- [x] security

## Changes

- Correct `no-cache-filter` → `no-cache-filters` (plural) in the `docker/build-push-action` step of `docker-publish.yml`. This is the input that forces the runtime stages (`backend`, `db`, `frontend`, `nginx`, `mcp-server` — the ones running `apk upgrade --no-cache`) to rebuild against the live Alpine repos even on cached builds, while the expensive `frontend-build` / `backend-build` stages stay cached.
- Correct the `SECURITY_PIPELINE.md` note to describe the real mechanism:
  - **What publishes `:latest`:** semver `v*.*.*` tag pushes (via `latest=auto`), `workflow_dispatch` from `main`, and the weekly `schedule` — **not** a plain merge to `main` (which publishes `:main` + `:sha-XXX` only).
  - **Why the filter matters:** a `v*.*.*` tag push is a `push` event, so `no-cache` is `false` and the build is cached — yet a tag push is exactly what publishes `:latest`. Without the filter, a **release** could ship `:latest` with a stale cached apk layer. This was the real gap behind the curl 8.19.0-r0 → 8.20.0-r0 findings.
  - How to force a fresh `:latest` on demand: run `docker-publish.yml` via `workflow_dispatch` from `main`.

## Test Plan

- Confirmed from the #836 merge publish run that GitHub logged `Unexpected input(s) 'no-cache-filter'` and the frontend runtime stage built in ~21s (cache hit) — i.e. the singular input was ignored and `apk upgrade` did not re-run.
- Verified the corrected input name (`no-cache-filters`) against the action's accepted inputs list printed in that same log.
- Validated `docker-publish.yml` parses as YAML.
- Post-merge, the publish on `main` should show the frontend/nginx runtime stages rebuilding (not a sub-second cache hit) and their Trivy scans reporting the current Alpine package set.

- [ ] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [x] Manually tested the affected feature <!-- verified via the #836 publish-run build logs (Unexpected-input warning + cached 21s build) -->
- [ ] Added/updated tests for new or changed behavior <!-- CI workflow change; no unit-testable surface -->

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints <!-- n/a: CI-only change -->
- [ ] I created an Alembic migration for any schema changes <!-- n/a -->
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven) <!-- n/a -->
- [ ] I used `async def` for all new route handlers and DB operations <!-- n/a -->
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses <!-- n/a -->
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change) <!-- n/a: internal CI/pipeline change, not user-facing -->
- [ ] I added translations for new UI strings in all 8 locales (if applicable) <!-- n/a -->
- [ ] I updated user documentation in `docs/` (if UI or feature change) <!-- n/a: internal pipeline doc updated instead -->
- [ ] Screenshots attached for UI changes (if applicable) <!-- n/a -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018xngb7WPtFVHx5WgpghXFp)_