### PR TITLE
fix: order BPMN elements by process flow

### DIFF
--- a/backend/app/services/bpmn_parser.py
+++ b/backend/app/services/bpmn_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 from dataclasses import dataclass
 
 import defusedxml.ElementTree as ET  # noqa: N817
@@ -31,6 +32,11 @@ EXTRACTABLE_TYPES = {
     f"{{{BPMN_NS}}}boundaryEvent": "boundaryEvent",
 }
 
+FLOW_TYPES = (
+    f"{{{BPMN_NS}}}sequenceFlow",
+    f"{{{BPMN_NS}}}messageFlow",
+)
+
 
 @dataclass
 class ExtractedElement:
@@ -43,11 +49,129 @@ class ExtractedElement:
     sequence_order: int
 
 
+def _strongly_connected_components(
+    node_ids: list[str], adjacency: dict[str, set[str]]
+) -> list[list[str]]:
+    """Return graph SCCs in deterministic order.
+
+    BPMN sequence flows may contain loops. Collapsing each loop into a strongly
+    connected component lets us derive a stable causal order without pretending
+    a cyclic process has a conventional topological sort.
+    """
+    next_index = 0
+    index_by_node: dict[str, int] = {}
+    lowlink: dict[str, int] = {}
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    components: list[list[str]] = []
+
+    def visit(node_id: str) -> None:
+        nonlocal next_index
+        index_by_node[node_id] = next_index
+        lowlink[node_id] = next_index
+        next_index += 1
+        stack.append(node_id)
+        on_stack.add(node_id)
+
+        for target_id in adjacency[node_id]:
+            if target_id not in index_by_node:
+                visit(target_id)
+                lowlink[node_id] = min(lowlink[node_id], lowlink[target_id])
+            elif target_id in on_stack:
+                lowlink[node_id] = min(lowlink[node_id], index_by_node[target_id])
+
+        if lowlink[node_id] != index_by_node[node_id]:
+            return
+
+        component: list[str] = []
+        while True:
+            member = stack.pop()
+            on_stack.remove(member)
+            component.append(member)
+            if member == node_id:
+                break
+        components.append(component)
+
+    for node_id in node_ids:
+        if node_id not in index_by_node:
+            visit(node_id)
+
+    return components
+
+
+def _chronological_element_ids(root: ET.Element, node_ids: list[str]) -> list[str]:
+    """Order BPMN elements by causal flow, with XML order as a stable tie-breaker.
+
+    Sequence flows define order inside a process and message flows add ordering
+    constraints between pools. Parallel/alternative nodes at the same causal
+    depth retain their order in the source XML. Cycles are treated as one causal
+    level and their members also retain XML order.
+    """
+    if not node_ids:
+        return []
+
+    xml_position = {node_id: position for position, node_id in enumerate(node_ids)}
+    adjacency = {node_id: set() for node_id in node_ids}
+
+    for flow_tag in FLOW_TYPES:
+        for flow in root.iter(flow_tag):
+            source_id = flow.get("sourceRef")
+            target_id = flow.get("targetRef")
+            if source_id in adjacency and target_id in adjacency and source_id != target_id:
+                adjacency[source_id].add(target_id)
+
+    components = _strongly_connected_components(node_ids, adjacency)
+    component_by_node: dict[str, int] = {}
+    component_position: list[int] = []
+    for component_id, component in enumerate(components):
+        for node_id in component:
+            component_by_node[node_id] = component_id
+        component_position.append(min(xml_position[node_id] for node_id in component))
+
+    component_adjacency = {component_id: set() for component_id in range(len(components))}
+    indegree = [0] * len(components)
+    for source_id, target_ids in adjacency.items():
+        source_component = component_by_node[source_id]
+        for target_id in target_ids:
+            target_component = component_by_node[target_id]
+            if source_component == target_component:
+                continue
+            if target_component not in component_adjacency[source_component]:
+                component_adjacency[source_component].add(target_component)
+                indegree[target_component] += 1
+
+    level = [0] * len(components)
+    ready = [
+        (component_position[component_id], component_id)
+        for component_id, degree in enumerate(indegree)
+        if degree == 0
+    ]
+    heapq.heapify(ready)
+
+    while ready:
+        _, component_id = heapq.heappop(ready)
+        for target_component in component_adjacency[component_id]:
+            level[target_component] = max(level[target_component], level[component_id] + 1)
+            indegree[target_component] -= 1
+            if indegree[target_component] == 0:
+                heapq.heappush(
+                    ready,
+                    (component_position[target_component], target_component),
+                )
+
+    return sorted(
+        node_ids,
+        key=lambda node_id: (
+            level[component_by_node[node_id]],
+            xml_position[node_id],
+        ),
+    )
+
+
 def parse_bpmn_xml(bpmn_xml: str) -> list[ExtractedElement]:
     """Parse BPMN 2.0 XML and return extracted elements."""
     root = ET.fromstring(bpmn_xml)
     elements: list[ExtractedElement] = []
