### PR TITLE
Stop two flaky teardown/timing failures in the frontend suite

### DIFF
--- a/frontend/src/features/admin/ImpersonateRoleDialog.test.tsx
+++ b/frontend/src/features/admin/ImpersonateRoleDialog.test.tsx
@@ -38,6 +38,16 @@ const MOCK_ROLES = [
   { id: "4", key: "old", label: "Archived role", color: "#000", is_system: false, is_default: false, is_archived: true, permissions: {}, sort_order: 4 },
 ];
 
+/**
+ * The Select is gated behind the dialog's `loading` flag, so it does not exist
+ * until `api.get` has *resolved* and React has committed. Waiting on the mock
+ * having been *called* is not the same thing — that is true the instant the
+ * effect fires, one microtask too early — so these tests wait on the rendered
+ * combobox instead. `findByRole` retries; `getByRole` does not, which is what
+ * made this file fail under load on CI while passing locally.
+ */
+const combobox = () => screen.findByRole("combobox");
+
 describe("ImpersonateRoleDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -51,9 +61,9 @@ describe("ImpersonateRoleDialog", () => {
 
   it("fetches roles on open and excludes admin + archived", async () => {
     wrap(<ImpersonateRoleDialog open onClose={() => {}} onSuccess={() => {}} />);
-    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/roles"));
     // Open the Select to make its options visible in the DOM.
-    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.mouseDown(await combobox());
+    expect(api.get).toHaveBeenCalledWith("/roles");
     await screen.findByRole("option", { name: "Member" });
     expect(screen.queryByRole("option", { name: "Admin" })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Archived role" })).not.toBeInTheDocument();
@@ -66,9 +76,8 @@ describe("ImpersonateRoleDialog", () => {
     const onSuccess = vi.fn();
     const onClose = vi.fn();
     wrap(<ImpersonateRoleDialog open onClose={onClose} onSuccess={onSuccess} />);
-    await waitFor(() => expect(api.get).toHaveBeenCalled());
 
-    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.mouseDown(await combobox());
     fireEvent.click(await screen.findByRole("option", { name: "Viewer" }));
     fireEvent.click(screen.getByRole("button", { name: /Start viewing/i }));
 
@@ -81,9 +90,8 @@ describe("ImpersonateRoleDialog", () => {
   it("renders an error when impersonate API fails", async () => {
     (auth.impersonate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Forbidden"));
     wrap(<ImpersonateRoleDialog open onClose={() => {}} onSuccess={() => {}} />);
-    await waitFor(() => expect(api.get).toHaveBeenCalled());
 
-    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.mouseDown(await combobox());
     fireEvent.click(await screen.findByRole("option", { name: "Member" }));
     fireEvent.click(screen.getByRole("button", { name: /Start viewing/i }));
 

--- a/frontend/src/features/inventory/InventoryDragFill.test.tsx
+++ b/frontend/src/features/inventory/InventoryDragFill.test.tsx
@@ -7,6 +7,18 @@
  * so the page's `onFill` can be invoked directly — the request shape is a
  * stable seam, and driving a pointer drag through the page's own stubbed grid
  * would test the stub, not the writes.
+ *
+ * AG Grid itself is stubbed too, so **there is no grid DOM to assert on here**
+ * — add a case that needs one to `useDragFill.integration.test.tsx` instead.
+ * That is not just tidiness: `handleGridFill` fires `loadData()` without
+ * awaiting it (one reload per fill, by design), so every test below ends with
+ * a re-render in flight. React's scheduler runs on Node's `setImmediate`,
+ * which jsdom's teardown does not cancel — so with a real grid mounted, a
+ * continuation could commit after `window` was deleted and reach AG Grid's
+ * `dispatchAsync`, throwing `ReferenceError: window is not defined` as an
+ * unhandled error and failing CI with every test passing. With no grid there
+ * is no `RowRenderer`, so that cannot happen rather than merely being
+ * unlikely. `InventoryPage.test.tsx` stubs AG Grid for the same reason.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
@@ -34,6 +46,13 @@ vi.mock("./ImportDialog", () => ({ default: () => null }));
 vi.mock("./RelationCellPopover", () => ({ default: () => null }));
 vi.mock("ag-grid-community/styles/ag-grid.css", () => ({}));
 vi.mock("ag-grid-community/styles/ag-theme-quartz.css", () => ({}));
+// Nothing here reads grid DOM or the grid api — see the header. `AgGridReact`
+// is the page's only value import from this module (the rest are types), and
+// every `gridRef.current?.api` call site is optional-chained, so the page
+// mounts fine without it.
+vi.mock("ag-grid-react", () => ({
+  AgGridReact: () => <div data-testid="ag-grid" />,
+}));
 
 // Capture the options the page hands the hook so `onFill` can be driven
 // directly; render nothing.

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -8,21 +8,41 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-// AG Grid schedules async event flushes via window.setTimeout (e.g.
-// RowRenderer's displayedRowsChanged). When the last test of a file finishes
-// while such a timeout is pending, it fires after jsdom is torn down and
-// throws "window is not defined" — Vitest reports that as an unhandled error
-// and fails the run even though every test passed (flaky on slow CI runners).
-// Drain the macrotask queue after each test. Hooks run in reverse
-// registration order, so Testing Library's auto-cleanup (registered by the
-// test file's imports) has already unmounted by the time this runs — the
-// drain also catches flushes scheduled during grid destroy. Two ticks cover
-// a flush that schedules a follow-up. Skipped under fake timers: mocked
-// timeouts die with the mock clock and never reach the real event loop.
+// Drain pending async work after each test, so nothing lands after Vitest has
+// torn jsdom down and deleted `window`. The symptom is an unhandled
+// "ReferenceError: window is not defined" — typically AG Grid's
+// `LocalEventService.dispatchAsync`, reached from a late `RowRenderer` redraw
+// — which fails the run even though every test passed, and only on loaded CI
+// runners.
+//
+// Two queues matter, and they are drained separately because neither drains
+// the other:
+//   - the timer queue (`setTimeout`), which is what AG Grid itself schedules;
+//   - Node's check phase (`setImmediate`), which is what React 19's scheduler
+//     posts its work through. jsdom's teardown calls `window.close()` and so
+//     cancels every `window.setTimeout`/rAF, but it has no say over
+//     `setImmediate` — that is the queue a late React commit rides in on.
+//
+// Hooks run in reverse registration order, so Testing Library's auto-cleanup
+// (registered by the test file's imports) has already unmounted by the time
+// this runs; the drain therefore also catches work scheduled during unmount.
+//
+// This is defence in depth, NOT a guarantee: React re-posts itself whenever it
+// yields, so a fixed number of drains narrows the window rather than closing
+// it. The deterministic fix for any one file is to leave nothing in flight —
+// either stub the grid (`InventoryDragFill.test.tsx`) or end the test by
+// awaiting the grid's own DOM (`InventoryFreezePersistence.test.tsx`,
+// `InventoryOrderPersistence.test.tsx`). A test that mounts a real AG Grid and
+// does neither will eventually trip this again.
+//
+// Skipped under fake timers: mocked timeouts die with the mock clock and never
+// reach the real event loop.
 afterEach(async () => {
   if (vi.isFakeTimers()) return;
   await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setImmediate(resolve));
 });
 
 // Ensure i18n is set to English for all tests so t() returns English text.


### PR DESCRIPTION
## Summary

Frontend CI went red on `main` with every test passing — Vitest exits non-zero on unhandled errors, and two were escaping from a late AG Grid redraw that ran after jsdom had been torn down. Fixing that surfaced a second, unrelated flake in the impersonation dialog tests. Both are timing races in test code; no production code changes.

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore (CI / build / dependency / housekeeping)
- [ ] security

## Changes

### 1. Late AG Grid redraw after jsdom teardown

- **`frontend/src/features/inventory/InventoryDragFill.test.tsx`** — stub `ag-grid-react`. The file never reads grid DOM or the grid api (its own header says the drag gesture is covered against a real grid in `useDragFill.integration.test.tsx`), so the real grid bought nothing and cost a teardown race. `InventoryPage.test.tsx` already stubs it for the same reason.
- **`frontend/src/test/setup.ts`** — the existing `afterEach` drain named this exact symptom in its comment but drained only the timer queue, which cannot reach React's scheduler. It now drains Node's check phase (`setImmediate`) as well, and the comment says plainly that this is defence in depth rather than a guarantee, and names the deterministic alternative.

**Mechanism.** `handleGridFill` fires `loadData()` without awaiting it — one reload per fill, which is correct in production — so each test ends with a grid re-render in flight. React 19's scheduler posts work through Node's `setImmediate`, which jsdom's teardown does not cancel: `window.close()` kills every `window.setTimeout` and rAF, but not a check-phase continuation. That continuation commits after `window` has been deleted, reaches `RowRenderer.dispatchDisplayedRowsChanged` → `dispatchAsync` → `flush`, and dereferences the bare global `window`. With `ag-grid-react` stubbed there is no `RowRenderer`, so that stack is impossible in this file rather than merely unlikely.

**Not a regression from #955.** The identical tree passed CI on the branch (`ef68f397`, run 31969207580) and failed on `main` (`accbb837`, run 31969621760) — `accbb837` is the squash-merge, so the content is byte-identical. `InventoryDragFill.test.tsx` arrived three hours earlier in #953; #955 added three test files and 32 tests, which shifted scheduling enough to tip a race that was already present.

### 2. Impersonation dialog tests reached for a Select that had not rendered

Surfaced by this PR's own first CI run, which failed with `Unable to find an accessible element with the role "combobox"` and a DOM dump showing a `CircularProgress` and a disabled **Start viewing** button.

- **`frontend/src/features/admin/ImpersonateRoleDialog.test.tsx`** — `ImpersonateRoleDialog` gates its `<Select>` behind a `loading` flag, so the combobox does not exist until `api.get("/roles")` has *resolved* and React has committed. Three tests waited on `expect(api.get).toHaveBeenCalled()` and then reached for the combobox with `getByRole`. The call is observable the instant the effect fires, one microtask before the resolution that clears the flag, and `getByRole` does not retry — so the reach was a race against that microtask. They now wait on the rendered combobox with `findByRole`, which retries until the spinner is replaced. That still proves the fetch happened (the Select cannot appear without it), so the assertion on the `/roles` path simply moves after the await.

Pre-existing since #879 and unrelated to the first half of this PR.

## Test Plan

**AG Grid half** — ran the exact CI command locally (`npx vitest run --coverage.enabled --coverage.reporter=text`) three times: 2532 tests passed, no `Errors` line, exit 0 each time. `npx vitest run src/features/inventory/InventoryDragFill.test.tsx` — all 16 tests pass unchanged with the grid stubbed, which is the check that the stub is legitimate: a test that needed the real grid would fail here. Coverage of `features/inventory` for that file moves 12.35% → 12.19% statements — the grid markup that was being rendered but never asserted on.

**Impersonation half** — this one reproduces, so it is verified rather than argued: **3 of 5** runs of the file failed before the change, **8 of 8** pass after. Full suite with the CI command green afterwards (173 files, 2532 tests, exit 0).

`npx tsc -b` and `eslint` clean on all three changed files.

**Honest limitation on the AG Grid half:** that failure does not reproduce locally. I tried the file alone 5×, the whole `inventory/` directory with coverage 3×, and the full suite with the CI command — all clean, on the failing commit. So the green runs are weak evidence on their own; the load-bearing argument is the structural one above. The `setup.ts` change is genuinely probabilistic — React re-posts work whenever it yields, so a fixed number of drains narrows the window rather than closing it — and the comment now says exactly that instead of implying coverage it does not have. The first CI run on this PR did come back with **no `Errors` line**, which is the signal that half was aiming for; the real confirmation is the next few `main` runs staying green after merge.

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [ ] Manually tested the affected feature
- [x] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [x] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [x] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)

Unchecked items are not applicable: this touches three test files and the test setup only — no endpoints, no schema, no UI, no user-facing behaviour, hence no `VERSION`/`CHANGELOG` bump. "Manually tested" is unticked because there is no UI to exercise.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cRUNGBq9xcyoAF7ZDWuio