### PR TITLE
Stop AG Grid re-measuring the scrollbar on every call under jsdom

### DIFF
--- a/frontend/src/test/agGridScrollbarProbe.test.tsx
+++ b/frontend/src/test/agGridScrollbarProbe.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { AgGridReact } from "ag-grid-react";
+
+/**
+ * The shim that stopped AG Grid re-probing `document` forever under jsdom.
+ *
+ * AG Grid measures the scrollbar by appending a hidden 100×100 div and caches
+ * the answer — but only when the measurement is non-degenerate. jsdom lays
+ * nothing out, so the measurement was always discarded, the cache never filled,
+ * and `_getScrollbarWidth()` re-probed `document` on every call. AG Grid defers
+ * some of that work onto a timer, so on a loaded runner one probe lands after
+ * Vitest has torn the environment down: "ReferenceError: document is not
+ * defined" fails the whole run while every test reports as passing, which is
+ * what makes it expensive to diagnose. It took main red after #1030.
+ */
+describe("AG Grid's scrollbar probe under jsdom", () => {
+  /** Count the probes a real grid makes: AG Grid's own element, by signature. */
+  function countProbes(): () => number {
+    let probes = 0;
+    const append = HTMLElement.prototype.appendChild;
+    vi.spyOn(HTMLElement.prototype, "appendChild").mockImplementation(function (
+      this: HTMLElement,
+      node: Node,
+    ) {
+      const style = (node as HTMLElement).style;
+      if (style?.overflow === "scroll" && style.opacity === "0") probes += 1;
+      return append.call(this, node) as Node;
+    });
+    return () => probes;
+  }
+
+  const Grid = ({ seed }: { seed: number }) => (
+    <div style={{ height: 400, width: 600 }}>
+      <AgGridReact
+        rowData={[{ a: seed }, { a: 2 }]}
+        columnDefs={[{ field: "a" }, { field: "b" }]}
+      />
+    </div>
+  );
+
+  it("measures once for the life of the module, however hard the grid works", async () => {
+    // Measured: 27 probes without the shim, 1 with it. Every one of those 27
+    // reads `document`, and only one has to outlive the environment.
+    const probes = countProbes();
+    const { container, rerender } = render(<Grid seed={0} />);
+    await waitFor(() => expect(container.querySelector(".ag-root")).not.toBeNull());
+    for (let i = 1; i <= 5; i++) {
+      rerender(<Grid seed={i} />);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(probes()).toBeLessThanOrEqual(1);
+  });
+
+  it("leaves every other element with jsdom's own answer", () => {
+    // Scoped to the probe's signature precisely so no test's view of layout
+    // changes: jsdom lays nothing out, and it must stay that way.
+    const plain = document.createElement("div");
+    plain.style.width = "100px";
+    document.body.appendChild(plain);
+    expect(plain.clientWidth).toBe(0);
+    expect(plain.offsetWidth).toBe(0);
+    plain.remove();
+  });
+});

--- a/frontend/src/test/agGridScrollbarProbe.ts
+++ b/frontend/src/test/agGridScrollbarProbe.ts
@@ -1,0 +1,61 @@
+/**
+ * Let AG Grid's scrollbar measurement succeed under jsdom, so it caches.
+ *
+ * AG Grid measures the browser's scrollbar by probing a hidden 100×100 div and
+ * caching the result — but only when the measurement is non-degenerate
+ * (`ag-grid-community/dist/package/main.esm.mjs`, `initScrollbarWidthAndVisibility`):
+ *
+ *     let width = div.offsetWidth - div.clientWidth;
+ *     if (width === 0 && div.clientWidth === 0) width = null;   // discard
+ *     if (width != null) { browserScrollbarWidth = width; … }   // cache
+ *
+ * jsdom reports 0 for every layout box, so the measurement is always discarded
+ * and the cache never fills. `_getScrollbarWidth()` therefore re-probes
+ * `document` on **every** call, forever — including from work AG Grid defers on
+ * a timer (`ColumnAnimationService.executeLaterVMTurn`). On a loaded runner one
+ * of those timers lands after Vitest has torn the environment down, and the
+ * probe throws `ReferenceError: document is not defined`, failing the whole run
+ * even though every test passed. That is what broke CI on main after #1030.
+ *
+ * Answering the probe the way a scrollbar-less environment does — equal offset
+ * and client widths, i.e. a 0px scrollbar — makes the value cache on first use,
+ * so `document` is never touched again from this path. The drain in `setup.ts`
+ * stays as defence in depth for everything else AG Grid and React can leave in
+ * flight; this closes the one path that could not be drained, because it was
+ * guaranteed to re-arm itself.
+ *
+ * Scoped to the probe alone, by the inline styles AG Grid gives it. Every other
+ * element keeps jsdom's own answer, so no test's view of layout changes.
+ */
+
+/** AG Grid's probe: a 100px square, invisible, absolutely positioned, scrolling. */
+function isScrollbarProbe(el: Element): boolean {
+  const style = (el as HTMLElement).style;
+  return (
+    el.tagName === "DIV" &&
+    style?.overflow === "scroll" &&
+    style.opacity === "0" &&
+    style.position === "absolute" &&
+    style.width === "100px" &&
+    style.height === "100px"
+  );
+}
+
+/** The size the probe reports: any equal, non-zero pair means "no scrollbar". */
+const PROBE_SIZE = 100;
+
+export function installAgGridScrollbarProbe(): void {
+  for (const proto of [HTMLElement.prototype, Element.prototype]) {
+    for (const prop of ["offsetWidth", "clientWidth"] as const) {
+      const original = Object.getOwnPropertyDescriptor(proto, prop);
+      if (!original?.get) continue;
+      Object.defineProperty(proto, prop, {
+        configurable: true,
+        enumerable: original.enumerable,
+        get(this: Element) {
+          return isScrollbarProbe(this) ? PROBE_SIZE : original.get!.call(this);
+        },
+      });
+    }
+  }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,9 +4,14 @@ import i18n from "@/i18n";
 // AG Grid module registration (mandatory since v33) for every test that
 // mounts a real <AgGridReact> — same side-effect import the grid pages use.
 import "@/lib/agGridSetup";
+import { installAgGridScrollbarProbe } from "./agGridScrollbarProbe";
 import { installMatchMedia, setViewportWidth } from "./matchMedia";
 
 installMatchMedia();
+// Must run before any grid mounts: it is what lets AG Grid cache its scrollbar
+// measurement instead of re-probing `document` from a timer that can outlive
+// the test environment. See the module for the full account.
+installAgGridScrollbarProbe();
 
 // Provide a minimal sessionStorage for tests (jsdom includes one, but
 // this ensures it's always clean between test files).
@@ -23,6 +28,10 @@ beforeEach(() => {
 // `LocalEventService.dispatchAsync`, reached from a late `RowRenderer` redraw
 // — which fails the run even though every test passed, and only on loaded CI
 // runners.
+//
+// One member of that family is NOT a race and cannot be drained away: AG
+// Grid's scrollbar probe re-armed itself on every call under jsdom. That one is
+// closed at the source by `installAgGridScrollbarProbe` above.
 //
 // Two queues matter, and they are drained separately because neither drains
 // the other:


### PR DESCRIPTION
## Summary

The Frontend Tests job went red on `main` after #1030 on a run where all 3,454 tests passed: it died on a single unhandled `ReferenceError: document is not defined`, thrown from AG Grid's scrollbar probe on a timer that landed after Vitest tore the environment down. A re-run went green, but the cause is real and will recur. This makes AG Grid's measurement cache correctly under jsdom, so the probe runs once instead of forever.

## Type

- [ ] feature
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore (CI / build / dependency / housekeeping)
- [ ] security

## Changes

- `frontend/src/test/agGridScrollbarProbe.ts` (new) — answers AG Grid's probe the way a scrollbar-less environment does (equal offset/client widths ⇒ a 0px scrollbar), so the measurement is kept rather than discarded. Scoped to the probe's exact inline-style signature, so every other element keeps jsdom's own zeros.
- `frontend/src/test/setup.ts` — installs it before any grid mounts, and records why the existing drain could never have closed this particular path.
- `frontend/src/test/agGridScrollbarProbe.test.tsx` (new) — regression test on the **probe count** across a real grid render plus five re-renders, and a second test pinning that ordinary elements still measure 0.

### Why the drain could not fix it

Not a race. AG Grid caches its scrollbar measurement, but only when the measurement is non-degenerate (`ag-grid-community/dist/package/main.esm.mjs`, `initScrollbarWidthAndVisibility`):

```js
let width = div.offsetWidth - div.clientWidth;
if (width === 0 && div.clientWidth === 0) width = null;   // discarded
if (width != null) { browserScrollbarWidth = width; … }   // cached
```

jsdom reports 0 for every layout box, so the result was **always** discarded, the cache never filled, and `_getScrollbarWidth()` re-read `document` on every call for the life of the process. Some of that work is deferred onto a timer, so under load one probe eventually outlives the environment. The drain in `setup.ts` already predicted this class of failure would "eventually trip again" — this member of it re-armed itself on every call and so could never be drained away.

## Test Plan

- Measured the behaviour rather than inferring it: instrumented `appendChild` and counted AG Grid's probe elements across one grid mount plus five re-renders — **27 probes without the fix, 1 with it**. Each of those 27 reads `document`.
- Confirmed the direction of causation by disabling the shim in `setup.ts` and re-running the same test: the count returns to 27.
- Full frontend suite: 227 files / 3,456 tests, exit code 0, with no unhandled-error section (the failing CI run reported `Errors 1 error` and exit 1 while every test passed).
- `npm run build` clean.

- [x] All CI checks pass (backend lint, backend tests, frontend lint, frontend build, frontend tests)
- [x] Manually tested the affected feature
- [x] Added/updated tests for new or changed behavior

## Checklist

- [x] My changes follow the conventions in `CLAUDE.md`
- [ ] I added permission checks to any new mutating endpoints
- [ ] I created an Alembic migration for any schema changes
- [ ] I did not introduce hardcoded card types or fields (metamodel is data-driven)
- [ ] I used `async def` for all new route handlers and DB operations
- [ ] I did not expose sensitive fields (password hashes, encrypted secrets) in API responses
- [ ] I bumped `/VERSION` and added a `CHANGELOG.md` entry (if user-facing change)
- [ ] I added translations for new UI strings in all 8 locales (if applicable)
- [ ] I updated user documentation in `docs/` (if UI or feature change)
- [ ] Screenshots attached for UI changes (if applicable)

Test infrastructure only — nothing here reaches the app bundle, so no VERSION bump, no CHANGELOG entry and no user-facing surface to document.

One risk worth naming: the shim is keyed on AG Grid's probe markup, so a future AG Grid version that changes those inline styles would silently stop matching. The probe-count test is what catches that, and it fails loudly rather than degrading quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdsPqwNbNMhKW1iH498v2K