-
     # Build lane → element mapping
     lane_map: dict[str, str] = {}  # element_id → lane_name
     for lane in root.iter(f"{{{BPMN_NS}}}lane"):
@@ -57,33 +181,41 @@ def parse_bpmn_xml(bpmn_xml: str) -> list[ExtractedElement]:
             if flow_node_ref.text:
                 lane_map[flow_node_ref.text.strip()] = lane_name
 
-    order = 0
-    for tag, element_type in EXTRACTABLE_TYPES.items():
-        for elem in root.iter(tag):
-            elem_id = elem.get("id", "")
-            if not elem_id:
-                continue
+    # Collect extractable nodes in XML document order first. The old parser iterated
+    # EXTRACTABLE_TYPES and therefore grouped the EA-linking table by BPMN type.
+    extractable: list[tuple[ET.Element, str]] = []
+    for elem in root.iter():
+        element_type = EXTRACTABLE_TYPES.get(elem.tag)
+        if element_type is None or not elem.get("id"):
+            continue
+        extractable.append((elem, element_type))
 
-            name = elem.get("name")
+    ordered_ids = _chronological_element_ids(
+        root,
+        [elem.get("id", "") for elem, _ in extractable],
+    )
+    order_by_id = {elem_id: order for order, elem_id in enumerate(ordered_ids)}
 
-            # Extract documentation
-            doc_elem = elem.find(f"{{{BPMN_NS}}}documentation")
-            documentation = doc_elem.text if doc_elem is not None and doc_elem.text else None
+    for elem, element_type in extractable:
+        elem_id = elem.get("id", "")
+        name = elem.get("name")
 
