### PR TITLE
Fix docker-publish buildx incompatibility: guard no-cache-filters on push

### DIFF
--- a/.github/SECURITY_PIPELINE.md
+++ b/.github/SECURITY_PIPELINE.md
@@ -53,12 +53,19 @@ Two scanners covering the same layer is deliberate — different vuln DBs have d
 >    publishes `:latest`, a release could otherwise ship `:latest` with a stale
 >    apk layer. The build step therefore also sets
 >    `no-cache-filters: backend,db,frontend,nginx,mcp-server` (plural — the
->    singular form is silently ignored), which forces just the runtime stages
->    (the ones running `apk upgrade --no-cache`) to rebuild against the live
->    alpine repos on **every** build, cached ones included, while the expensive
->    `frontend-build` / `backend-build` stages stay cached. This closes the curl
->    8.19.0-r0 → 8.20.0-r0 gap seen in July 2026, where `:latest` kept shipping a
->    cached, unpatched curl.
+>    singular form is silently ignored) **on `push` events only**, which forces
+>    just the runtime stages (the ones running `apk upgrade --no-cache`) to
+>    rebuild against the live alpine repos on every cached build, while the
+>    expensive `frontend-build` / `backend-build` stages stay cached. This
+>    closes the curl 8.19.0-r0 → 8.20.0-r0 gap seen in July 2026, where
+>    `:latest` kept shipping a cached, unpatched curl.
+>
+>    The `push`-only condition is **not** cosmetic: buildx hard-rejects
+>    `--no-cache` and `--no-cache-filter` in the same invocation (*"cannot
+>    currently be used together"*). Emitting both killed every `schedule` and
+>    `workflow_dispatch` run for three weeks in 2026-07. Scheduled and manual
+>    runs don't need the filters anyway — their full `--no-cache` already
+>    rebuilds every stage.
 >
 > To force a fresh `:latest` on demand (e.g. right after an alpine CVE fix lands
 > in the repo), run `docker-publish.yml` via **`workflow_dispatch` from `main`**
@@ -124,12 +131,13 @@ you republish the image.
    the **installed** version is still the old one, the image itself is stale —
    go to step 2. If it already shows the fixed version, the alert is just stale
    in the tab — skip to step 3.
-2. **Republish so `:latest` carries the fix.** Since the build step sets
-   `no-cache-filter` on the runtime stages, any publish (a merge to `main`, or a
-   `workflow_dispatch` run of `docker-publish.yml`) now rebuilds `apk upgrade`
-   against the live alpine repos, so `:latest` picks up the fix and stays patched
-   across subsequent pushes. (Before that filter existed, a cached push would
-   overwrite the patched `:latest` right back to the stale layer.)
+2. **Republish so `:latest` carries the fix.** Any publish rebuilds `apk
+   upgrade` against the live alpine repos, so `:latest` picks up the fix and
+   stays patched across subsequent pushes — a cached push via the
+   `no-cache-filters` on the runtime stages, a `workflow_dispatch` run of
+   `docker-publish.yml` via its full `no-cache`. (Before those filters existed,
+   a cached push would overwrite the patched `:latest` right back to the stale
+   layer.)
 3. **Close stale `<=medium` alerts.** The routine observe scans are
    `HIGH,CRITICAL` only, so a MEDIUM alert created by an earlier all-severity
    scan never auto-closes on rebuild. Run `trivy-reconcile.yml` with

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -106,9 +106,23 @@ jobs:
           # cached apk layer (the curl 8.19.0-r0 vs 8.20.0-r0 gap in July 2026).
           # The expensive build stages (frontend-build npm ci/build,
           # backend-build pip) are NOT listed, so they stay cached and builds
-          # stay fast. NOTE: the input is `no-cache-filters` (plural) —
-          # build-push-action silently ignores the singular form.
-          no-cache-filters: backend,db,frontend,nginx,mcp-server
+          # stay fast.
+          #
+          # ⚠️ THE `push` GUARD BELOW IS LOAD-BEARING — DO NOT MAKE THIS
+          # UNCONDITIONAL. buildx hard-rejects `--no-cache` and
+          # `--no-cache-filter` in the same invocation ("cannot currently be
+          # used together"), so the filters may only be emitted on the events
+          # where `no-cache` above is false, i.e. `push`. On `schedule` /
+          # `workflow_dispatch` the full `--no-cache` already rebuilds every
+          # stage, so the filters would be redundant there anyway. Setting
+          # both broke every scheduled and manual run from 2026-07-15 (when
+          # the singular→plural typo fix in #837 made this input take effect)
+          # until it was caught three weeks later.
+          #
+          # NOTE: the input is `no-cache-filters` (plural) — build-push-action
+          # silently ignores the singular form. An empty string is parsed as an
+          # empty list, so no `--no-cache-filter` flag is emitted at all.
+          no-cache-filters: ${{ github.event_name == 'push' && 'backend,db,frontend,nginx,mcp-server' || '' }}
           provenance: true
           sbom: true
 
@@ -153,8 +167,11 @@ jobs:
           # fail on the bare CVE lines.
           trivyignores: .github/trivy-allowlist
 
+      # Guarded on the file existing, not just `always()`: when the build step
+      # fails there is no SARIF, and an unguarded upload adds a second red
+      # "Path does not exist" error that buries the real build failure.
       - name: Upload Trivy SARIF to Security tab
-        if: always()
+        if: always() && hashFiles(format('trivy-{0}.sarif', matrix.image)) != ''
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: trivy-${{ matrix.image }}.sarif


### PR DESCRIPTION
## Summary

Every `schedule` and `workflow_dispatch` run of `docker-publish.yml` has failed since 2026-07-15 — buildx hard-rejects `--no-cache` and `--no-cache-filter` in the same invocation, and the workflow set both unconditionally. This emits `no-cache-filters` on `push` events only, where `no-cache` is false and the filters actually do work; scheduled and manual runs keep their full `--no-cache`, which already rebuilds every stage.

## Type

- [x] fix
- [x] chore (CI / build / dependency / housekeeping)

## Changes

- **`docker-publish.yml`** — `no-cache-filters` is now `${{ github.event_name == 'push' && 'backend,db,frontend,nginx,mcp-server' || '' }}`. An empty string is parsed as an empty list, so no flag is emitted on the events where `--no-cache` is already set.
- **`docker-publish.yml`** — the guard carries a load-bearing comment. This line has broken twice in three weeks (singular→plural typo in #836/#837, then this conflict) and no CI job lints it.
- **`docker-publish.yml`** — the Trivy SARIF upload is now guarded on the file existing (`hashFiles(...)`), matching the Docker Scout upload below it. The unguarded `always()` added a second red `Path does not exist: trivy-<image>.sarif` to every failed build, which is what the run summary surfaced instead of the actual buildx error.
- **`SECURITY_PIPELINE.md`** — documents the `push`-only condition and why it is not cosmetic; fixes a stale singular `no-cache-filter` reference in the alert-triage runbook.

### Root cause

`no-cache: ${{ github.event_name != 'push' }}` is `true` on cron, and `no-cache-filters` was set unconditionally. That combination only started failing after #837 (`54fa35e`) fixed the singular→plural typo: before it, `no-cache-filter` was an unknown input that `build-push-action` silently dropped, so only `--no-cache` reached buildx. Fixing the typo made the flag real — and immediately illegal on non-`push` events.

Last green `schedule` was 2026-07-13; last green `workflow_dispatch` was 2026-07-15 13:39 UTC, before #837 merged.

### Impact

`:latest` was **not** stale. Push events (merges to `main` and `v*.*.*` tags) build with `no-cache: false` and were unaffected, so the `no-cache-filters` kept busting the `apk upgrade` runtime stages — the 2026-07-30 and 2026-08-01 releases carry fresh apk layers. What was lost is the unattended weekly refresh during code-quiet weeks, and the `workflow_dispatch` escape hatch that `SECURITY_PIPELINE.md` documents for forcing a fresh `:latest` after an alpine CVE fix.

## Test Plan

`docker-publish.yml` does not run on pull requests, and the repo has no actionlint/workflow-lint job — so **PR CI cannot exercise this change**. What was verified locally instead:

- Confirmed the failure mode in the logs of run [30799538930](https://github.com/vincentmakes/turbo-ea/actions/runs/30799538930): all 5 matrix jobs, `ERROR: failed to build: --no-cache and --no-cache-filter cannot currently be used together`.
- Confirmed the blast radius from run history — `push` runs green throughout, `schedule` red since 2026-07-20, `workflow_dispatch` red since #837 merged.
- Parsed the workflow with PyYAML and asserted the two inputs and the new `if:` render as intended.
- Checked the pinned action source rather than assuming behaviour: `build-push-action@53b7df9` `src/context.ts` pushes one `--no-cache-filter` per list item, and `@docker/actions-toolkit@0.92.0` `getList()` early-returns `[]` on an empty string (plus a trailing `.filter(item => item)`). So the falsy branch emits no flag at all.

Post-merge verification (the only real proof):

1. The merge fires a `push` run → should stay green, with `--no-cache-filter backend ...` and no `--no-cache` on the buildx command line.
2. Trigger **`workflow_dispatch` from `main`** → exercises the identical `no-cache: true` branch the weekly cron uses. Expect `--no-cache` and no `--no-cache-filter`, all 5 images pushed, cosign signing, Trivy gate running.
3. Confirm `:latest` moved (`docker buildx imagetools inspect ghcr.io/vincentmakes/turbo-ea/backend:latest`).

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature — not possible pre-merge; see above
- [ ] Added/updated tests for new or changed behavior — no workflow-lint harness in this repo; the guard comment is the mitigation

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change) — CI-only, not user-facing; matches the precedent of `54fa35e` / `a19f992`
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change) — internal `.github/SECURITY_PIPELINE.md` updated instead
- [ ] Screenshots attached for UI changes (if applicable)