-            # Determine if automated (serviceTask, scriptTask, businessRuleTask)
-            is_automated = element_type in ("serviceTask", "scriptTask", "businessRuleTask")
-
-            elements.append(
-                ExtractedElement(
-                    bpmn_element_id=elem_id,
-                    element_type=element_type,
-                    name=name,
-                    documentation=documentation,
-                    lane_name=lane_map.get(elem_id),
-                    is_automated=is_automated,
-                    sequence_order=order,
-                )
+        # Extract documentation
+        doc_elem = elem.find(f"{{{BPMN_NS}}}documentation")
+        documentation = doc_elem.text if doc_elem is not None and doc_elem.text else None
+        # Determine if automated (serviceTask, scriptTask, businessRuleTask)
+        is_automated = element_type in ("serviceTask", "scriptTask", "businessRuleTask")
+        elements.append(
+            ExtractedElement(
+                bpmn_element_id=elem_id,
+                element_type=element_type,
+                name=name,
+                documentation=documentation,
+                lane_name=lane_map.get(elem_id),
+                is_automated=is_automated,
+                sequence_order=order_by_id[elem_id],
             )
-            order += 1
+        )
 
+    elements.sort(key=lambda element: element.sequence_order)
     return elements

--- a/backend/tests/services/test_bpmn_parser.py
+++ b/backend/tests/services/test_bpmn_parser.py
@@ -191,6 +191,84 @@ class TestSequenceOrder:
         assert orders == sorted(orders)
         assert len(set(orders)) == len(orders)  # all unique
 
+    def test_sequence_flows_determine_order_not_bpmn_type(self):
+        xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" id="d1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="start" name="Start" />
+    <manualTask id="manual" name="Discuss" />
+    <userTask id="user" name="Approve" />
+    <sendTask id="send" name="Send" />
+    <endEvent id="end" name="End" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="manual" />
+    <sequenceFlow id="f2" sourceRef="manual" targetRef="user" />
+    <sequenceFlow id="f3" sourceRef="user" targetRef="send" />
+    <sequenceFlow id="f4" sourceRef="send" targetRef="end" />
+  </process>
+</definitions>
+"""
+        elements = parse_bpmn_xml(xml)
+        assert [element.bpmn_element_id for element in elements] == [
+            "start",
+            "manual",
+            "user",
+            "send",
+            "end",
+        ]
+
+    def test_message_flow_adds_order_between_pools(self):
+        xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" id="d1">
+  <collaboration id="Collaboration_1">
+    <participant id="p1" processRef="Process_A" />
+    <participant id="p2" processRef="Process_B" />
+    <messageFlow id="m1" sourceRef="send" targetRef="receive" />
+  </collaboration>
+  <process id="Process_A" isExecutable="false">
+    <startEvent id="a_start" name="A start" />
+    <sendTask id="send" name="Send request" />
+    <sequenceFlow id="a1" sourceRef="a_start" targetRef="send" />
+  </process>
+  <process id="Process_B" isExecutable="false">
+    <startEvent id="b_start" name="B start" />
+    <receiveTask id="receive" name="Receive request" />
+    <sequenceFlow id="b1" sourceRef="b_start" targetRef="receive" />
+  </process>
+</definitions>
+"""
+        elements = parse_bpmn_xml(xml)
+        by_id = {element.bpmn_element_id: element for element in elements}
+        assert by_id["send"].sequence_order < by_id["receive"].sequence_order
+
+    def test_loop_is_deterministic_and_does_not_block_following_nodes(self):
+        xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" id="d1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="start" name="Start" />
+    <userTask id="check" name="Check" />
+    <exclusiveGateway id="gateway" name="Again?" />
+    <sendTask id="finish" name="Finish" />
+    <endEvent id="end" name="End" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="check" />
+    <sequenceFlow id="f2" sourceRef="check" targetRef="gateway" />
+    <sequenceFlow id="f3" sourceRef="gateway" targetRef="check" />
+    <sequenceFlow id="f4" sourceRef="gateway" targetRef="finish" />
+    <sequenceFlow id="f5" sourceRef="finish" targetRef="end" />
+  </process>
+</definitions>
+"""
+        elements = parse_bpmn_xml(xml)
+        assert [element.bpmn_element_id for element in elements] == [
+            "start",
+            "check",
+            "gateway",
+            "finish",
+            "end",
+        ]
+
 
 class TestEdgeCases:
     def test_empty_process(self):


### PR DESCRIPTION
# Summary

Fix the ordering of BPMN elements extracted for the **Pre-link Elements** table so that `sequence_order` follows BPMN causal flow instead of grouping elements by BPMN type.

Fixes #NNN

## What changed

`parse_bpmn_xml()` previously iterated `EXTRACTABLE_TYPES` and assigned `sequence_order` as each type was processed. As a result, all `userTask` elements appeared together, followed by all `sendTask` elements, `receiveTask` elements, etc., regardless of their position in the process.

The parser now:

- collects extractable elements in XML document order;
- builds a directed graph from `sequenceFlow` and `messageFlow` relationships;
- collapses strongly connected components so BPMN loops do not block ordering;
- derives causal levels from the resulting acyclic graph;
- uses XML document order as a deterministic tie-breaker for branches / elements at the same causal level;
- sorts the returned elements by the derived `sequence_order`.

## Why

The numeric order in **Pre-link Elements** is used as a reading order for EA cross-linking. Grouping by BPMN type makes even simple mixed-type processes appear scrambled.

A fictitious reproduction BPMN is attached to the issue/PR (`bpmn-element-order-demo.bpmn`). It includes two pools, message flows, mixed task types, an exclusive gateway, and a loop.

With current `main`, its extracted order starts with the two user tasks and does not list the start event until item 9. With this change, the order follows the process from the requester through procurement and back to the requester.

## Tests

Added regression coverage for:

- sequence-flow ordering across mixed BPMN element types;
- message-flow ordering across pools;
- deterministic handling of loops without blocking downstream nodes.

Focused parser tests:

```text
22 passed
```

Command used:

```bash
cd backend
pytest -q tests/services/test_bpmn_parser.py
```

## Trade-offs / notes

BPMN is a graph rather than a single total sequence, so parallel and alternative branches do not have one objectively correct linear order. The implementation therefore preserves causality where it exists and uses XML document order only as a stable tie-breaker.

No database schema, REST API, or frontend changes are involved.